### PR TITLE
fix: correct warnings about affects of 2FA on tokens

### DIFF
--- a/docs/platform/howto/set-authentication-policies.md
+++ b/docs/platform/howto/set-authentication-policies.md
@@ -16,12 +16,12 @@ address and password. For an added layer of security, you can enforce
 two-factor authentication (2FA) for password logins for all users in
 your organization.
 
-When two-factor authentication is required, users won\'t be able to
+When 2FA is required, users won't be able to
 access any resources in your organization until they set up 2FA.
 
 :::note
-Authentication tokens are not affected and will continue to work when
-you enable two-factor authentication.
+Authentication tokens are not affected and continue to work when you make 2FA required.
+However, when users [enable 2FA](/docs/platform/howto/user-2fa) their existing authentication tokens are revoked.
 :::
 
 ### Third-party authentication

--- a/docs/platform/howto/user-2fa.md
+++ b/docs/platform/howto/user-2fa.md
@@ -2,9 +2,12 @@
 title: Manage two-factor authentication
 ---
 
-Two-factor authentication (also known as 2-step verification or 2FA) in
-Aiven provides an extra level of security by requiring a second
-authentication code in addition to the user password.
+Two-factor authentication in Aiven provides an extra level of security by requiring a second authentication code in addition to the user password.
+
+:::warning
+Enabling and disabling two-factor authentication revokes your
+existing authentication tokens.
+:::
 
 ## Enable two-factor authentication {#enable-2fa}
 
@@ -46,10 +49,6 @@ To disable two-factor authentication on the Aiven Console:
     authentication**.
 3.  Enter your password and click **Disable Two-Factor Authentication**.
 
-:::warning
-Disabling two-factor authentication will automatically revoke your
-existing authentication tokens.
-:::
 
 ## Reset two-factor authentication
 


### PR DESCRIPTION
## Describe your changes

Fix incorrect and misleading info in docs about the affects of enabling 2FA on existing tokens.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](../styleguide.md).
- [X] My links start with `/docs/`.
