### PR TITLE
update: add link to TF Cookbook

### DIFF
--- a/docs/tools/terraform.md
+++ b/docs/tools/terraform.md
@@ -2,9 +2,7 @@
 title: Aiven Provider for Terraform
 ---
 
-With Aiven's [Terraform](https://www.terraform.io) provider, you can
-use an open source infrastructure as code tool to declare and manage
-your cloud services.
+Declare and manage your Aiven cloud services with the [Aiven Provider for Terraform](https://registry.terraform.io/providers/aiven/aiven/latest/docs) infrastructure as code tool.
 
 ## Start using Aiven Provider for Terraform
 
@@ -12,8 +10,13 @@ import DocCardList from '@theme/DocCardList';
 
 <DocCardList />
 
+## Terraform Cookbook
+
+Use [recipes for the Aiven Provider](https://aiven.io/developer/terraform) to set up your
+infrastructure for different use cases like importing your existing data platform,
+integrating services, creating custom configurations, and more.
+
 ## Get involved
 
-To report issues, give feedback, or to contribute to the tool join us on
-the [GitHub
-repository](https://github.com/aiven/terraform-provider-aiven).
+Report issues, give feedback, or contribute in the
+[GitHub repository](https://github.com/aiven/terraform-provider-aiven).


### PR DESCRIPTION
## Describe your changes
Add a link to the Terraform Cookbook to the main TF page on the docs site so that it's easier for customers to find.

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
