### PR TITLE
add: Ext PG integration to Flink docs

### DIFF
--- a/docs/products/flink/howto/connect-pg.md
+++ b/docs/products/flink/howto/connect-pg.md
@@ -39,7 +39,7 @@ console:
 
 3.  In the **Create new version** screen, select **Add source tables**.
 
-4.  Select **Add new table** or select **Edit** if you want to edit an
+4.  Select **Add new table** or select **Edit** to edit an
     existing source table.
 
 5.  In the **Add new source table** or **Edit source table** screen,

--- a/docs/products/flink/howto/connect-pg.md
+++ b/docs/products/flink/howto/connect-pg.md
@@ -80,7 +80,7 @@ page](https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table
 The Aiven for PostgreSQL® service named `pg-demo` contains a table named
 `students` in the `public` schema with the following structure:
 
-``` 
+```
 CREATE TABLE students_tbl (
   student_id INT,
   student_name VARCHAR
@@ -88,7 +88,7 @@ CREATE TABLE students_tbl (
   'connector' = 'jdbc',
   'url' = 'jdbc:postgresql://',
   'table-name' = 'public.students'
-  )  
+  )
 ```
 
 The `url` will be substituted with the appropriate address during

--- a/docs/products/flink/howto/ext-pg-cdc-jdbc-connector.md
+++ b/docs/products/flink/howto/ext-pg-cdc-jdbc-connector.md
@@ -28,8 +28,8 @@ application table, using either CDC or JDBC:
    click **Create application**.
 
    :::note
-    If modifying an existing Flink application, create a new version of the application
-    for changes to source or sink tables.
+    If you are modifying an existing Aiven for Apache Flink application, create a new
+    version of the application for any changes to source or sink tables.
    :::
 
 1. Click **Create first version** to create the first version of your application.

--- a/docs/products/flink/howto/ext-pg-cdc-jdbc-connector.md
+++ b/docs/products/flink/howto/ext-pg-cdc-jdbc-connector.md
@@ -54,6 +54,7 @@ application table, using either CDC or JDBC:
         'username' = '<db_user>',
         'password' = '<db_password>',
         'decoding.plugin.name' = 'your_decoding_plugin'
+        'slot.name' = '<your_slot_name>'
       );
      ```
 
@@ -74,6 +75,8 @@ application table, using either CDC or JDBC:
        resides, which is set to `defaultdb` in the example.
      - `decoding.plugin.name`: The decoding plugin to be used by the
        CDC connector, which is set to `pgoutput` in the example.
+     - `slot.name`: The identifier for the replication slot, used to track and
+       stream database changes for CDC operations.
 
    - For a **JDBC connector**:
 

--- a/docs/products/flink/howto/ext-pg-cdc-jdbc-connector.md
+++ b/docs/products/flink/howto/ext-pg-cdc-jdbc-connector.md
@@ -53,7 +53,7 @@ application table, using either CDC or JDBC:
         'table-name' = '<your_table>',
         'username' = '<db_user>',
         'password' = '<db_password>',
-        'decoding.plugin.name' = 'your_decoding_plugin'
+        'decoding.plugin.name' = 'your_decoding_plugin',
         'slot.name' = '<your_slot_name>'
       );
      ```

--- a/docs/products/flink/howto/ext-pg-cdc-jdbc-connector.md
+++ b/docs/products/flink/howto/ext-pg-cdc-jdbc-connector.md
@@ -1,0 +1,111 @@
+---
+title: Create a PostgreSQL® CDC or JDBC connector-based Apache Flink®
+---
+
+Learn how to create a table in your Apache Flink® application to interact with an external PostgreSQL® database.
+
+You can choose between two methods:
+
+- **Change Data Capture (CDC)**: Process real-time changes from the PostgreSQL tables
+  using Debezium.
+- **JDBC**: Execute SQL queries directly on the PostgreSQL database.
+
+## Prerequisites
+
+- An active Aiven for Apache Flink service.
+- An external PostgreSQL database with access details.
+- [Integration](/docs/products/flink/howto/ext-pg-flink-integration) between
+  Aiven for Apache Flink and external PostgreSQL.
+
+## Configure external PostgreSQL connector
+
+Follow these steps to configure an external PostgreSQL connector in your Aiven for Apache Flink
+application table, using either CDC or JDBC:
+
+1. Go to the **Aiven for Apache Flink** service page and
+   click **Application** in the sidebar.
+1. Click **Create new application**, enter a name your application, and
+   click **Create application**.
+
+   :::note
+    If modifying an existing application, create a new version for source or s
+    ink table changes.
+   :::
+
+1. Click **Create first version** to create the first version of your application.
+1. Click **Add your first source table** to begin setting up your data source.
+1. In the **Add new source table** screen, select the *external PostgreSQL* as the
+   integrated service.
+1. In the **Table SQL**, enter the SQL statement for your chosen connector:
+
+   - For a **CDC connector**:
+
+     ```sql
+      CREATE TABLE external_pg_cdc_source (
+        id INT PRIMARY KEY,
+        data VARCHAR
+      ) WITH (
+        'connector' = 'cdc-postgres',
+        'hostname' = '<external-db-host>',
+        'port' = '5432',
+        'database-name' = '<your_database>',
+        'schema-name' = 'public',
+        'table-name' = '<your_table>',
+        'username' = '<db_user>',
+        'password' = '<db_password>',
+        'decoding.plugin.name' = 'your_decoding_plugin'
+      );
+     ```
+
+     Parameters:
+
+     - `connector`: The connector type to be used, which is  `cdc-postgres`.
+     - `hostname`: The hostname or address of the PostgreSQL database
+       server.
+     - `username`: The username to authenticate with the PostgreSQL
+       database.
+     - `password`: The password for the provided username.
+     - `schema-name`: The name of the schema where the source table is
+       located, which is set to `public` in the example.
+     - `table-name`: The name of the source table to be captured by the
+       CDC connector, which is set to `test-1` in the example.
+     - `port`: The port number of the PostgreSQL database server.
+     - `database-name`: The name of the database where the source table
+       resides, which is set to `defaultdb` in the example.
+     - `decoding.plugin.name`: The decoding plugin to be used by the
+       CDC connector, which is set to `pgoutput` in the example.
+
+   - For a **JDBC connector**:
+
+     ```sql
+      CREATE TABLE external_pg_jdbc_sink (
+         id INT PRIMARY KEY,
+         data VARCHAR
+      ) WITH (
+         'connector' = 'JDBC',
+         'url' = 'jdbc:postgresql://<external-db-host>:5432/<your_database>',
+         'table-name' = '<your_table>',
+         'username' = '<db_user>',
+         'password' = '<db_password>'
+      );
+     ```
+
+     Parameters:
+
+     - `connector`: The connector type to be used, which is `JDBC`.
+     - `url`: The external PostgreSQL connection URL should include the hostname, port,
+       and database name. Replace with your specific details.
+     - `table-name`: Specify the name of the table to interact with
+        within the chosen database.
+     - `username`: The username for your PostgreSQL database
+     - `password`: Enter the password associated with the provided username.
+
+1. Click **Next** to configure the sink table.
+1. Click **Add your first sink table** and specify the destination for your processed
+   data. For example, Aiven for Apache Kafka service.
+1. In the **Table SQL** section, enter the SQL creation statement for the sink table based
+   on where to send the data.
+1. After configuring both source and sink tables, click **Create deployment** to deploy
+   your application. Choose the desired version to deploy (default: Version 1) and select
+   **Deploy without a savepoint** (as there are no savepoints available for the first
+   application).

--- a/docs/products/flink/howto/ext-pg-cdc-jdbc-connector.md
+++ b/docs/products/flink/howto/ext-pg-cdc-jdbc-connector.md
@@ -24,12 +24,12 @@ application table, using either CDC or JDBC:
 
 1. Go to the **Aiven for Apache Flink** service page and
    click **Application** in the sidebar.
-1. Click **Create new application**, enter a name your application, and
+1. Click **Create new application**, enter a name for your application, and
    click **Create application**.
 
    :::note
-    If modifying an existing application, create a new version for source or s
-    ink table changes.
+    If modifying an existing Flink application, create a new version of the application
+    for changes to source or sink tables.
    :::
 
 1. Click **Create first version** to create the first version of your application.

--- a/docs/products/flink/howto/ext-pg-flink-integration.md
+++ b/docs/products/flink/howto/ext-pg-flink-integration.md
@@ -105,8 +105,9 @@ via the Aiven Console by following these steps:
 
 1. Log in to [Aiven Console](https://console.aiven.io/) and choose your project.
 1. [Create a new Aiven for Apache Flink](/docs/platform/howto/create_new_service)
-    service or select an existing service.
+   service or select an existing service.
 1. Configure an external PostgreSQL integration endpoint:
+
    1. Go to the **Projects > Integration endpoints**
    1. Click **External PostgreSQL** from the list, then click **Add new endpoint**.
    1. Enter the following details:

--- a/docs/products/flink/howto/ext-pg-flink-integration.md
+++ b/docs/products/flink/howto/ext-pg-flink-integration.md
@@ -125,14 +125,13 @@ via the Aiven Console by following these steps:
    1. Click **Create**.
 1. Create Integration:
    1. Return to the **Project** page and open your Aiven for Apache Flink service
-     from the list of services.
+      from the list of services.
    1. For first-time integration, click **Get Started** on the **Overview page**.
-     Otherwise, add a new integration in the **Data Flow** section by clicking **Plus (+)**.
+      Otherwise, add a new integration in the **Data Flow** section by clicking **Plus (+)**.
    1. On the **Data Service integrations screen**, go to the
-     **Create external integration endpoint** tab.
-
+      **Create external integration endpoint** tab.
    1. Select the checkbox next to **PostgreSQL**, and select the external PostgreSQL
-     endpoint from the list to integrate.
+      endpoint from the list to integrate.
    1. Click **Integrate**.
 
 After completing these steps, the integration is set up,

--- a/docs/products/flink/howto/ext-pg-flink-integration.md
+++ b/docs/products/flink/howto/ext-pg-flink-integration.md
@@ -91,12 +91,12 @@ Parameters:
 
 To create an Aiven for Apache Flink application, retrieve the `integration_id` for
 your Aiven for Apache Flink service from the
-[integration list](docs/tools/cli/service/integration)
+[integration list](/docs/tools/cli/service/integration#avn_service_integration_list)
 and use it to connect your application to an external PostgreSQL database as
 either a source or a sink.
 
 For information on how to create Aiven for Apache Flink applications, see
-[avn service flink create-application](/docs/tools/cli/service/flink#avn%20service%20flink%20create-application).
+[avn service flink create-application](/docs/products/flink/howto/create-flink-applications).
 
 ## Configure integration using Aiven Console
 

--- a/docs/products/flink/howto/ext-pg-flink-integration.md
+++ b/docs/products/flink/howto/ext-pg-flink-integration.md
@@ -91,7 +91,7 @@ Parameters:
 
 To create an Aiven for Apache Flink application, retrieve the `integration_id` for
 your Aiven for Apache Flink service from the
-[integration list](docs/tools/cli/service/integration#avn_service_integration_list)
+[integration list](docs/tools/cli/service/integration)
 and use it to connect your application to an external PostgreSQL database as
 either a source or a sink.
 

--- a/docs/products/flink/howto/ext-pg-flink-integration.md
+++ b/docs/products/flink/howto/ext-pg-flink-integration.md
@@ -9,8 +9,7 @@ Integrating Aiven for Apache Flink® with external PostgreSQL allows users to ex
 - Aiven for Apache Flink service
 - An external PostgreSQL database running and accessible. You will need the database's
   hostname, port, database name, user, and password.
-- If your external PostgreSQL database is set up with SSL encryption, make sure you have
-  the SSL certificate in PEM format to ensure a secure connection.
+- For SSL-encrypted databases, the SSL certificate in PEM format is required for a secure connection.
 
 ## Configure integration using CLI​
 
@@ -87,30 +86,28 @@ Parameters:
 - `--project <project-name>`: The name of your Aiven project.
 - `<flink-service-name>`: The name of your Aiven for Apache Flink service.
 
-To create Aiven for Apache Flink applications, you will need the
-integration ID of the Aiven for Apache Flink service. Obtain the
-`integration_id` from the integration list.
 
 ### Create Aiven for Apache Flink applications
 
-With the integration ID obtained, you're now ready to develop Aiven for Apache Flink
-applications that utilize the data from your external PostgreSQL database
-as either a source or a sink.
+To create an Aiven for Apache Flink application, retrieve the `integration_id` for
+your Aiven for Apache Flink service from the
+[integration list](docs/tools/cli/service/integration#avn_service_integration_list)
+and use it to connect your application to an external PostgreSQL database as
+either a source or a sink.
+
 For information on how to create Aiven for Apache Flink applications, see
 [avn service flink create-application](/docs/tools/cli/service/flink#avn%20service%20flink%20create-application).
 
 ## Configure integration using Aiven Console
 
-Integrating your Aiven for Apache Flink service with an external PostgreSQL
-database can be achieved through the Aiven Console by following these steps:
+Integrate your Aiven for Apache Flink service with an external PostgreSQL database
+via the Aiven Console by following these steps:
 
 1. Log in to [Aiven Console](https://console.aiven.io/) and choose your project.
-1. From the **Services page**, you can either
-   - Create a new [**Aiven for Apache Flink service](/docs/platform/howto/create_new_service)
-   - Select an existing service
-1. Configure an external PostgreSQL database integration endpoint:
-   - Go to the **Projects** screen where all services are listed.
-   - From the sidebar, click **Integration endpoints**.
+1. [Create a new Aiven for Apache Flink](/docs/platform/howto/create_new_service)
+    service or select an existing service.
+1. Configure an external PostgreSQL integration endpoint:
+   - Go to the **Projects > Integration endpoints**
    - Click **External PostgreSQL** from the list, then click **Add new endpoint**.
    - Enter the following details:
 
@@ -125,10 +122,18 @@ database can be achieved through the Aiven Console by following these steps:
        - **SSL Mode**: Choose `require`, `verify-ca`, or `verify-full`.
        - **SSL Root Certificate**: Upload the SSL root certificate.
    - Click **Create**.
-1. If integrating for the first time, on the **Overview page**, click **Get Started**.
-   Alternatively, add a new integration in the **Data Flow** section by clicking **Plus (+)**.
-1. On the **Data Service integrations screen**, go to the **Create external integration endpoint**
-   tab.
-1. Select the checkbox next to **PostgreSQL**, and select the external PostgreSQL
-   endpoint from the list to integrate.
-1. Click **Integrate**.
+1. Create Integration:
+   - Return to the **Project** page and open your Aiven for Apache Flink service
+     from the list of services.
+   - For first-time integration, click **Get Started** on the **Overview page**.
+     Otherwise, add a new integration in the **Data Flow** section by clicking **Plus (+)**.
+   - On the **Data Service integrations screen**, go to the
+     **Create external integration endpoint** tab.
+
+   - Select the checkbox next to **PostgreSQL**, and select the external PostgreSQL
+     endpoint from the list to integrate.
+   - Click **Integrate**.
+
+After completing these steps, the integration is set up,
+enabling you to start creating [Aiven for Apache Flink applications](/docs/products/flink/howto/create-flink-applications)
+that use the external PostgreSQL database as either a source or a sink.

--- a/docs/products/flink/howto/ext-pg-flink-integration.md
+++ b/docs/products/flink/howto/ext-pg-flink-integration.md
@@ -107,32 +107,32 @@ via the Aiven Console by following these steps:
 1. [Create a new Aiven for Apache Flink](/docs/platform/howto/create_new_service)
     service or select an existing service.
 1. Configure an external PostgreSQL integration endpoint:
-   - Go to the **Projects > Integration endpoints**
-   - Click **External PostgreSQL** from the list, then click **Add new endpoint**.
-   - Enter the following details:
+   1. Go to the **Projects > Integration endpoints**
+   1. Click **External PostgreSQL** from the list, then click **Add new endpoint**.
+   1. Enter the following details:
 
-     - **Endpoint name**: Name your endpoint.
-     - **Host**: PostgreSQL server's hostname or IP.
-     - **Port**: PostgreSQL server's port.
-     - **Database name**: Name of the database to connect.
-     - **Username**: Username for database access.
-     - **Password**: Password for the username.
-     - For SSL-encrypted databases:
+      - **Endpoint name**: Name your endpoint.
+      - **Host**: PostgreSQL server's hostname or IP.
+      - **Port**: PostgreSQL server's port.
+      - **Database name**: Name of the database to connect.
+      - **Username**: Username for database access.
+      - **Password**: Password for the username.
+      - For SSL-encrypted databases:
 
-       - **SSL Mode**: Choose `require`, `verify-ca`, or `verify-full`.
-       - **SSL Root Certificate**: Upload the SSL root certificate.
-   - Click **Create**.
+        - **SSL Mode**: Choose `require`, `verify-ca`, or `verify-full`.
+        - **SSL Root Certificate**: Upload the SSL root certificate.
+   1. Click **Create**.
 1. Create Integration:
-   - Return to the **Project** page and open your Aiven for Apache Flink service
+   1. Return to the **Project** page and open your Aiven for Apache Flink service
      from the list of services.
-   - For first-time integration, click **Get Started** on the **Overview page**.
+   1. For first-time integration, click **Get Started** on the **Overview page**.
      Otherwise, add a new integration in the **Data Flow** section by clicking **Plus (+)**.
-   - On the **Data Service integrations screen**, go to the
+   1. On the **Data Service integrations screen**, go to the
      **Create external integration endpoint** tab.
 
-   - Select the checkbox next to **PostgreSQL**, and select the external PostgreSQL
+   1. Select the checkbox next to **PostgreSQL**, and select the external PostgreSQL
      endpoint from the list to integrate.
-   - Click **Integrate**.
+   1. Click **Integrate**.
 
 After completing these steps, the integration is set up,
 enabling you to start creating [Aiven for Apache Flink applications](/docs/products/flink/howto/create-flink-applications)

--- a/docs/products/flink/howto/ext-pg-flink-integration.md
+++ b/docs/products/flink/howto/ext-pg-flink-integration.md
@@ -1,0 +1,134 @@
+---
+title: Integrate Aiven for Apache Flink® with external PostgreSQL
+---
+
+Integrating Aiven for Apache Flink® with external PostgreSQL allows users to extend their real-time data streaming and processing capabilities by connecting to an external PostgreSQL database as a source or sink.
+
+## Prerequisites
+
+- Aiven for Apache Flink service
+- An external PostgreSQL database running and accessible. You will need the database's
+  hostname, port, database name, user, and password.
+- If your external PostgreSQL database is set up with SSL encryption, make sure you have
+  the SSL certificate in PEM format to ensure a secure connection.
+
+## Configure integration using CLI​
+
+To configure integration using Aiven CLI, follow these steps:
+
+### Create an Aiven for Apache Flink service
+
+To use an existing Aiven for Apache Flink service and retrieve its details,
+execute the following command:
+
+```bash
+avn service create -t flink -p <project-name> --cloud <cloud-name> <flink-service-name>
+```
+
+Alternatively, if can create a new Aiven for Apache Flink service,
+you can use the following command:
+
+```bash
+avn service create -t flink -p <project-name> --cloud <cloud-name> <flink-service-name>
+```
+
+Parameters:
+
+- `-t flink`: The type of service to create, which is Aiven for Apache
+  Flink.
+- `-p <project-name>`: The name of the Aiven project where the service
+  should be created.
+- `cloud <cloud-name>`: The name of the cloud provider on which the
+  service should be created.
+- `<flink-service-name>`: The name of the new Aiven for Apache Flink
+  service to be created. This name must be unique within the specified
+  project.
+
+### Gather external PostgreSQL details
+
+Ensure you have all the necessary details of your external PostgreSQL database,
+including any SSL certificates, if applicable.
+
+### Create an external PostgreSQL endpoint
+
+Create an integration endpoint for your external PostgreSQL database using the
+[avn service integration-endpoint-create](/docs/tools/cli/service/integration#avn_service_integration_endpoint_create)
+command with the required parameters.
+
+```bash
+avn service integration-endpoint-create --project <project-name> \
+    --endpoint-name <external-pg-endpoint-name> \
+    --endpoint-type external_postgresql \
+    --user-config-json '{"host":"<postgres_host>", \
+    "port":"<postgres_port>", "db_name":"<postgres_db>", \
+    "user":"<postgres_user>", "password":"<postgres_password>", \
+    "ssl":"<ssl_mode>", "sslrootcert":"<path_to_ssl_cert>"}'
+```
+
+Parameters:
+
+- `--project <project-name>`: The name of your Aiven project.
+- `--endpoint-name <external-pg-endpoint-name>`: The name for the new endpoint.
+- `--endpoint-type external_postgresql`: The type of endpoint to create.
+- `--user-config-json`: Configuration details of your PostgreSQL database in JSON format.
+
+### Verify integration with service
+
+After creating the integration between Aiven for Apache Flink and your external
+PostgreSQL database, verify that the
+integration has been created successfully, and create applications that
+use the integration.
+
+```bash
+  avn service integration-list --project <project-name> <flink-service-name>
+```
+
+Parameters:
+- `--project <project-name>`: The name of your Aiven project.
+- `<flink-service-name>`: The name of your Aiven for Apache Flink service.
+
+To create Aiven for Apache Flink applications, you will need the
+integration ID of the Aiven for Apache Flink service. Obtain the
+`integration_id` from the integration list.
+
+### Create Aiven for Apache Flink applications
+
+With the integration ID obtained, you're now ready to develop Aiven for Apache Flink
+applications that utilize the data from your external PostgreSQL database
+as either a source or a sink.
+For information on how to create Aiven for Apache Flink applications, see
+[avn service flink create-application](/docs/tools/cli/service/flink#avn%20service%20flink%20create-application).
+
+## Configure integration using Aiven Console
+
+Integrating your Aiven for Apache Flink service with an external PostgreSQL
+database can be achieved through the Aiven Console by following these steps:
+
+1. Log in to [Aiven Console](https://console.aiven.io/) and choose your project.
+1. From the **Services page**, you can either
+   - Create a new [**Aiven for Apache Flink service](/docs/platform/howto/create_new_service)
+   - Select an existing service
+1. Configure an external PostgreSQL database integration endpoint:
+   - Go to the **Projects** screen where all services are listed.
+   - From the sidebar, click **Integration endpoints**.
+   - Click **External PostgreSQL** from the list, then click **Add new endpoint**.
+   - Enter the following details:
+
+     - **Endpoint name**: Name your endpoint.
+     - **Host**: PostgreSQL server's hostname or IP.
+     - **Port**: PostgreSQL server's port.
+     - **Database name**: Name of the database to connect.
+     - **Username**: Username for database access.
+     - **Password**: Password for the username.
+     - For SSL-encrypted databases:
+
+       - **SSL Mode**: Choose `require`, `verify-ca`, or `verify-full`.
+       - **SSL Root Certificate**: Upload the SSL root certificate.
+   - Click **Create**.
+1. If integrating for the first time, on the **Overview page**, click **Get Started**.
+   Alternatively, add a new integration in the **Data Flow** section by clicking **Plus (+)**.
+1. On the **Data Service integrations screen**, go to the **Create external integration endpoint**
+   tab.
+1. Select the checkbox next to **PostgreSQL**, and select the external PostgreSQL
+   endpoint from the list to integrate.
+1. Click **Integrate**.

--- a/docs/products/flink/howto/pg-cdc-connector.md
+++ b/docs/products/flink/howto/pg-cdc-connector.md
@@ -2,6 +2,8 @@
 title: Create a PostgreSQL® CDC connector-based Apache Flink®
 ---
 
+Learn how to create a PostgreSQL CDC connector-based Apache Flink® table.
+
 Change Data Capture (CDC) is a technique that enables the tracking and
 capturing of changes made to data within a PostgreSQL® database. By
 identifying and capturing changes at the granular row level, CDC enables
@@ -14,9 +16,6 @@ power of the PostgreSQL CDC Connector to stream and process real-time
 data changes from PostgreSQL databases. Integrated with the Debezium
 engine, the CDC connector captures changes at the granular level of each
 table within an event stream.
-
-This article provides you with information on how to create a PostgreSQL
-CDC connector-based Apache Flink® table.
 
 ## Prerequisites
 
@@ -46,14 +45,14 @@ source PostgreSQL database:
     authentication.
 -   `Schema name`: The schema name where the source table is located
     within the database.
--   `Table name`: The name of the source table from which you want to
+-   `Table name`: The name of the source table from which to
     capture data changes.
 -   `Decoding plugin name`: The decoding plugin name to use for
     capturing the changes. For PostgreSQL CDC, set it as `pgoutput`.
 
 :::important
 To create a PostgreSQL CDC source connector in Aiven for Apache Flink
-with Aiven for PostgreSQL using the pgoutput plugin, you need to have
+with Aiven for PostgreSQL using the `pgoutput` plugin, you must have the
 superuser privileges.
 
 For more information, see [Troubleshooting](#Troubleshooting).
@@ -89,7 +88,7 @@ Console](https://console.aiven.io/):
 
     For example:
 
-    ``` 
+    ```
     CREATE TABLE test_table (
         column1 INT,
         column2 VARCHAR
@@ -132,7 +131,7 @@ Console](https://console.aiven.io/):
     connecting user must have enough privileges to create it.
     :::
 
-7.  Select **Next** to add the sink table, and then select **Add your
+7.  Select **Next** to add the sink table, and select **Add your
     first sink table**. Select *Aiven for Apache Kafka®* as the
     integrated service from the drop-down list.
 
@@ -159,14 +158,14 @@ using the `pgoutput` plugin, follow these steps to resolve the issue:
 
 1.  Install the `aiven-extras` extension by executing the SQL command:
 
-    ``` 
+    ```
     CREATE EXTENSION aiven_extras CASCADE;
     ```
 
 2.  Create a publication for all tables in the source database: Execute
     the SQL command:
 
-    ``` 
+    ```
     SELECT * FROM aiven_extras.pg_create_publication_for_all_tables(
        'dbz_publication',
        'INSERT,UPDATE,DELETE'

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -985,6 +985,7 @@ const sidebars: SidebarsConfig = {
                     'products/flink/howto/create-integration',
                     'products/flink/howto/ext-kafka-flink-integration',
                     'products/flink/howto/connect-bigquery',
+                    'products/flink/howto/ext-pg-flink-integration',
                   ],
                 },
                 {

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1022,6 +1022,7 @@ const sidebars: SidebarsConfig = {
                         'products/flink/howto/connect-pg',
                         'products/flink/howto/connect-opensearch',
                         'products/flink/howto/pg-cdc-connector',
+                        'products/flink/howto/ext-pg-cdc-jdbc-connector',
                         'products/flink/howto/slack-connector',
                         'products/flink/howto/datagen-connector',
                       ],


### PR DESCRIPTION
## Describe your changes

Add content for ext PG integration with Aiven for Apache Flink
New topics: 
 - Integrate Aiven for Apache Flink® with external PostgreSQL
 - Create a PostgreSQL® CDC or JDBC connector-based Apache Flink®

Vale fixes to other related articles. 

[HH-3427](https://aiven.atlassian.net/browse/HH-3427)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.


[HH-3427]: https://aiven.atlassian.net/browse/HH-3427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ