### PR TITLE
fix: Fixed the guide to monitor metrics on Grafana prebuilt dashboards

### DIFF
--- a/docs/platform/howto/create-service-integration.md
+++ b/docs/platform/howto/create-service-integration.md
@@ -28,7 +28,7 @@ Ensure you have these services:
     **Overview** page of your service.
 
     1.  Select to **Integrations** from the sidebar.
-    1.  Under **Aiven solutions**, click **Monitor Data in Grafana**.
+    1.  Under **Aiven solutions**, click **Grafana Metrics Dashboard**.
     1.  In the **Datasource integration** window, select the **Existing
         service** radio button and choose the Aiven for Grafana service
         you created.

--- a/docs/products/postgresql/howto/report-metrics-grafana.md
+++ b/docs/products/postgresql/howto/report-metrics-grafana.md
@@ -40,7 +40,7 @@ of the metrics in case of problems with the service.
 
 1.  Select the target M3DB, or PostgreSQL database service and
     go to its service page. Under **Manage integrations**, choose the
-    **Monitor Data in Grafana** option to make the metrics available on
+    **Grafana Metrics Dashboard** option to make the metrics available on
     that platform.
 
 2.


### PR DESCRIPTION
The guides to monitor Kafka and PostgreSQL using Aiven prebuilt dashboards, wrongly referenced to create an integration of type Monitor Data in Grafana instead of Grafana Metrics Dashboard.

Fixed it for both service types.