### PR TITLE
fix: formatting of MySQL commands

### DIFF
--- a/docs/products/mysql/howto/migrate-from-external-mysql.md
+++ b/docs/products/mysql/howto/migrate-from-external-mysql.md
@@ -57,9 +57,11 @@ You can use the following variables in the code samples provided:
     (you can substitute `%` in the below command with the IP address of
     the Aiven for MySQL database, if already existing):
 
-        create user 'SRC_USERNAME'@'%' identified by 'SRC_PASSWORD';
-        grant replication slave on *.* TO 'SRC_USERNAME'@'%';
-        grant select, process, event on *.* to 'SRC_USERNAME'@'%'
+    ```
+    create user 'SRC_USERNAME'@'%' identified by 'SRC_PASSWORD';
+    grant replication slave on *.* TO 'SRC_USERNAME'@'%';
+    grant select, process, event on *.* to 'SRC_USERNAME'@'%'
+    ```
 
 2.  If you don't have an Aiven for MySQL database yet, create it via
     [Aiven Console](/docs/products/mysql/get-started) or the dedicated


### PR DESCRIPTION
## Describe your changes

Fix formatting of MySQL commands creating a user in source.

Note: untested, because simple formatting change, and leaving this to the people merging.

Link of the page where the bad formatting can be found:
https://aiven.io/docs/products/mysql/howto/migrate-from-external-mysql

Screenshot of the bad formatting:
<img width="854" alt="Screenshot 2024-03-27 at 14 38 25" src="https://github.com/aiven/aiven-docs/assets/8471576/e1fe9a61-dcaa-4857-b9ab-d7ce1a5439d5">

## Checklist

- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
