### PR TITLE
update: add import ref link

### DIFF
--- a/docs/products/dragonfly/reference/advanced-params.md
+++ b/docs/products/dragonfly/reference/advanced-params.md
@@ -4,6 +4,6 @@ title: Advanced parameters for Aiven for Dragonfly®
 
 Summary of all configuration options available for Aiven for Dragonfly® service:
 
-import Reference from '@site/static/includes/config-dragonfly';
+import Reference from '@site/static/includes/config-dragonfly.md';
 
 <Reference />

--- a/docs/products/dragonfly/reference/advanced-params.md
+++ b/docs/products/dragonfly/reference/advanced-params.md
@@ -2,5 +2,8 @@
 title: Advanced parameters for Aiven for Dragonfly®
 ---
 
-Below you can find a summary of every configuration option available for
-Aiven for Dragonfly® service:
+Summary of all configuration options available for Aiven for Dragonfly® service:
+
+import Reference from '@site/static/includes/config-flink.md';
+
+<Reference />

--- a/docs/products/dragonfly/reference/advanced-params.md
+++ b/docs/products/dragonfly/reference/advanced-params.md
@@ -4,6 +4,6 @@ title: Advanced parameters for Aiven for Dragonfly®
 
 Summary of all configuration options available for Aiven for Dragonfly® service:
 
-import Reference from '@site/static/includes/config-flink.md';
+import Reference from '@site/static/includes/config-dragonfly';
 
 <Reference />


### PR DESCRIPTION
## Describe your changes

Updated the advanced-params.md file to include the import reference link, which was missing. 

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
