### PR TITLE
update: Debezium v2.5 breaking changes

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.md
@@ -39,8 +39,8 @@ Before you begin, gather the necessary information about your source MongoDB dat
     password, only needed when using Avro as data format
 
 :::note
-When Aiven for Apache Kafka, you can gather the necessary Apache Kafka
-details from the service's Overview page on  [Aiven
+With Aiven for Apache Kafka, you can gather the necessary Apache Kafka
+details from the service's Overview page on the [Aiven
 console](https://console.aiven.io/)  or by using the `avn service get` command with
 the [Aiven CLI](/docs/tools/cli/service-cli#avn_service_get).
 :::

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.md
@@ -2,26 +2,31 @@
 title: Create a Debezium source connector from MongoDB to Apache Kafka®
 ---
 
-The Debezium source connector for MongoDB tracks database changes using
-a MongoDB replica set or shared cluster, and writes them to an Apache
-Kafka® topic in a standard format where they can be transformed and read
-by multiple consumers.
+Track and write MongoDB database changes to an Apache Kafka® topic in a standard format with the Debezium source connector, enabling transformation and access by multiple consumers using a MongoDB replica set or sharded cluster.
 
 :::note
-You can check the full set of available parameters and configuration
-options in the [connector's
-documentation](https://debezium.io/docs/connectors/mongodb/).
+**Breaking changes in Debezium 2.5**:
+Debezium version 2.5 introduces significant changes to the connector's configuration
+and behavior. New setups [defaults to version 2.5](https://debezium.io/releases/2.5/release-notes)
+while existing setups using version 1.9 remain on that version for stability.
+Test configurations with version 2.5 before upgrading. Review the specific
+changes to the MongoDB connector in Debezium 2.5.
+For help with upgrades or queries, contact Aiven support.
 :::
 
 ## Prerequisites {#connect_debezium_mongodb_source_prereq}
 
-To setup a Debezium source connector pointing to MongoDB, you need an
-Aiven for Apache Kafka service
-[with Kafka Connect enabled](enable-connect) or a
-[dedicated Aiven for Apache Kafka Connect cluster](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
+To configure a Debezium source connector for MongoDB, you need either an
+Aiven for Apache Kafka service with [Apache Kafka Connect enabled](enable-connect) or
+a [dedicated Aiven for Apache Kafka Connect cluster](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
 
-Furthermore you need to collect the following information about the
-source MongoDB database upfront:
+:::note
+You can view the full set of available parameters and configuration
+options in the [connector's
+documentation](https://debezium.io/docs/connectors/mongodb/).
+:::
+
+Before you begin, gather the necessary information about your source MongoDB database:
 
 -   `MONGODB_HOST`: The database hostname
 -   `MONGODB_PORT`: The database port
@@ -39,10 +44,10 @@ source MongoDB database upfront:
     password, only needed when using Avro as data format
 
 :::note
-If you're using Aiven for Apache Kafka®, the Kafka related details are
-available in the [Aiven console](https://console.aiven.io/) service
-Overview tab or via the dedicated `avn service get` command with the
-[Aiven CLI](/docs/tools/cli/service-cli#avn_service_get).
+When Aiven for Apache Kafka, you can gather the necessary Apache Kafka
+details from the service's Overview page on  [Aiven
+console](https://console.aiven.io/)  or by using the `avn service get` command with
+the [Aiven CLI](/docs/tools/cli/service-cli#avn_service_get).
 :::
 
 ## Setup a MongoDB Debezium source connector with Aiven Console
@@ -53,11 +58,10 @@ Console](https://console.aiven.io/).
 
 ### Define a Kafka Connect configuration file
 
-Define the connector configurations in a file (we'll refer to it with
-the name `debezium_source_mongodb.json`) with the following content.
-Creating a file is not strictly necessary but allows to have all the
-information in one place before copy/pasting them in the [Aiven
-Console](https://console.aiven.io/):
+Create a configuration file named `debezium_source_mongodb.json` with the following
+connector configurations. While optional, creating this file helps you organize your
+settings in one place and copy/paste them into the
+[Aiven Console](https://console.aiven.io/) later.
 
 ```json
 {
@@ -81,84 +85,84 @@ Console](https://console.aiven.io/):
 
 The configuration file contains the following entries:
 
--   `name`: the connector name, replace CONNECTOR_NAME with the name you
+-   `name`: The connector name, replace CONNECTOR_NAME with the name you
     want to use for the connector
 
 -   `MONGODB_HOST`, `MONGODB_PORT`, `MONGODB_DATABASE_NAME`,
     `MONGODB_USER`, `MONGODB_PASSWORD` and `MONGODB_REPLICA_SET_NAME`:
-    source database parameters collected in the
-    [prerequisite](/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb#connect_debezium_mongodb_source_prereq) phase.
+    Source database parameters collected in the
+    [prerequisite](/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb#connect_debezium_mongodb_source_prereq)
+    phase.
 
--   `tasks.max`: maximum number of tasks to execute in parallel. By
+-   `tasks.max`: Maximum number of tasks to execute in parallel. By
     default this is 1, the connector can use at most 1 task for each
     collection defined. Replace `NR_TASKS` with the amount of parallel
     task based on the number of input collections.
 
--   `key.converter` and `value.converter`: defines the messages data
+-   `key.converter` and `value.converter`: Defines the messages data
     format in the Apache Kafka topic. The
     `io.confluent.connect.avro.AvroConverter` converter pushes messages
-    in Avro format. To store the messages schema we use Aiven's
-    [Karapace schema registry](https://github.com/aiven/karapace) as
-    specified by the `schema.registry.url` parameter and related
-    credentials.
+    in Avro format. To store the message schemas, Aiven's
+    [Karapace schema registry](https://github.com/Aiven-Open/karapace) is used,
+    specified by the `schema.registry.url` parameter and related credentials.
 
     :::note
     The `key.converter` and `value.converter` sections are only needed
-    when pushing data in Avro format. If omitted the messages will be
-    defined in JSON format.
+    when pushing data in Avro format. Otherwise, messages default to JSON format.
 
-    The `USER_INFO` is **not** a placeholder, no substitution is needed
-    for that parameter.
+    The `USER_INFO` is not a placeholder and does not require any parameter substitution.
     :::
 
 ### Create a Kafka Connect connector with the Aiven Console
 
 To create a Kafka Connect connector, follow these steps:
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/) and select
-    the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
-    service where the connector needs to be defined.
+1.  Log in to the [Aiven Console](https://console.aiven.io/).
 
-2.  Select **Connectors** from the left sidebar.
+1.  Select the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service where
+    you want to define the connector.
 
-3.  Select **Create New Connector**, the button is enabled only for
+1.  Select **Connectors** from the sidebar.
+
+1.  Select **Create New Connector**, the button is enabled only for
     services
     [with Kafka Connect enabled](enable-connect).
 
-4.  Select **Debezium - MongoDB**.
+1.  Select **Debezium - MongoDB**.
 
-5.  In the **Common** tab, locate the **Connector configuration** text
+1.  In the **Common** tab, locate the **Connector configuration** text
     box and select on **Edit**.
 
-6.  Paste the connector configuration (stored in the
+1.  Paste the connector configuration (stored in the
     `debezium_source_mongodb.json` file) in the form.
 
-7.  Select **Apply**.
+1.  Select **Apply**.
 
     :::note
-    The Aiven Console parses the configuration file and fills the
-    relevant UI fields. You can review the UI fields across the various
-    tabs and change them if necessary. The changes will be reflected in
-    JSON format in the **Connector configuration** text box.
+    The Aiven Console reads through the configuration file and automatically populates
+    the relevant UI fields. You can view and modify these fields across
+    different tabs. Any change you make is reflected in JSON format
+    within the **Connector configuration** text box.
     :::
 
-8.  After all the settings are correctly configured, select **Create new
-    connector**.
+1. After all the settings are correctly configured, select **Create new
+   connector**.
 
-    :::tip
-    If you're using Aiven for Apache Kafka, topics will not be created
-    automatically. Either create them manually following the
-    `database.server.name.schema_name.table_name` naming pattern or
-    enable the `kafka.auto_create_topics_enable` advanced parameter.
-    :::
+   :::tip
+   With Aiven for Apache Kafka, topics are not created automatically. You have two options:
 
-9.  Verify the connector status under the **Connectors** screen.
+   - Manually create topics using the naming pattern: `database.server.name.schema_name.table_name`.
+   - Enable the `Kafka topic auto-creation` feature.
+     See [Enable automatic topic creation with Aiven CLI](docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli).
+   :::
 
-10. Verify the presence of the data in the target Apache Kafka topic
-    coming from the MongoDB dataset. The topic name is equal to the
-    concatenation of the database and collection name. If you need to
-    change the target table name, you can do so using the Kafka Connect
-    `RegexRouter` transformation.
+1. Verify the connector status under the **Connectors** screen.
+
+1. Verify the presence of the data in the target Apache Kafka topic
+   coming from the MySQL dataset. The topic name is equal to
+   concatenation of the database and table name. To change
+   the target table name, you can use Apache Kafka Connect
+   `RegexRouter` transformation.
 
 You can also create connectors using the
 [Aiven CLI command](/docs/tools/cli/service/connector#avn_service_connector_create).

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.md
@@ -4,15 +4,10 @@ title: Create a Debezium source connector from MongoDB to Apache Kafka®
 
 Track and write MongoDB database changes to an Apache Kafka® topic in a standard format with the Debezium source connector, enabling transformation and access by multiple consumers using a MongoDB replica set or sharded cluster.
 
-:::note
-**Breaking changes in Debezium 2.5**:
-Debezium version 2.5 introduces significant changes to the connector's configuration
-and behavior. New setups [defaults to version 2.5](https://debezium.io/releases/2.5/release-notes)
-while existing setups using version 1.9 remain on that version for stability.
-Test configurations with version 2.5 before upgrading. Review the specific
-changes to the MongoDB connector in Debezium 2.5.
-For help with upgrades or queries, contact Aiven support.
-:::
+import Note from "@site/static/includes/debezium-breakingchange.md"
+
+<Note/>
+
 
 ## Prerequisites {#connect_debezium_mongodb_source_prereq}
 
@@ -119,14 +114,13 @@ To create a Kafka Connect connector, follow these steps:
 
 1.  Log in to the [Aiven Console](https://console.aiven.io/).
 
-1.  Select the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service where
-    you want to define the connector.
+1.  Select the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service
+    to define the connector.
 
 1.  Select **Connectors** from the sidebar.
 
-1.  Select **Create New Connector**, the button is enabled only for
-    services
-    [with Kafka Connect enabled](enable-connect).
+1.  Select **Create New Connector**, which is available only for
+    services [that have Apache Kafka Connect enabled](enable-connect).
 
 1.  Select **Debezium - MongoDB**.
 

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.md
@@ -153,7 +153,7 @@ To create a Kafka Connect connector, follow these steps:
 
    - Manually create topics using the naming pattern: `database.server.name.schema_name.table_name`.
    - Enable the `Kafka topic auto-creation` feature.
-     See [Enable automatic topic creation with Aiven CLI](docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli).
+     See [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli).
    :::
 
 1. Verify the connector status under the **Connectors** screen.

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mysql.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mysql.md
@@ -3,15 +3,10 @@ title: Create a Debezium source connector from MySQL to Apache Kafka®
 ---
 The MySQL Debezium source connector extracts the changes committed to the database binary log (binlog), and writes them to an Apache Kafka® topic in a standard format where they can be transformed and read by multiple consumers.
 
-:::note
-**Breaking changes in Debezium 2.5**:
-Debezium version 2.5 introduces significant changes to the connector's configuration
-and behavior. New setups [defaults to version 2.5](https://debezium.io/releases/2.5/release-notes)
-while existing setups using version 1.9 remain on that version for stability.
-Test configurations with version 2.5 before upgrading. For MySQL, review any
-specific deprecations or recommended plugin transitions in this version.
-For help with upgrades or queries, contact Aiven support.
-:::
+import Note from "@site/static/includes/debezium-breakingchange.md"
+
+<Note/>
+
 
 ## Schema versioning {#connect_debezium_mysql_schema_versioning}
 
@@ -181,13 +176,13 @@ To create a Kafka Connect connector, follow these steps:
 
 1.  Log in to the [Aiven Console](https://console.aiven.io/).
 
-1.  Select the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service where
-    you want to define the connector.
+1.  Select the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service
+    to define the connector.
 
 1. Select **Connectors** from the sidebar.
 
-1. Select **Create New Connector**, the button is enabled only for
-   services [with Apache Kafka Connect enabled](enable-connect).
+1. Select **Create New Connector**, which is available only for
+   services [that have Apache Kafka Connect enabled](enable-connect).
 
 1. Select the **Debezium - MySQL**.
 

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mysql.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mysql.md
@@ -213,7 +213,7 @@ To create a Kafka Connect connector, follow these steps:
 
    - Manually create topics using the naming pattern: `database.server.name.schema_name.table_name`.
    - Enable the `Kafka topic auto-creation` feature.
-     See [Enable automatic topic creation with Aiven CLI](docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli).
+     See [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli).
 
    :::
 

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg-node-replacement.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg-node-replacement.md
@@ -4,7 +4,7 @@ title: Handle PostgreSQL® node replacements when using Debezium for change data
 
 When running a
 [Debezium source connector for PostgreSQL®](debezium-source-connector-pg) to capture changes from an Aiven for PostgreSQL® service,
-there are some activities on the database side that could impact the
+there are some activities on the database side that can impact the
 correct functionality of the connector.
 
 As example, when the source PostgreSQL service undergoes any operation
@@ -17,10 +17,8 @@ PostgreSQL replication slot used by Debezium can start lagging and
 therefore cause a growing amount of WAL logs.
 
 :::tip
-There is a GitHub repository where you can easily spin up a Debezium -
-PostgreSQL setup to test the node replacement scenario and also follow
-along this [Aiven Debezium help
-article](https://github.com/aiven/debezium-pg-kafka-connect-test).
+Use the GitHub repository to set up and test a Debezium - PostgreSQL node replacement
+scenario. For guidance, follow the [Aiven Debezium help article](https://github.com/aiven/debezium-pg-kafka-connect-test).
 :::
 
 ## Common Debezium errors related to PostgreSQL node replacement
@@ -39,7 +37,7 @@ org.PostgreSQL.util.PSQLException: ERROR: replication slot "SLOT_NAME" is active
 ```
 
 The above errors are unrecoverable, meaning that they require a restart
-of the connector task(s) in order to resume operations again.
+of the connector tasks to resume operations again.
 
 A restart can be performed manually either through the [Aiven
 Console](https://console.aiven.io/), in under the `Connectors` tab
@@ -66,9 +64,9 @@ docs](https://debezium.io/documentation/reference/stable/connectors/postgresql.h
 there are two main reasons why growing replication lag can happen after
 the Debezium connector is restarted:
 
-1.  Too many updates are happening in the tracked database but only a
-    tiny number of updates are related to the table(s) and schema(s) for
-    which the connector is capturing changes.
+1.  Too many updates are happening in the tracked database, but only a few of these
+    updates pertain to the tables and schemas that the connector
+    is monitoring for changes.
 
     Such issue can be resolved by enabling periodic heartbeat events and
     setting the (`heartbeat.interval.ms`) connector configuration
@@ -87,10 +85,10 @@ the Debezium connector is restarted:
 During the Aiven testing, the above situations have been observed to
 happen in 2 scenarios:
 
-1.  The table(s) which the Debezium connector is tracking has not had
+1.  The tables which the Debezium connector is tracking has not had
     any changes, and heartbeats are not enabled in the connector.
 
-2.  The table(s) which the Debezium connector is tracking has not had
+2.  The tables which the Debezium connector is tracking has not had
     any changes, heartbeats are enabled (via `heartbeat.interval.ms` and
     `heartbeat.action.query`), but the connector is not sending the
     heartbeat.
@@ -124,7 +122,7 @@ PoistgreSQL database.
 
     After a node replacement, replication slots are not recreated
     automatically in the newly promoted database. When Debezium
-    recovers, it will recreate the replication slot.If there were
+    recovers, it will recreate the replication slot. If there were
     changes made to the database before the replication slot is
     recreated on the new primary server, then Debezium will not be able
     to capture them, resulting in data loss.
@@ -136,11 +134,11 @@ PoistgreSQL database.
     once the snapshot finishes to avoid regenerating snapshot on every
     restart.
 
-2.  Manually restart the failed task(s)
+2.  Manually restart the failed tasks.
 
 3.  Confirm that the connector has created a new replication slot and
     that it is in active state by querying the `pg_replication_slots`
-    table
+    table.
 
 4.  Resume the write operations on the database.
 
@@ -184,10 +182,8 @@ also suggest:
 Verify that Debezium was able to read all changes in the slot before
 the old primary failed.
 
-To ensure that client applications that depend on events captured by
-Debezium get all the events, you need to implement a method to verify
-that all changes made to the tables that Debezium is capturing from are
-recorded.
+To ensure client applications receive all events captured by Debezium,
+implement a verification method to confirm all changes to the monitored tables are recorded.
 
 :::tip
 The example contained in the [dedicated Aiven

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg.md
@@ -4,15 +4,10 @@ title: Create a Debezium source connector from PostgreSQL® to Apache Kafka®
 
 The Debezium source connector extracts the changes committed to the transaction log in a relational database, such as PostgreSQL®, and writes them to an Apache Kafka® topic in a standard format where they can be transformed and read by multiple consumers.
 
-:::note
-**Breaking changes in Debezium 2.5**:
-Debezium version 2.5 introduces significant changes to the connector's configuration
-and behavior. New setups [defaults to version 2.5](https://debezium.io/releases/2.5/release-notes)
-while existing setups using version 1.9 remain on that version for stability.
-Test configurations with version 2.5 before upgrading. The `wal2json` plugin is
-deprecated in this version; consider transitioning to `pgoutput` or `decoderbufs`.
-For help with upgrades or queries, contact Aiven support.
-:::
+import Note from "@site/static/includes/debezium-breakingchange.md"
+
+<Note/>
+
 
 ## Prerequisites {#connect_debezium_pg_source_prereq}
 

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg.md
@@ -183,8 +183,7 @@ With Aiven for Apache Kafka, topics are not created automatically. You have two 
 
 - Manually create topics using the naming pattern: `database.server.name.schema_name.table_name`.
 - Enable the `Kafka topic auto-creation` feature. See
-  [Enable automatic topic creation with Aiven CLI](docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli).
-
+  [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli)
 :::
 
 ## Solve the error `must be superuser to create FOR ALL TABLES publication`

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.md
@@ -1,22 +1,11 @@
 ---
 title: Create a Debezium source connector from SQL Server to Apache Kafka® with CDC
 ---
+The SQL Server Debezium source connector uses the [change data capture (CDC) ](https://learn.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-data-capture-sql-server?view=sql-server-2017) feature to extract database changes from designated tables and write them to Apache Kafka® topic in a standard format for multiple consumers to read and transform.
 
-The SQL Server Debezium source connector uses the
-[change data capture (CDC)
-](https://learn.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-data-capture-sql-server?view=sql-server-2017)
-feature to extract database changes from designated tables and write them to
-Apache Kafka® topic in a standard format for multiple consumers to read and transform.
+import Note from "@site/static/includes/debezium-breakingchange.md"
 
-:::note
-**Breaking changes in Debezium 2.5**:
-Debezium version 2.5 introduces significant changes to the connector's configuration
-and behavior. New setups [defaults to version 2.5](https://debezium.io/releases/2.5/release-notes)
-while existing setups using version 1.9 remain on that version for stability.
-Test configurations with version 2.5 before upgrading. Review the specific changes to the
-SQL Server connector in Debezium 2.5. For help with upgrades or queries, contact
-Aiven support.
-:::
+<Note/>
 
 ## Enable CDC in SQL Server {#connect_debezium_sql_server_schema_versioning}
 
@@ -247,13 +236,13 @@ To create a Kafka Connect connector, follow these steps:
 
 1. Log in to the [Aiven Console](https://console.aiven.io/).
 
-1. Select the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service where
-   you want to define the connector.
+1. Select the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service
+   to define the connector.
 
 1. Select **Connectors** from the  sidebar.
 
-1. Select **Create New Connector**, the button is enabled only for
-    services [with Kafka Connect enabled](enable-connect).
+1. Select **Create New Connector**, which is available only for
+   services [that have Apache Kafka Connect enabled](enable-connect).
 
 1. Select **Debezium - SQL Server**.
 

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.md
@@ -279,7 +279,7 @@ To create a Kafka Connect connector, follow these steps:
 
    - Manually create topics using the naming pattern: `database.server.name.schema_name.table_name`.
    - Enable the `Kafka topic auto-creation` feature.
-     See [Enable automatic topic creation with Aiven CLI](docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli).
+     See [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli).
 
 1.  Verify the connector status under the **Connectors** screen.
 

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.md
@@ -2,34 +2,34 @@
 title: Create a Debezium source connector from SQL Server to Apache Kafka® with CDC
 ---
 
-The SQL Server Debezium source connector is based on the [change data
-capture (CDC)
-feature](https://learn.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-data-capture-sql-server?view=sql-server-2017),
-extracts the database changes captured in specific [change
-tables](https://debezium.io/documentation/reference/stable/connectors/sqlserver.html)
-on a polling interval, and writes them to an Apache Kafka® topic in a
-standard format where they can be transformed and read by multiple
-consumers.
+The SQL Server Debezium source connector uses the
+[change data capture (CDC)
+](https://learn.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-data-capture-sql-server?view=sql-server-2017)
+feature to extract database changes from designated tables and write them to
+Apache Kafka® topic in a standard format for multiple consumers to read and transform.
 
 :::note
-You can check the full set of available parameters and configuration
-options in the [connector's
-documentation](https://debezium.io/documentation/reference/stable/connectors/sqlserver.html).
+**Breaking changes in Debezium 2.5**:
+Debezium version 2.5 introduces significant changes to the connector's configuration
+and behavior. New setups [defaults to version 2.5](https://debezium.io/releases/2.5/release-notes)
+while existing setups using version 1.9 remain on that version for stability.
+Test configurations with version 2.5 before upgrading. Review the specific changes to the
+SQL Server connector in Debezium 2.5.For help with upgrades or queries, contact
+Aiven support.
 :::
 
 ## Enable CDC in SQL Server {#connect_debezium_sql_server_schema_versioning}
 
-To use the Debezium source connector for SQL server, you need to enabled
-at database level and table level the SQL Server Change Data Capture
-(CDC). This will create the necessary schemas and tables containing a
-history of all the change events happening to the tables you want to
-track with the connector.
+To use the Debezium source connector for SQL Server, enable the SQL Server
+Change Data Capture (CDC) at both the database and table levels. This creates the
+necessary schemas and tables containing a history of all change events in the tables
+you wish to track with the connector.
 
 ### Enable CDC at database level
 
 To enable the CDC at database level, you can use the following command:
 
-```
+```sql
 USE <DATABASE_NAME>
 GO
 EXEC sys.sp_cdc_enable_db
@@ -40,19 +40,20 @@ GO
 If you're using GCP Cloud SQL for SQL Server, you can enable database
 CDC with:
 
-```
+```sql
 EXEC msdb.dbo.gcloudsql_cdc_enable_db '<DATABASE_NAME>'
 ```
+
 :::
 
-Once the CDC is enabled, a new schema called `cdc` is created for the
-target database, containing all the required tables.
+Enabling CDC creates a new schema called `cdc` in the target database, which contains
+all necessary tables.
 
 ### Enable CDC at table level
 
 To enable CDC for a table you can execute the following command:
 
-```
+```sql
 USE <DATABASE_NAME>
 GO
 
@@ -67,52 +68,50 @@ GO
 
 The command above has the following parameters:
 
--   `<DATABASE_NAME>`, `<SCHEMA_NAME>`, `<TABLE_NAME>`: the references
-    to the table where CDC needs to be setup
--   `<ROLE_NAME>`: the database role that will have access to the change
+-   `<DATABASE_NAME>`, `<SCHEMA_NAME>`, `<TABLE_NAME>`: The references
+    to the table where CDC needs to be set.
+-   `<ROLE_NAME>`: The database role that will have access to the change
     tables. Leave it `NULL` to only allow access to members of
-    `sysadmin` or `db_owner` groups
+    `sysadmin` or `db_owner` groups.
 -   `<FILEGROUP_NAME>`: Specifies the [file
     group](https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-files-and-filegroups)
-    where the files will be written, needs to be pre-existing
+    where the files will be written, needs to be pre-existing.
 
 :::note
 If you're using GCP Cloud SQL for SQL Server, you can enable database
 CDC on a table with:
 
-```
+```sql
 EXEC sys.sp_cdc_enable_table
 @source_schema = N'<SCHEMA_NAME>',
 @source_name = N'<TABLE_NAME>',
 @role_name = N'<ROLE_NAME>'
 ```
+
 :::
 
 :::warning
-When evolving table schemas in online mode, new columns information
-might be lost until the CDC is re-enabled for the table. More
-information are available in the [related Debezium
+When modifying table schemas online, new column information can be lost
+until CDC is re-enabled for the table. For more details,
+refer to the [related Debezium
 documentation](https://debezium.io/documentation/reference/stable/connectors/sqlserver.html#sqlserver-schema-evolution).
 :::
 
 ## Prerequisites {#connect_debezium_sql_server_source_prereq}
 
-To setup a Debezium source connector pointing to SQL Server, you need an
-Aiven for Apache Kafka service
-[with Kafka Connect enabled](enable-connect) or a
-[dedicated Aiven for Apache Kafka Connect cluster](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
+To configure a Debezium source connector for MongoDB, you need either an
+Aiven for Apache Kafka service with [Apache Kafka Connect enabled](enable-connect) or
+a [dedicated Aiven for Apache Kafka Connect cluster](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
 
-Furthermore you need to collect the following information about the
-source SQL Server database upfront:
+Before you begin, gather the necessary information about your source MongoDB database:
 
 -   `SQLSERVER_HOST`: The database hostname
 -   `SQLSERVER_PORT`: The database port
 -   `SQLSERVER_USER`: The database user to connect
 -   `SQLSERVER_PASSWORD`: The database password for the `SQLSERVER_USER`
 -   `SQLSERVER_DATABASE_NAME`: The database name
--   `SQLSERVER_TABLES`: The list of database tables to be included in
-    Apache Kafka; the list must be in the form of
-    `schema_name1.table_name1,schema_name2.table_name2`
+-   `SQLSERVER_TABLES`: The list of database tables to be included in Apache Kafka. Format
+    the list as `schema_name1.table_name1,schema_name2.table_name2`
 -   `APACHE_KAFKA_HOST`: The hostname of the Apache Kafka service,
     needed when storing the
     [schema definition changes](/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server#connect_debezium_sql_server_schema_versioning)
@@ -126,13 +125,13 @@ source SQL Server database upfront:
 -   `SCHEMA_REGISTRY_PASSWORD`: The Apache Kafka's schema registry user
     password, only needed when using Avro as data format
 
-:::note
-If you're using Aiven for SQL Server and Aiven for Apache Kafka the
-above details are available in the [Aiven
-console](https://console.aiven.io/) service Overview tab or via the
-dedicated `avn service get` command with the
+If you are using Aiven for PostgreSQL and Aiven for Apache Kafka the above details are
+available in the [Aiven console](https://console.aiven.io/) service Overview page or
+via the dedicated `avn service get` command with the
 [Aiven CLI](/docs/tools/cli/service-cli#avn_service_get).
-:::
+
+For a complete list of all available parameters and configuration options, see
+Debezium [connector's documentation](https://debezium.io/documentation/reference/stable/connectors/sqlserver.html).
 
 ## Setup a SQL Server Debezium source connector with Aiven Console
 
@@ -142,11 +141,10 @@ Console](https://console.aiven.io/).
 
 ### Define a Kafka Connect configuration file
 
-Define the connector configurations in a file (we'll refer to it with
-the name `debezium_source_sql_server.json`) with the following content,
-creating a file is not strictly necessary but allows to have all the
-information in one place before copy/pasting them in the [Aiven
-Console](https://console.aiven.io/):
+Create a configuration file named `debezium_source_mysql.json` with the following
+connector configurations. While optional, creating this file helps you organize your
+settings in one place and copy/paste them into the
+[Aiven Console](https://console.aiven.io/) later.
 
 ```json
 {
@@ -191,35 +189,34 @@ Console](https://console.aiven.io/):
 
 The configuration file contains the following entries:
 
--   `name`: the connector name, replace CONNECTOR_NAME with the name you
+-   `name`: The connector name, replace CONNECTOR_NAME with the name you
     want to use for the connector.
 
 -   `SQLSERVER_HOST`, `SQLSERVER_PORT`, `SQLSERVER_DATABASE_NAME`,
     `SSL_MODE`, `SQLSERVER_USER`, `SQLSERVER_PASSWORD`,
-    `SQLSERVER_TABLES`: source database parameters collected in the
+    `SQLSERVER_TABLES`: Source database parameters collected in the
     [prerequisite](/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server#connect_debezium_sql_server_source_prereq) phase.
 
--   `database.server.name`: the logical name of the database, dictates
-    the prefix that will be used for Apache Kafka topic names. The
-    resulting topic name will be the concatenation of the
+-   `database.server.name`: The logical name of the database, which determines the prefix
+    used for Apache Kafka topic names. The resulting topic name is a combination of the
     `database.server.name` and the table name.
 
--   `tasks.max`: maximum number of tasks to execute in parallel. By
+-   `tasks.max`: Maximum number of tasks to execute in parallel. By
     default this is 1, the connector can use at most 1 task for each
     source table defined. Replace `NR_TASKS` with the amount of parallel
     task based on the number of input tables.
 
--   `poll.interval.ms`: the frequency of the queries to the CDC tables.
+-   `poll.interval.ms`: The frequency of the queries to the CDC tables.
 
--   `database.history.kafka.topic`: the name of the Apache Kafka topic
-    that will contain the history of schema changes.
+-   `database.history.kafka.topic`: The name of the Apache Kafka topic
+    that contains the history of schema changes.
 
--   `database.history.kafka.bootstrap.servers`: points to the Aiven for
+-   `database.history.kafka.bootstrap.servers`: Directs to the Aiven for
     Apache Kafka service where the connector is running and is needed to
     store
     [schema definition changes](/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server#connect_debezium_sql_server_schema_versioning)
 
--   `database.history.producer` and `database.history.consumer`: points
+-   `database.history.producer` and `database.history.consumer`: Refers
     to truststores and keystores pre-created on the Aiven for Apache
     Kafka node to handle SSL authentication
 
@@ -227,74 +224,70 @@ The configuration file contains the following entries:
     The values defined for each `database.history.producer` and
     `database.history.consumer` parameters are already set to work with
     the predefined truststore and keystore created in the Aiven for
-    Apache Kafka nodes. Therefore, they **should not be changed**.
+    Apache Kafka nodes. Modifying these values is not recommended.
     :::
 
--   `key.converter` and `value.converter`: defines the messages data
+-   `key.converter` and `value.converter`: Defines the messages data
     format in the Apache Kafka topic. The
     `io.confluent.connect.avro.AvroConverter` converter pushes messages
-    in Avro format. To store the messages schema we use Aiven's
-    [Karapace schema registry](https://github.com/aiven/karapace) as
-    specified by the `schema.registry.url` parameter and related
-    credentials.
+    in Avro format. To store the message schemas, Aiven's
+    [Karapace schema registry](https://github.com/Aiven-Open/karapace) is used,
+    specified by the `schema.registry.url` parameter and related credentials.
 
     :::note
     The `key.converter` and `value.converter` sections are only needed
-    when pushing data in Avro format. If omitted the messages will be
-    defined in JSON format.
+    when pushing data in Avro format. Otherwise, messages default to JSON format.
 
-    The `USER_INFO` is not a placeholder, no substitution is needed for
-    that parameter.
+    The `USER_INFO` is not a placeholder and does not require any parameter substitution.
     :::
 
 ### Create a Kafka Connect connector with the Aiven Console
 
 To create a Kafka Connect connector, follow these steps:
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/) and select
-    the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
-    service where the connector needs to be defined.
+1. Log in to the [Aiven Console](https://console.aiven.io/).
 
-2.  Select **Connectors** from the left sidebar.
+1. Select the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service where
+   you want to define the connector.
 
-3.  Select **Create New Connector**, the button is enabled only for
-    services
-    [with Kafka Connect enabled](enable-connect).
+1. Select **Connectors** from the  sidebar.
 
-4.  Select **Debezium - SQL Server**.
+1. Select **Create New Connector**, the button is enabled only for
+    services [with Kafka Connect enabled](enable-connect).
 
-5.  In the **Common** tab, locate the **Connector configuration** text
+1. Select **Debezium - SQL Server**.
+
+1. In the **Common** tab, locate the **Connector configuration** text
     box and select on **Edit**.
 
-6.  Paste the connector configuration (stored in the
-    `debezium_source_sql_server.json` file) in the form.
+1. Paste the connector configuration (stored in the
+   `debezium_source_sql_server.json` file) in the form.
 
-7.  Select **Apply**.
+1. Select **Apply**.
 
-    :::note
-    The Aiven Console parses the configuration file and fills the
-    relevant UI fields. You can review the UI fields across the various
-    tabs and change them if necessary. The changes will be reflected in
-    JSON format in the **Connector configuration** text box.
-    :::
+   :::note
+   The Aiven Console reads through the configuration file and automatically populates
+   the relevant UI fields. You can view and modify these fields across
+   different tabs. Any change you make is reflected in JSON format
+   within the **Connector configuration** text box.
+   :::
 
-8.  After all the settings are correctly configured, select **Create
-    connector**.
+1. After all the settings are correctly configured, select **Create connector**.
 
-    :::tip
-    If you're using Aiven for Apache Kafka, topics will not be created
-    automatically. Either create them manually following the
-    `database.server.name.schema_name.table_name` naming pattern or
-    enable the `kafka.auto_create_topics_enable` advanced parameter.
-    :::
+   :::tip
+   With Aiven for Apache Kafka, topics are not created automatically. You have two options:
 
-9.  Verify the connector status under the **Connectors** screen.
+   - Manually create topics using the naming pattern: `database.server.name.schema_name.table_name`.
+   - Enable the `Kafka topic auto-creation` feature.
+     See [Enable automatic topic creation with Aiven CLI](docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli).
 
-10. Verify the presence of the data in the target Apache Kafka topic
-    coming from the SQL Server dataset. The topic name is equal to
-    concatenation of the database and table name. If you need to change
-    the target table name, you can do so using the Kafka Connect
-    `RegexRouter` transformation.
+1.  Verify the connector status under the **Connectors** screen.
+
+1. Verify the presence of the data in the target Apache Kafka topic
+   coming from the MySQL dataset. The topic name is equal to
+   concatenation of the database and table name. To change
+   the target table name, you can use Apache Kafka Connect
+   `RegexRouter` transformation.
 
 :::note
 You can also create connectors using the

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.md
@@ -14,7 +14,7 @@ Debezium version 2.5 introduces significant changes to the connector's configura
 and behavior. New setups [defaults to version 2.5](https://debezium.io/releases/2.5/release-notes)
 while existing setups using version 1.9 remain on that version for stability.
 Test configurations with version 2.5 before upgrading. Review the specific changes to the
-SQL Server connector in Debezium 2.5.For help with upgrades or queries, contact
+SQL Server connector in Debezium 2.5. For help with upgrades or queries, contact
 Aiven support.
 :::
 

--- a/static/includes/debezium-breakingchange.md
+++ b/static/includes/debezium-breakingchange.md
@@ -1,0 +1,10 @@
+:::note
+**Breaking changes in Debezium 2.5**
+
+Debezium version 2.5 introduces significant changes to the connector's configuration
+and behavior. New setups [defaults to version 2.5](https://debezium.io/releases/2.5/release-notes)
+while existing setups using version 1.9 remain on that version for stability.
+Test configurations with version 2.5 before upgrading. Review the specific
+changes to the MongoDB connector in Debezium 2.5.
+For help with upgrades or queries, contact Aiven support.
+:::


### PR DESCRIPTION
## Describe your changes
Updated Debezium source connector documentation to reflect breaking changes introduced in Debezium version 2.5. 
[HH-3411](https://aiven.atlassian.net/browse/HH-3411)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.


[HH-3411]: https://aiven.atlassian.net/browse/HH-3411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ