### PR TITLE
update: Kafka TS remove feature flag content

### DIFF
--- a/docs/products/kafka/concepts/kafka-tiered-storage.md
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.md
@@ -31,7 +31,7 @@ Tiered storage offers multiple benefits, including:
     storage and computing are effectively decoupled, enabling them to
     scale independently. This flexibility ensures that while the storage
     capacity can expand almost infinitely with cloud solutions, compute
-    resources can also be adjusted based on demand, thus eliminating any
+    resources can also be adjusted based on demand, thereby eliminating any
     concerns about storage or processing limitations.
 -   **Cost efficiency:** By moving less frequently accessed data to a
     cost-effective storage tier, you can achieve significant financial

--- a/docs/products/kafka/howto/configure-topic-tiered-storage.md
+++ b/docs/products/kafka/howto/configure-topic-tiered-storage.md
@@ -25,8 +25,8 @@ step by step.
 
 1.  From the **Topics** page, select **Add topic**.
 
-1.  Enable advanced configurations by setting the **Do you want to
-    enable advanced configuration?** option to **Yes**.
+1.  Set the "Do you want to enable advanced configuration?" option to Yes to enable
+advanced configurations.
 
 1.  In the **Topic advanced configuration** drop-down, choose
     `remote_storage_enable`. This action will reveal the **Remote
@@ -83,7 +83,7 @@ step by step.
 
 For optimal performance and reduced risk of broker interruptions when
 using tiered storage, it is recommended to update the client-side
-parameter `fetch.max.wait.ms` from its default value of 500ms to 5000ms.
+parameter `fetch.max.wait.ms` from its default value of 500 ms to 5000 ms.
 
 ## Enable tiered storage for topics via Aiven CLI
 

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.md
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.md
@@ -4,10 +4,7 @@ sidebar_label: Enable tiered storage
 early: true
 ---
 
-Tiered storage significantly improves the storage efficiency of your
-Aiven for Apache Kafka® service. You can enable this feature for your
-service using either the [Aiven console](https://console.aiven.io/) or
-the [Aiven CLI](/docs/tools/cli).
+Tiered storage significantly improves the storage efficiency of your Aiven for Apache Kafka® service. You can enable this feature for your service using either the [Aiven console](https://console.aiven.io/) or the [Aiven CLI](/docs/tools/cli).
 
 ## Prerequisites
 
@@ -18,11 +15,6 @@ the [Aiven CLI](/docs/tools/cli).
     page](https://aiven.io/pricing?product=kafka) for a comprehensive
     list of supported plans and regions.
 -   Aiven CLI
--   The tiered storage for Aiven for Apache Kafka® is an **early availability**
-    feature and requires activation on your Aiven account.
-    Contact [our sales team](mailto:sales@aiven.io) to request activation. Once activated,
-    enable tiered storage from the [feature preview](/docs/platform/howto/feature-preview)
-    page in your user profile to start using it.
 
 ## Enable tiered storage via Aiven Console
 
@@ -31,18 +23,17 @@ Aiven Console.
 
 1. Log in to the [Aiven console](https://console.aiven.io/), and select
     your project.
-1. Either create a new Aiven for Apache Kafka service or select an
+1. Choose to either create a new Aiven for Apache Kafka service or select an
    existing one.
    -   For [a new service](/docs/platform/howto/create_new_service):
 
        1.  On the **Create Apache Kafka® service** page, scroll down to
            the **Tiered storage** section.
-       1.  Turn on the **Enable tiered storage** toggle to activate
-           tiered storage.
+       1.  Click **Enable tiered storage**.
        1.  In the **Service summary**, you can view the pricing for
            tiered storage.
    -   For an existing service:
-       1.  Go to the service's **Overview** page, select **Service
+       1.  Go to the service's **Overview** page, click **Service
            settings** from the sidebar.
        1.  In the Service plan section, click **Enable tiered storage**
            to activate it.
@@ -89,7 +80,7 @@ Additionally, you can configure the retention policies from the
 
 For optimal performance and reduced risk of broker interruptions when
 using tiered storage, it is recommended to update the client-side
-parameter `fetch.max.wait.ms` from its default value of 500ms to 5000ms.
+parameter `fetch.max.wait.ms` from its default value of 500 ms to 5000 ms.
 
 ## Enable tiered storage via Aiven CLI
 

--- a/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
+++ b/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
@@ -1,5 +1,6 @@
 ---
 title: Get started with tiered storage for Aiven for Apache Kafka®
+early: true
 ---
 
 Aiven for Apache Kafka®'s tiered storage optimizes resources by keeping
@@ -7,27 +8,15 @@ recent data---typically the most accessed---on faster local disks. As
 data becomes less active, it's transferred to more economical, slower
 storage, balancing performance with cost efficiency.
 
-:::important
-Aiven for Apache Kafka® tiered storage is an
-[early availability feature](/docs/platform/concepts/beta_services).
-
-To use this feature, contact [our sales team](mailto:sales@aiven.io) to activate tiered storage for your account.
-
-After activation, you must enable the feature from the
-[feature preview page](/docs/platform/howto/feature-preview) in your user profile to start using tiered storage.
-
-For further details, see [Enable tiered storage for Aiven for Apache Kafka](/docs/products/kafka/howto/enable-kafka-tiered-storage).
-:::
-
 For an in-depth understanding of tiered storage, how it works, and its
 benefits, see
 [Tiered storage in Aiven for Apache Kafka®](/docs/products/kafka/concepts/kafka-tiered-storage).
 
 ## Enable tiered storage for service
 
-To use tiered storage, you need to first
-[enable](/docs/products/kafka/howto/enable-kafka-tiered-storage) it for your Aiven for Apache Kafka service® service. This
-foundational step ensures that the necessary infrastructure is in place.
+To use tiered storage, [enable](/docs/products/kafka/howto/enable-kafka-tiered-storage)
+it for your Aiven for Apache Kafka service. This foundational step ensures that the
+necessary infrastructure is in place.
 
 :::note
 Tiered storage for Aiven for Apache Kafka® is supported starting from


### PR DESCRIPTION
## Describe your changes
Updated docs to remove feature flag required to enable tiered storage for Apache Kafka

[HH-3492](https://aiven.atlassian.net/browse/HH-3492)
## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
