### PR TITLE
fix: change link to Console page to docs

### DIFF
--- a/docs/tools/api.md
+++ b/docs/tools/api.md
@@ -2,67 +2,53 @@
 title: Aiven API
 ---
 
-Use the Aiven API to programmatically perform any task that you can do
-through the web interface. This is an ideal way to automate tasks
-involving Aiven at every stage of your workflow.
+Use the Aiven API to programmatically access and automate tasks in the Aiven platform.
 
 Common use cases for the Aiven API:
 
--   Use with CI (Continuous Integration) to spin up data platforms on
-    Aiven for use during test runs.
+-   Use with continuous integration to create services during test runs.
 -   Integrate with other parts of your existing automation setup to
-    achieve complex tasks.
+    complete complex tasks.
 -   Deploy and tear down development or demo platforms on a schedule.
-
-We make the API available to all Aiven users. It is also the engine
-behind the Aiven Console, so you should find that all operations are
-also available through the API.
 
 ## API quickstart
 
--   **Postman**: Try [Aiven on
-    Postman](https://www.postman.com/aiven-apis/workspace/aiven/documentation/21112408-1f6306ef-982e-49f8-bdae-4d9fdadbd6cd)
-    and start working with your data platform programmatically.
--   **API documentation**: Check the [API documentation and OpenAPI
-    description](https://api.aiven.io/doc/) to work with the API
-    directly.
+-   View the [API documentation and OpenAPI
+    description](https://api.aiven.io/doc/).
+-   Try the [Aiven API on
+    Postman](https://www.postman.com/aiven-apis/workspace/aiven/documentation/21112408-1f6306ef-982e-49f8-bdae-4d9fdadbd6cd).
 
 ## Authentication
 
-Most (but not all) endpoints require authentication. You\'ll need an
-authentication token from the [profile section of your Aiven
-console](https://console.aiven.io/profile/auth).
+Most endpoints require authentication.
+[Create an authentication token](docs/platform/howto/create_authentication_token.md)
+and send it in the header.
 
-Send this token in the header, using a structure like this, and
-replacing `TOKEN` with your actual API token:
+You can use a structure like this:
 
-```
+```bash
 Authorization: aivenv1 TOKEN
 ```
 
-Read more about
-[authentication tokens](/docs/platform/concepts/authentication-tokens).
+Where `TOKEN` is your authentication token.
 
 ## Handling JSON responses
 
-The [Aiven API](https://api.aiven.io/doc/) returns information in JSON
-format, sometimes a lot of information. This is perfect for machines but
-not ideal for humans. Try a tool like `jq`
-([https://stedolan.github.io/jq/](https://stedolan.github.io/jq/)) to make things easier to read and
-manipulate.
+The Aiven API returns information in JSON format. To get
+information in an easier-to-read format, you can use a tool like
+[`jq`](https://stedolan.github.io/jq/).
 
 ## API examples
 
-In the following examples, replace `{TOKEN}` with your own value of the
-authentication token.
-
 ### List your projects
 
-```
-curl -H "Authorization: aivenv1 {TOKEN}" https://api.aiven.io/v1/project
+```bash
+curl -H "Authorization: aivenv1 TOKEN" https://api.aiven.io/v1/project
 ```
 
-The following is a sample response:
+Where `TOKEN` is your authentication token.
+
+The output is similar to the following:
 
 ```json
 {
@@ -143,16 +129,16 @@ The following is a sample response:
 }
 ```
 
-## List of cloud regions
+### List cloud regions
 
-This endpoint does not require authorization; if you aren't
-authenticated then the standard set of clouds will be returned.
+This endpoint does not require authorization. If you aren't
+authenticated, it returns the standard set of cloud regions.
 
-```
+```bash
 curl https://api.aiven.io/v1/clouds
 ```
 
-The following is a sample response:
+The output is similar to the following:
 
 ```json
 {
@@ -173,15 +159,11 @@ The following is a sample response:
     },
 ```
 
-For most endpoints where a cloud is used as an input, the `cloud_name`
-from this result is the field to use.
+You can use the `cloud_name` from this response as an input for other endpoints.
 
-## Further reading
+## Related pages
 
-Here are some more resources for you:
-
--   Some [API examples on the Aiven
-    blog](https://aiven.io/blog/your-first-aiven-api-call). This post
-    also includes information about importing our OpenAPI description
-    into Postman.
--   Learn more about the [Aiven CLI](/docs/tools/cli).
+-   Read about
+    [authentication tokens](/docs/platform/concepts/authentication-tokens).
+-   See more [API examples](https://aiven.io/blog/your-first-aiven-api-call).
+-   Learn about the [Aiven CLI](/docs/tools/cli).


### PR DESCRIPTION
## Describe your changes

Fixes a link that pointed to the wrong Console page to link to the relevant documentation page instead. Fix other linting issues and light restructuring. This page will be completely reworked in a later PR.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](../styleguide.md).
- [X] My links start with `/docs/`.
