### PR TITLE
update: Flink ref doc link version to 1.16

### DIFF
--- a/docs/products/flink/concepts/checkpoints.md
+++ b/docs/products/flink/concepts/checkpoints.md
@@ -2,21 +2,26 @@
 title: Checkpoints
 ---
 
-Checkpoints in Aiven for Apache Flink® are a key feature for ensuring
-resiliency and fault tolerance in stateful functions. By periodically
-creating snapshots of the data stream and storing them, checkpoints
-enable Flink to quickly and efficiently recover the stream's state and
-position in the event of a failure, ensuring that applications can
-continue to execute without interruption.
+Checkpoints in Aiven for Apache Flink® are a key feature for ensuring resiliency and fault tolerance in stateful functions.
+
+By periodically creating snapshots of the data stream and storing them, checkpoints
+enable Apache Flink to recover the stream's state and position in the event of a failure,
+ensuring that applications can continue to execute without interruption.
+
+## Recover from failures
 
 In the event of a failure, Aiven for Apache Flink uses these checkpoints
 to restore the application's state and resume processing from the last
 recorded reading position, allowing the application to continue as if
 the failure had never occurred.
 
-Unlike traditional backups in database systems, rather than creating
-full copies of the data, checkpoints function more like recovery logs by
-periodically creating snapshots of the data stream and storing them.
+## Efficient data handling
+
+Unlike traditional backups that create full data copies, checkpoints act more like
+recovery logs. They periodically snapshot the data stream and store these snapshots,
+making data handling more efficient.
+
+## Visualize checkpoints
 
 ```mermaid
 graph TD;
@@ -28,5 +33,7 @@ graph TD;
     id3-->id6[(State backend)];
 ```
 
-For more information, see the [Apache Flink® documentation on
-checkpoints](https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/ops/state/checkpoints/).
+## Related pages
+
+- [Apache Flink® documentation on
+checkpoints](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/ops/state/checkpoints/)

--- a/docs/products/flink/concepts/checkpoints.md
+++ b/docs/products/flink/concepts/checkpoints.md
@@ -36,4 +36,4 @@ graph TD;
 ## Related pages
 
 - [Apache Flink® documentation on
-checkpoints](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/ops/state/checkpoints/)
+checkpoints](https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/ops/state/checkpoints/)

--- a/docs/products/flink/concepts/event-processing-time.md
+++ b/docs/products/flink/concepts/event-processing-time.md
@@ -2,22 +2,33 @@
 title: Event and processing times
 ---
 
-Event time refers to when events actually happen, while processing time
-refers to when events are observed within a system. Various factors
-affect how events are processed, including shared hardware resources and
-network congestion, distributed system logic, and variances in the data
-throughput and order. Because of this, there can be significant
-differences between the event time and processing time for an event,
-even though ideally they would be equal.
+Event time refers to when events occur, and processing time is when a system observes or processes these events. Understanding the difference between these two is essential for data processing and streaming. It affects data handling, analysis, and storage.
 
-In Apache Flink®, the streamed data does not always arrive in the same
-order as the events occurred. This means that using processing time in
-your applications can cause issues in system behavior. For this reason,
-we recommend that you use event time to process data, as it allows your
-applications to maintain the correct event sequence throughout the data
-streaming pipeline. In addition, using event time to process your data
-allows you to reprocess the data later on with consistent results.
+## Factors affecting processing
 
-For more information, see the [Apache Flink® documentation on event time
+Several factors can cause differences between event time and processing time,
+including:
+
+- Shared hardware resources can lead to variable processing capabilities.
+- Changes in network traffic can delay data transmission, affecting when data is processed.
+- The complexities of distributed systems can introduce delays or reorder data.
+- Variations in the volume of data and the order in which it arrives can further
+complicate processing times.
+
+Ideally, event time and processing time would be the same, but this is rarely the
+case in practice.
+
+## Use event time
+
+In Apache Flink®, data might not always arrive in the order in which the events occurred.
+Relying on processing time can lead to inaccuracies and issues in system behavior.
+To mitigate these issues, Aiven recommends using **event time** when processing data.
+This approach maintains the correct sequence of events throughout the data streaming
+pipeline. Additionally, event time allows for consistent data reprocessing,
+improving reliability and system resilience.
+
+## Related pages
+
+- [Apache Flink® event time
 and processing
-time](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/ops/state/checkpoints/).
+time](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/concepts/time/)

--- a/docs/products/flink/concepts/event-processing-time.md
+++ b/docs/products/flink/concepts/event-processing-time.md
@@ -20,4 +20,4 @@ allows you to reprocess the data later on with consistent results.
 
 For more information, see the [Apache Flink® documentation on event time
 and processing
-time](https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/concepts/time/).
+time](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/ops/state/checkpoints/).

--- a/docs/products/flink/concepts/event-processing-time.md
+++ b/docs/products/flink/concepts/event-processing-time.md
@@ -29,4 +29,4 @@ improving reliability and system resilience.
 
 ## Related pages
 
-- [Apache Flink® event time and processing time](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/concepts/time/)
+- [Apache Flink® event time and processing time](https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/concepts/time/)

--- a/docs/products/flink/concepts/event-processing-time.md
+++ b/docs/products/flink/concepts/event-processing-time.md
@@ -13,7 +13,7 @@ including:
 - Changes in network traffic can delay data transmission, affecting when data is processed.
 - The complexities of distributed systems can introduce delays or reorder data.
 - Variations in the volume of data and the order in which it arrives can further
-complicate processing times.
+  complicate processing times.
 
 Ideally, event time and processing time would be the same, but this is rarely the
 case in practice.
@@ -29,6 +29,4 @@ improving reliability and system resilience.
 
 ## Related pages
 
-- [Apache Flink® event time
-and processing
-time](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/concepts/time/)
+- [Apache Flink® event time and processing time](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/concepts/time/)

--- a/docs/products/flink/concepts/kafka-connector-requirements.md
+++ b/docs/products/flink/concepts/kafka-connector-requirements.md
@@ -2,14 +2,13 @@
 title: Settings for Apache Kafka® connectors
 ---
 
-This article outlines the required settings for standard and upsert
-Kafka connectors in Aiven for Apache Flink®.
+Explore the necessary settings for standard and upsert Kafka connectors in Aiven for Apache Flink®.
 
 :::note
 Aiven for Apache Flink® supports the following data formats: JSON
 (default), Apache Avro, Confluent Avro, Debezium CDC. For more
 information on these, see the [Apache Flink® documentation on
-formats](https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/connectors/table/formats/overview/).
+formats](https://ci.apache.org/projects/flink/flink-docs-release-1.16/docs/connectors/table/formats/overview/).
 :::
 
 <table>

--- a/docs/products/flink/concepts/kafka-connector-requirements.md
+++ b/docs/products/flink/concepts/kafka-connector-requirements.md
@@ -8,7 +8,7 @@ Explore the necessary settings for standard and upsert Kafka connectors in Aiven
 Aiven for Apache Flink® supports the following data formats: JSON
 (default), Apache Avro, Confluent Avro, Debezium CDC. For more
 information on these, see the [Apache Flink® documentation on
-formats](https://ci.apache.org/projects/flink/flink-docs-release-1.16/docs/connectors/table/formats/overview/).
+formats](https://ci.apache.org/projects/flink/flink-docs-release-1.19/docs/connectors/table/formats/overview/).
 :::
 
 <table>

--- a/docs/products/flink/concepts/watermarks.md
+++ b/docs/products/flink/concepts/watermarks.md
@@ -2,21 +2,19 @@
 title: Watermarks
 ---
 
-Another concept closely related to windows and event time in Apache
-Flink® is *watermarks*. Flink uses watermarks as a mechanism to measure
-progress in event time; they flow as part of the data stream, carrying a
-timestamp that declares the minimum event time reached in the data
-stream.
+Apache Flink® uses watermarks to synchronize and process events in data streams accurately. These watermarks are timestamps embedded in the data stream that track the progression of event time.
 
-This allows Flink to set points in the stream when all events up to a
-certain timestamp should have arrived, so that operators can set their
-internal event time to the value of the watermarks that reach them.
+## Role of watermarks
 
-Flink uses *watermark strategies* and *watermark generators* to define
-how the watermark logic is implemented. For example, you can set Flink
-to generate watermarks either periodically at specific intervals or when
-triggered by an event or element with a specific marker.
+Watermarks signal when all events up to a certain time have arrived, allowing
+Apache Flink operators to synchronize their event time clocks with these timestamps.
+This mechanism is crucial for timely and accurate event processing.
 
-For more information on watermarks, see the [Apache Flink® documentation
-on generating
-watermarks](https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/dev/datastream/event-time/generating_watermarks/).
+Apache Flink® defines the watermark logic using watermark strategies and watermark
+generators. For example, you can configure Apache Flink to generate
+watermarks either periodically at specific intervals or when an event or element
+with a specific marker triggers it.
+
+## Related pages
+
+For detailed information on watermarks and how to generate them in Apache Flink®, visit the [official documentation](https://ci.apache.org/projects/flink/flink-docs-release-1.16/docs/dev/datastream/event-time/generating_watermarks/).

--- a/docs/products/flink/concepts/watermarks.md
+++ b/docs/products/flink/concepts/watermarks.md
@@ -17,4 +17,4 @@ with a specific marker triggers it.
 
 ## Related pages
 
-For detailed information on watermarks and how to generate them in Apache Flink®, visit the [official documentation](https://ci.apache.org/projects/flink/flink-docs-release-1.16/docs/dev/datastream/event-time/generating_watermarks/).
+For detailed information on watermarks and how to generate them in Apache Flink®, visit the [official documentation](https://ci.apache.org/projects/flink/flink-docs-release-1.19/docs/dev/datastream/event-time/generating_watermarks/).

--- a/docs/products/flink/concepts/windows.md
+++ b/docs/products/flink/concepts/windows.md
@@ -2,29 +2,33 @@
 title: Windows
 ---
 
-Apache Flink® uses *windows* to split the streamed data into segments
-that can be processed. Due to the unbounded nature of data streams,
-there is never a situation where *all* of the data is available, because
-you would be waiting indefinitely for new data points to arrive - so
-instead, windowing offers a way to define a subset of data points that
-you can then process and analyze.
+Apache Flink® uses the concept of *windows* to manage the continuous flow of data in streams by segmenting it into manageable chunks. This approach is essential due to the continuous and unbounded nature of data streams, where waiting for all data to arrive is impractical.
 
-A window is created when the first element matching the criteria that is
-set for it appears. The window'strigger defines when the window is
-considered ready for processing, and the function set for the window
-specifies how to process the data. Each window also has an allowed
-lateness value - this indicates how long new events are accepted for
-inclusion in the window after the trigger closes it.
+## How windows work
 
-For example, you can set 15:00 as the start time for a time-based
-window, with the end timestamp set to 15:10 and an allowed lateness of 1
-minute. The first event with a timestamp between 15:00 and 15:10 creates
-the window, and any event that arrives between 15:10 and 15:11 with a
-timestamp between 15:00 and 15:10 is still included in the window.
+Windows in Apache Flink® is defined to segment the data stream into subsets for
+processing and analysis. A window is created when the first element that meets
+the specified criteria arrives.
 
-Events may still arrive after the allowed lateness for the window, so
-your application should include a means of handling those events, for
-example by logging them separately and then discarding them.
+The trigger of a window determines when the window is ready for processing.
+Once the window is ready, the processing function determines how the data within the
+window is analyzed or manipulated. Additionally, each window has an **allowed lateness**
+value, indicating how long new events are accepted into the window after the
+trigger has closed it.
 
-For more information, see the [Apache Flink® documentation on
-windows](https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/dev/datastream/operators/windows/).
+### Example scenario
+
+Consider setting a time-based window from 15:00 to 15:10 with an allowed lateness
+of one minute. The window is created upon the arrival of the first event within this
+interval. Events arriving between 15:10 and 15:11, but still within the window's
+time range, are included. This mechanism allows for flexibility in handling data that
+arrives slightly out of order or delayed.
+
+### Handling late events
+
+Events that arrive after the allowed lateness should be managed separately, such as by
+logging and discarding them. This is done to ensure the integrity of windowed processing.
+
+## Further reading
+
+- [Apache Flink® windows](https://ci.apache.org/projects/flink/flink-docs-release-1.16/docs/dev/datastream/operators/windows/)

--- a/docs/products/flink/concepts/windows.md
+++ b/docs/products/flink/concepts/windows.md
@@ -21,8 +21,8 @@ trigger has closed it.
 Consider setting a time-based window from 15:00 to 15:10 with an allowed lateness
 of one minute. The window is created upon the arrival of the first event within this
 interval. Events arriving between 15:10 and 15:11, but still within the window's
-time range, are included. This mechanism allows for flexibility in handling data that
-arrives slightly out of order or delayed.
+time range, are included. This mechanism provides flexibility in managing data that is
+slightly out of order or arrives later than expected.
 
 ### Handling late events
 

--- a/docs/products/flink/concepts/windows.md
+++ b/docs/products/flink/concepts/windows.md
@@ -31,4 +31,4 @@ logging and discarding them. This is done to ensure the integrity of windowed pr
 
 ## Further reading
 
-- [Apache Flink® windows](https://ci.apache.org/projects/flink/flink-docs-release-1.16/docs/dev/datastream/operators/windows/)
+- [Apache Flink® windows](https://ci.apache.org/projects/flink/flink-docs-release-1.19/docs/dev/datastream/operators/windows/)

--- a/docs/products/flink/howto/connect-pg.md
+++ b/docs/products/flink/howto/connect-pg.md
@@ -4,7 +4,7 @@ title: Create a PostgreSQL®-based Apache Flink® table
 
 To build data pipelines, Apache Flink® requires source and target data
 structures to [be mapped as Flink
-tables](https://ci.apache.org/projects/flink/flink-docs-release-1.16/docs/dev/table/sql/create/#create-table).
+tables](https://ci.apache.org/projects/flink/flink-docs-release-1.19/docs/dev/table/sql/create/#create-table).
 This functionality can be achieved via the [Aiven
 console](https://console.aiven.io/) or
 [Aiven CLI](/docs/tools/cli/service/flink).

--- a/docs/products/flink/howto/connect-pg.md
+++ b/docs/products/flink/howto/connect-pg.md
@@ -4,7 +4,7 @@ title: Create a PostgreSQL®-based Apache Flink® table
 
 To build data pipelines, Apache Flink® requires source and target data
 structures to [be mapped as Flink
-tables](https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/dev/table/sql/create/#create-table).
+tables](https://ci.apache.org/projects/flink/flink-docs-release-1.16/docs/dev/table/sql/create/#create-table).
 This functionality can be achieved via the [Aiven
 console](https://console.aiven.io/) or
 [Aiven CLI](/docs/tools/cli/service/flink).
@@ -26,10 +26,10 @@ one or more Aiven for PostgreSQL® services.
 To create a Flink table based on Aiven for PostgreSQL® via Aiven
 console:
 
-1.  In the Aiven for Apache Flink service page, select **Application**
+1.  In the Aiven for Apache Flink service page, click **Application**
     from the left sidebar.
 
-2.  Create an application or select an existing one with Aiven for
+1.  Create new application or select an existing one with Aiven for
     PostgreSQL® integration.
 
     :::note
@@ -37,34 +37,31 @@ console:
     changes to the source or sink tables.
     :::
 
-3.  In the **Create new version** screen, select **Add source tables**.
+1.  In the **Create new version** screen, click **Add source tables**.
 
-4.  Select **Add new table** or select **Edit** if you want to edit an
-    existing source table.
+1.  Click **Add new table** or click **Edit** to edit an existing source table.
 
-5.  In the **Add new source table** or **Edit source table** screen,
+1.  In the **Add new source table** or **Edit source table** screen,
     select the Aiven for PostgreSQL® service as the integrated service.
 
-6.  In the **Table SQL** section, enter the SQL statement to create the
+1.  In the **Table SQL** section, enter the SQL statement to create the
     PostgreSQL-based Apache Flink table with the following details:
 
-    -   Write the PostgreSQL® table name in the **JDBC table** field
-        with the format `schema_name.table_name`
+    - Write the PostgreSQL® table name in the **JDBC table** field
+      with the format `schema_name.table_name`
 
     :::warning
-    When using a PostgreSQL® table as target of a Flink data pipeline,
-    the table needs to exist before starting the Flink application
-    otherwise it will fail.
+    Before you create an Apache Flink application, ensure that the PostgreSQL®
+    table used as the target exists; otherwise, the application will fail.
     :::
 
-    -   Define the **Flink table name**; this name will represents the
-        Flink reference to the topic and will be used during the data
-        pipeline definition
+    - Define the **Flink table name**. This name is used as a reference to the
+      Apache Flink topic and in the definition of the data pipeline.
 
-7.  To create a sink table, select **Add sink tables** and repeat steps
+1.  To create a sink table, click **Add sink tables** and repeat steps
     4-6 for sink tables.
 
-8.  In the **Create statement** section, write the SQL schema that
+1.  In the **Create statement** section, write the SQL schema that
     defines the fields retrieved from the PostgreSQL® table and any
     additional transformations, such as format casting or timestamp
     extraction.
@@ -80,7 +77,7 @@ page](https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table
 The Aiven for PostgreSQL® service named `pg-demo` contains a table named
 `students` in the `public` schema with the following structure:
 
-```
+```sql
 CREATE TABLE students_tbl (
   student_id INT,
   student_name VARCHAR
@@ -89,7 +86,7 @@ CREATE TABLE students_tbl (
   'url' = 'jdbc:postgresql://',
   'table-name' = 'public.students'
   )
+  )
 ```
 
-The `url` will be substituted with the appropriate address during
-runtime.
+The `url` parameter is dynamically updated at runtime.

--- a/docs/products/kafka/howto/flink-with-aiven-for-kafka.md
+++ b/docs/products/kafka/howto/flink-with-aiven-for-kafka.md
@@ -2,57 +2,50 @@
 title: Use Apache Flink® with Aiven for Apache Kafka®
 ---
 
-[Apache Flink®](https://flink.apache.org/) is an open source platform
-for processing distributed streaming and batch data. Where Apache Kafka®
-excels at receiving and sending event streams, Flink consumes,
-transforms, aggregates, and enriches your data.
+[Apache Flink®](https://flink.apache.org/) is an open-source platform for handling distributed streaming and batch data. It enhances Apache Kafka's® event streaming abilities by offering advanced features for consuming, transforming, aggregating, and enriching data.
 
 :::note
-If you want to experience the power of streaming SQL transformations
+To experience the power of streaming SQL transformations
 with Flink, Aiven provides a managed
 [Aiven for Apache Flink®](/docs/products/flink) with built-in data
 flow integration with Aiven for Apache Kafka®.
 :::
 
-The example in this article shows you how to create a simple Java Flink
-job that reads data from a Kafka topic, processes it, and then pushes it
-to a different Kafka topic. It uses the Java API on a [local
-installation of Apache Flink
-1.15.1](https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/try-flink/local_installation/),
-but it can be applied to use Aiven for Apache Kafka with any self-hosted
-cluster.
+The following example demonstrates how to create a simple Java Flink job. This job
+reads data from a Apache Kafka topic, processes it,and sends it to another Apache Kafka
+topic. It uses the Java API on a
+[local installation of Apache Flink 1.16](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/try-flink/local_installation/). However, the same approach can be applied to use
+Aiven for Apache Kafka with any self-hosted cluster.
 
 ## Prerequisites {#kafka-flink-java-prereq}
 
-You need an Aiven for Apache Kafka service up and running with two
-topics, named `test-flink-input` and `test-flink-output`, already
-[created](https://docs.aiven.io/docs/products/kafka/howto/create-topic.html).
-Furthermore, for the example, you need to collect the following
-information about the Aiven for Apache Kafka service:
+Before you start, make sure you have the following:
 
--   `APACHE_KAFKA_HOST`: The hostname of the Apache Kafka service
--   `APACHE_KAFKA_PORT`: The port of the Apache Kafka service
-
-You need to have [Apache Maven™](https://maven.apache.org/install.html)
-installed to build the example.
+- An active **Aiven for Apache Kafka** service with two topics: `test-flink-input` and `test-flink-output`.
+  To create topics, see [Create an Apache Kafka topic](https://docs.aiven.io/docs/products/kafka/howto/create-topic.html).
+- Gather the following details about your Aiven for Apache Kafka service:
+   - `APACHE_KAFKA_HOST`: The hostname of your Apache Kafka service.
+   - `APACHE_KAFKA_PORT`: The port number of your Apache Kafka service.
+- [**Apache Maven™**](https://maven.apache.org/install.html) installed on your machine
+    build the example.
 
 ### Setup the truststore and keystore
 
 Create a
-[Java keystore and truststore](keystore-truststore) for the Aiven for Apache Kafka service. For the following
-example we assume:
+[Java keystore and truststore](keystore-truststore) for the Aiven for Apache Kafka service.
+For this example, the configuration is as follows:
 
--   The keystore is available at `KEYSTORE_PATH/client.keystore.p12`
--   The truststore is available at
-    `TRUSTSTORE_PATH/client.truststore.jks`
--   For simplicity, the same secret (password) is used for both the
-    keystore and the truststore, and is shown here as `KEY_TRUST_SECRET`
+- The keystore is available at `KEYSTORE_PATH/client.keystore.p12`
+- The truststore is available at
+  `TRUSTSTORE_PATH/client.truststore.jks`
+- For simplicity, use  the same secret (password) for both the
+  keystore and the truststore, referred to as `KEY_TRUST_SECRET`
 
 ## Use Apache Flink with Aiven for Apache Kafka
 
 The following example shows how to customise the `DataStreamJob`
 generated from the
-[Quickstart](https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/dev/configuration/overview/)
+[Quickstart](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/dev/configuration/overview/)
 to work with Aiven for Apache Kafka.
 
 :::note
@@ -68,14 +61,14 @@ repository](https://github.com/aiven/aiven-examples/tree/master/kafka/flink-capi
     mvn archetype:generate -DinteractiveMode=false  \
       -DarchetypeGroupId=org.apache.flink           \
       -DarchetypeArtifactId=flink-quickstart-java   \
-      -DarchetypeVersion=1.15.1                     \
+      -DarchetypeVersion=1.16.0                     \
       -DgroupId=io.aiven.example                    \
       -DartifactId=flink-capitalizer                \
       -Dpackage=io.aiven.example.flinkcapitalizer   \
       -Dversion=0.0.1-SNAPSHOT
     ```
 
-2.  Uncomment the Kafka connector in \`pom.xml\`:
+1.  Uncomment the Kafka connector in \`pom.xml\`:
 
     ```xml
     <dependency>
@@ -93,8 +86,8 @@ with the cluster for your processing.
 
 1.  Create a new class called
     `io.aiven.example.flinkcapitalizer.StringCapitalizer` which performs
-    a simple `MapFunction` transformation on incoming records with every
-    incoming string will be emitted as uppercase.
+    a simple `MapFunction` transformation on incoming records, emitting every incoming
+    string in uppercase.
 
     ```java
     package io.aiven.example.flinkcapitalizer;
@@ -108,7 +101,7 @@ with the cluster for your processing.
     }
     ```
 
-2.  Import the following classes in the `DataStreamJob`
+1.  Import the following classes in the `DataStreamJob`
 
     ```java
     import java.util.Properties;
@@ -121,8 +114,8 @@ with the cluster for your processing.
     import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
     ```
 
-3.  Modify the `main` method in `DataStreamJob` to read and write from
-    the Kafka topics, replacing the `APACHE_KAFKA_HOST`,
+1.  Modify the `main` method in `DataStreamJob` to read and write from
+    the Apache Kafka topics, replacing the `APACHE_KAFKA_HOST`,
     `APACHE_KAFKA_PORT`, `KEYSTORE_PATH`, `TRUSTSTORE_PATH` and
     `KEY_TRUST_SECRET` placeholders with the values from the
     [prerequisites](/docs/products/kafka/howto/flink-with-aiven-for-kafka#kafka-flink-java-prereq).
@@ -165,7 +158,7 @@ with the cluster for your processing.
     }
     ```
 
-4.  Tie the Kafka sources and sinks together with the
+1.  Tie the Apache Kafka sources and sinks together with the
     `StringCapitalizer` in a single processing pipeline.
 
     ```java
@@ -192,7 +185,7 @@ The above command should create a `jar` file named
 ### Run the applications
 
 If you have installed a [local cluster installation of Apache Flink
-1.15.1](https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/try-flink/local_installation/),
+1.16](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/try-flink/local_installation/),
 you can launch the job on your local machine. `$FLINK_HOME` is the Flink
 installation directory.
 
@@ -203,6 +196,6 @@ $FLINK_HOME/bin/flink run target/flink-capitalizer-0.0.1-SNAPSHOT.jar
 You can see that the job is running in the Flink web UI at
 `http://localhost:8081`.
 
-By following the article
-[Aiven for Apache Flink®](/docs/products/flink), you can send string events to the input topic and verify
-that the messages are forwarded to the output topic in upper case.
+By integrating [Aiven for Apache Flink®](/docs/products/flink) with
+Aiven for Apache Kafka®, you can process string events and transform
+them to uppercase before forwarding them to the output topic.

--- a/docs/products/kafka/howto/flink-with-aiven-for-kafka.md
+++ b/docs/products/kafka/howto/flink-with-aiven-for-kafka.md
@@ -27,7 +27,7 @@ Before you start, make sure you have the following:
    - `APACHE_KAFKA_HOST`: The hostname of your Apache Kafka service.
    - `APACHE_KAFKA_PORT`: The port number of your Apache Kafka service.
 - [**Apache Maven™**](https://maven.apache.org/install.html) installed on your machine
-    build the example.
+  build the example.
 
 ### Setup the truststore and keystore
 
@@ -84,7 +84,7 @@ In the generated code, `DataStreamJob` is the main entry point, and has
 already been configured with all of the context necessary to interact
 with the cluster for your processing.
 
-1.  Create a new class called
+1.  Create a class called
     `io.aiven.example.flinkcapitalizer.StringCapitalizer` which performs
     a `MapFunction` transformation on incoming records, emitting every incoming
     string in uppercase.

--- a/docs/products/kafka/howto/flink-with-aiven-for-kafka.md
+++ b/docs/products/kafka/howto/flink-with-aiven-for-kafka.md
@@ -86,7 +86,7 @@ with the cluster for your processing.
 
 1.  Create a new class called
     `io.aiven.example.flinkcapitalizer.StringCapitalizer` which performs
-    a simple `MapFunction` transformation on incoming records, emitting every incoming
+    a `MapFunction` transformation on incoming records, emitting every incoming
     string in uppercase.
 
     ```java

--- a/docs/products/kafka/howto/flink-with-aiven-for-kafka.md
+++ b/docs/products/kafka/howto/flink-with-aiven-for-kafka.md
@@ -45,7 +45,7 @@ For this example, the configuration is as follows:
 
 The following example shows how to customise the `DataStreamJob`
 generated from the
-[Quickstart](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/dev/configuration/overview/)
+[Quickstart](https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/dev/configuration/overview/)
 to work with Aiven for Apache Kafka.
 
 :::note
@@ -185,7 +185,7 @@ The above command should create a `jar` file named
 ### Run the applications
 
 If you have installed a [local cluster installation of Apache Flink
-1.16](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/try-flink/local_installation/),
+1.16](https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/try-flink/local_installation/),
 you can launch the job on your local machine. `$FLINK_HOME` is the Flink
 installation directory.
 


### PR DESCRIPTION
## Describe your changes

Updated links referring to Apache Flink® documentation from v1.15 to v1.16 and aligned content with the style guide and format.

[HH-1604](https://aiven.atlassian.net/browse/HH-1604)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.


[HH-1604]: https://aiven.atlassian.net/browse/HH-1604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ