### PR TITLE
add: RedisJSON v2 syntax compatibility

### DIFF
--- a/docs/products/dragonfly/howto/compatibility-redisjson.md
+++ b/docs/products/dragonfly/howto/compatibility-redisjson.md
@@ -13,7 +13,8 @@ moving away from the previously used dot (`.`) notation. This modification impro
 command standardization for seamless integration between Aiven for Dragonfly and
 RedisJSON.
 
-For a comprehensive list of these JSON commands, see [Dragonfly documentation](https://www.dragonflydb.io/docs/category/json).
+For a comprehensive list of these JSON commands,
+see [Dragonfly documentation](https://www.dragonflydb.io/docs/category/json).
 
 ## Ensure compatibility with RedisJSON v2
 

--- a/docs/products/dragonfly/howto/compatibility-redisjson.md
+++ b/docs/products/dragonfly/howto/compatibility-redisjson.md
@@ -2,12 +2,11 @@
 title: RedisJSON v2 syntax compatibility
 ---
 
-Learn how to optimize your experience with RedisJSON in Aiven for Dragonfly with the v2
-JSONPath syntax using the $ root node.
+Learn how to optimize your experience with RedisJSON in Aiven for Dragonfly® with the v2 JSONPath syntax using the $ root node.
 
 ## JSONPath syntax versions
 
-Aiven for Dragonfly services uses the v2 JSONPath syntax, ensuring compatibility with
+Aiven for Dragonfly services use the v2 JSONPath syntax, ensuring compatibility with
 RedisJSON. This syntax designates the dollar sign (`$`) as the root node for JSON paths,
 moving away from the previously used dot (`.`) notation. This modification improves JSON
 command standardization for seamless integration between Aiven for Dragonfly and
@@ -24,7 +23,7 @@ see [Dragonfly documentation](https://www.dragonflydb.io/docs/category/json).
 - **Adjust JSONPath expressions:** Update your JSONPath expressions to use the `$` root
   node. Convert dot notation paths (`.path.to.element`) to the v2
   syntax (`$.path.to.element`).
-- **Testing:** Thoroughly test your application after making these adjustments to
+- **Testing:** Test your application after making these adjustments to
   confirm that interactions with RedisJSON operate as expected, particularly in
   areas that rely heavily on JSONPath expressions.
 

--- a/docs/products/dragonfly/howto/compatibility-redisjson.md
+++ b/docs/products/dragonfly/howto/compatibility-redisjson.md
@@ -1,0 +1,32 @@
+---
+title: RedisJSON v2 syntax compatibility
+---
+
+Learn how to optimize your experience with RedisJSON in Aiven for Dragonfly with the v2
+JSONPath syntax using the $ root node.
+
+## JSONPath syntax versions
+
+Aiven for Dragonfly services uses the v2 JSONPath syntax, ensuring compatibility with
+RedisJSON. This syntax designates the dollar sign (`$`) as the root node for JSON paths,
+moving away from the previously used dot (`.`) notation. This modification improves JSON
+command standardization for seamless integration between Aiven for Dragonfly and
+RedisJSON.
+
+For a comprehensive list of these JSON commands, see [Dragonfly documentation](https://www.dragonflydb.io/docs/category/json).
+
+## Ensure compatibility with RedisJSON v2
+
+- **Confirm library support:** Ensure your application uses libraries compatible with
+  RedisJSON's v2 JSONPath syntax. This might require updating to the latest versions of
+  these libraries.
+- **Adjust JSONPath expressions:** Update your JSONPath expressions to use the `$` root
+  node. Convert dot notation paths (`.path.to.element`) to the v2
+  syntax (`$.path.to.element`).
+- **Testing:** Thoroughly test your application after making these adjustments to
+  confirm that interactions with RedisJSON operate as expected, particularly in
+  areas that rely heavily on JSONPath expressions.
+
+## Related pages
+
+- [RedisJSON documentation](https://redis.io/docs/data-types/json/path/)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1389,6 +1389,7 @@ const sidebars: SidebarsConfig = {
                   ],
                 },
                 'products/dragonfly/howto/eviction-policy-df',
+                'products/dragonfly/howto/compatibility-redisjson',
               ],
             },
             {


### PR DESCRIPTION
## Describe your changes

Added content for RedisJSON’s v2 JSONPath syntax compatibility with Aiven for Dragonfly.

[DOC-806](https://aiven.atlassian.net/browse/DOC-806)


## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.


[DOC-806]: https://aiven.atlassian.net/browse/DOC-806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ