### PR TITLE
update: added info to turn off certificate expiration notification

### DIFF
--- a/docs/products/kafka/howto/renew-ssl-certs.md
+++ b/docs/products/kafka/howto/renew-ssl-certs.md
@@ -1,75 +1,55 @@
 ---
 title: Renew and acknowledge service user SSL certificates
 ---
-
-In every Aiven for Apache Kafka® service, when the existing service user
-SSL certificate is close to expiration (approximately 3 months before
-the expiration date), a new certificate is automatically generated,
-including the renewal of the private key.
+Aiven for Apache Kafka® automatically generates a new SSL certificate for service users about three months before the existing certificate's expiration date. This new certificate includes a renewed private key.
 
 ## SSL certificate renewal schedule
 
-SSL certificates for Aiven for Apache Kafka® services remain valid for
-820 days (approximately 2 years and 3 months). To ensure uninterrupted
-service and enhance security, these certificates are renewed every 2
-years as a proactive measure.
-
-Each renewal process involves regenerating both the SSL certificate and
-its private key, reinforcing security and preserving integrity.
-Notifications about certificate renewals are sent to project admins,
-operators, and technical contacts associated with the service.
-
-The existing certificate stays operational until its expiration date,
-allowing for a seamless transition to the new certificate.
+SSL certificates for Aiven for Apache Kafka® services are valid for 820 days,
+approximately two years, and three months. This renewal involves regenerating the
+SSL certificate and its private key to enhance security. Renewal notifications are
+sent to project administrators, operators, and technical contacts. The current
+certificate stays valid until expiration to ensure a smooth transition.
 
 ## Download the new SSL certificates
 
-The renewed SSL certificate is immediately available for download in the
-[Aiven Console](https://console.aiven.io/),
-[API](https://api.aiven.io/doc/), and
-[Aiven CLI](/docs/tools/cli) after the
-notification.
+Once renewed, you can download the new SSL certificate from the [Aiven Console](https://console.aiven.io/),
+[Aiven API](https://api.aiven.io/doc/), or [Aiven CLI](/docs/tools/cli).
 
-When accessing the [Aiven Console](https://console.aiven.io/) service
-page for the Aiven for Apache Kafka service with expiring certificates,
-you will be notified with the following message:
+If your Aiven for Apache Kafka service has a certificate about
+to expire, the [Aiven Console](https://console.aiven.io/) will display a notification on
+the service page, prompting you to download the new certificate.
 
 ![Apache Kafka service user SSL certificate expiring message](/images/products/kafka/ssl-cert-renewal.png)
 
 To download the new certificate,
 
-1.  Access the [Aiven Console](https://console.aiven.io/)
-2.  Select the Aiven for Apache Kafka service for which you want to
-    download the new certificate.
-3.  Click the **Users** from the sidebar.
-4.  Select the required user and click **Show access key** and **Show
-    access cert** to download the new certificate.
+1. Access the [Aiven Console](https://console.aiven.io/).
+1. Select your Aiven for Apache Kafka service.
+1. Click **Users** in the sidebar.
+1. Select the required user and click **Show access key** and **Show access cert** to
+   download the new certificate.
 
 ![Apache Kafka service user SSL certificate and access key download](/images/products/kafka/new-ssl-cert-download.png)
 
 :::note
-You can download the renewed SSL certificate and key using the
-[dedicated Aiven CLI command](/docs/tools/cli/service/user#avn_service_user_creds_download) `avn service user-creds-download`
+You can also use the Aiven CLI command [`avn service user-creds-download`](/docs/tools/cli/service/user#avn_service_user_creds_download) to download the renewed SSL certificate and key.
 :::
 
 ## Acknowledge new SSL certificate usage
 
-To stop receiving notifications about certificate expiration, you must
-confirm that the new certificate is in use.
+Confirm that the new certificate is in use to stop receiving notifications about
+certificate expiration.
 
-To acknowledge the new SSL certificate with the [Aiven
-Console](https://console.aiven.io/):
+To acknowledge the new SSL certificate with the [Aiven Console](https://console.aiven.io/):
 
 -   Select `...` next to the certificate.
 -   Select `Acknowledge certificate`.
 
 :::note
-You can acknowledge the renewed SSL certificate using the
-[dedicated Aiven CLI command](/docs/tools/cli/service/user#avn_service_user_creds_acknowledge) `avn service user-creds-acknowledge`
-
-The same can be achieved with the Aiven API, using the \"Modify service
-user credentials\"
-[endpoint](https://api.aiven.io/doc/#operation/ServiceUserCredentialsModify):
+You can also use the Aiven CLI command [`avn service user-creds-acknowledge`](/docs/tools/cli/service/user#avn_service_user_creds_acknowledge) to acknowledge the user credentials.
+Similarly, the Aiven API provides a way to acknowledge the new SSL certificate
+through the [Modify service user credentials endpoint](https://api.aiven.io/doc/#operation/ServiceUserCredentialsModify):
 
 ```
 curl --request PUT \
@@ -79,3 +59,19 @@ curl --request PUT \
     --data '{"operation": "acknowledge-renewal"}'
 ```
 :::
+
+## Turn off certificate expiration notifications for SASL services
+
+When using SASL authentication in Aiven for Kafka services, you might still receive
+certificate expiration notifications, even if your service doesn't use certificates for
+authorization. Aiven updates certificates across all services to maintain security
+standards, which includes services that combine TLS encryption with SASL authentication.
+
+To turn off these notifications:
+
+1. Access the [Aiven Console](https://console.aiven.io/).
+1. Select your Aiven for Apache Kafka service.
+1. Click **Service settings** from the sidebar.
+1. Scroll to **Advanced configurations**, and click **Configure**.
+1. Click **Add configuration options**.
+1. Search for `kafka_authentication_methods.certificate` and disable it.


### PR DESCRIPTION
## Describe your changes

Added steps for users to disable SSL certificate expiration notifications, especially for services with SASL authentication and no certificate-based authentication.

[DOC-876](https://aiven.atlassian.net/browse/DOC-876)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.


[DOC-876]: https://aiven.atlassian.net/browse/DOC-876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ