### PR TITLE
add: Content for storage overview page

### DIFF
--- a/docs/products/metrics/howto.md
+++ b/docs/products/metrics/howto.md
@@ -1,0 +1,9 @@
+---
+title: HowTo
+---
+
+Get started with Aiven for Metrics in your own projects.
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/products/metrics/howto/storage-overview-page.md
+++ b/docs/products/metrics/howto/storage-overview-page.md
@@ -1,0 +1,41 @@
+---
+title: Storage overview for Aiven for Metrics
+sidebar_label: Storage overview page
+---
+Get complete insights into your storage usage with Aiven for Metrics. This overview page offers data that helps you better manage and understand your object storage usage and associated costs. Access important metrics such as current and forecasted billing, object storage consumption, and settings for data retention and storage threshold alerts.
+
+## Access the Storage Overview page
+
+1. Log into the [Aiven console](https://console.aiven.io/), select your project, and
+   select your Aiven for Metrics service.
+1. Click **Storage** in the sidebar.
+
+
+## Key storage insights
+
+- **Current billing expenses**: Shows the current cost incurred for the storage used.
+- **Forecasted monthly cost**: Provides an estimate of the expected cost for the
+  upcoming month based on usage.
+- **Object storage used**: Indicates the amount of storage used in MiB.
+- **Retention rule**: Displays the current data retention setting, which by default is
+  set to **Keep data forever**.
+
+
+## Manage storage settings
+
+Adjust your data retention settings and set up alerts to keep your storage in check.
+
+### Edit retention rules
+
+1. In **Storage overview**, click **Actions menu (...)** > **Edit retention rule**.
+1. Select **Keep data forever** or **Keep data for (days)** and enter the number of days.
+1. Click **Save**.
+
+### Set or edit storage alert threshold
+
+1. In **Storage overview**, click **Actions menu (...)** > **Set storage alert threshold**
+   or **Edit storage alert threshold**.
+1. To set a new threshold, click **Set storage alert threshold**. To change an existing
+   one, click **Edit storage alert threshold**.
+1. Set your threshold in GiB.
+1. Click **Save**.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1497,7 +1497,15 @@ const sidebars: SidebarsConfig = {
                 // Add the paths for your two topics here
               ],
             },
-            // Since there are no other contents yet, other sections are not included
+            {
+              type: 'category',
+              label: 'How to',
+              link: {
+                type: 'doc',
+                id: 'products/metrics/howto',
+              },
+              items: ['products/metrics/howto/storage-overview-page'],
+            },
           ],
         },
         {


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
