### PR TITLE
update(platform): format fix in list-byoc

### DIFF
--- a/docs/platform/howto/list-byoc.md
+++ b/docs/platform/howto/list-byoc.md
@@ -1,3 +1,7 @@
 ---
 title: Bring your own cloud (BYOC)
 ---
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />


### PR DESCRIPTION
Fixing the listing page for BYOC

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
