### PR TITLE
fix: update help.aiven.io link

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-sink.md
@@ -45,7 +45,7 @@ Apache Kafka® service page, *Overview* tab, and *Schema Registry* subtab
 
 As of version 3.0, Aiven for Apache Kafka no longer supports Confluent
 Schema Registry. For more information, read [the article describing the
-replacement, Karapace](https://aiven.io/docs/products/kafka/karapace)
+replacement, Karapace](https://aiven.io/docs/products/kafka/karapace).
 :::
 
 ## Setup a Google Pub/Sub Lite sink connector with Aiven Console

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-sink.md
@@ -45,7 +45,7 @@ Apache Kafka® service page, *Overview* tab, and *Schema Registry* subtab
 
 As of version 3.0, Aiven for Apache Kafka no longer supports Confluent
 Schema Registry. For more information, read [the article describing the
-replacement, Karapace](https://help.aiven.io/en/articles/5651983)
+replacement, Karapace](https://aiven.io/docs/products/kafka/karapace)
 :::
 
 ## Setup a Google Pub/Sub Lite sink connector with Aiven Console

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-sink.md
@@ -43,7 +43,7 @@ target Google Pub/Sub Lite upfront:
 The `SCHEMA_REGISTRY` related parameters are available in the Aiven for
 Apache Kafka® service page, *Overview* tab, and *Schema Registry* subtab
 
-As of version 3.0, Aiven for Apache Kafka no longer supports Confluent
+Starting with version 3.0, Aiven for Apache Kafka no longer supports Confluent
 Schema Registry. For more information, read [the article describing the
 replacement, Karapace](https://aiven.io/docs/products/kafka/karapace).
 :::

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-sink.md
@@ -45,7 +45,7 @@ Apache Kafka® service page, *Overview* tab, and *Schema Registry* subtab
 
 Starting with version 3.0, Aiven for Apache Kafka no longer supports Confluent
 Schema Registry. For more information, read [the article describing the
-replacement, Karapace](https://aiven.io/docs/products/kafka/karapace).
+replacement, Karapace](/docs/products/kafka/karapace).
 :::
 
 ## Setup a Google Pub/Sub Lite sink connector with Aiven Console

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-source.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-source.md
@@ -46,7 +46,7 @@ Apache Kafka® service page, *Overview* tab, and *Schema Registry* subtab
 
 Starting with version 3.0, Aiven for Apache Kafka no longer supports Confluent
 Schema Registry. For more information, read [the article describing the
-replacement, Karapace](https://aiven.io/docs/products/kafka/karapace).
+replacement, Karapace](/docs/products/kafka/karapace).
 :::
 
 ## Setup a Google Pub/Sub Lite source connector with Aiven Console

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-source.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-source.md
@@ -46,7 +46,7 @@ Apache Kafka® service page, *Overview* tab, and *Schema Registry* subtab
 
 As of version 3.0, Aiven for Apache Kafka no longer supports Confluent
 Schema Registry. For more information, read [the article describing the
-replacement, Karapace](https://help.aiven.io/en/articles/5651983)
+replacement, Karapace](https://aiven.io/docs/products/kafka/karapace).
 :::
 
 ## Setup a Google Pub/Sub Lite source connector with Aiven Console

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-source.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-source.md
@@ -44,7 +44,7 @@ target Google Pub/Sub upfront:
 The `SCHEMA_REGISTRY` related parameters are available in the Aiven for
 Apache Kafka® service page, *Overview* tab, and *Schema Registry* subtab
 
-As of version 3.0, Aiven for Apache Kafka no longer supports Confluent
+Starting with version 3.0, Aiven for Apache Kafka no longer supports Confluent
 Schema Registry. For more information, read [the article describing the
 replacement, Karapace](https://aiven.io/docs/products/kafka/karapace).
 :::


### PR DESCRIPTION
## Describe your changes
Fix the link from a help.aiven.io article to point to the Karapace docs.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](../styleguide.md).
- [X] My links start with `/docs/`.
