### PR TITLE
update: structure of orgs and access docs

### DIFF
--- a/docs/platform/concepts/orgs-and-units.md
+++ b/docs/platform/concepts/orgs-and-units.md
@@ -1,0 +1,5 @@
+---
+title: Organizations and units
+---
+
+You automatically have an organization when you sign up for Aiven and helps you [centrally manage billing and access](/docs/platform/concepts/projects_accounts_access#organizations-and-organizational-units). Add organizational units in your organization to group related projects together.

--- a/docs/platform/concepts/projects.md
+++ b/docs/platform/concepts/projects.md
@@ -1,0 +1,5 @@
+---
+title: Projects
+---
+
+Use projects to [create collections](/docs/platform/howto/manage-project) of related services and [manage access](/docs/platform/reference/project-member-privileges) to its services.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -34,12 +34,34 @@ const sidebars: SidebarsConfig = {
         id: 'platform/concepts/projects_accounts_access',
       },
       items: [
-        'tools/aiven-console/howto/create-accounts',
-        'platform/howto/manage-organizations',
-        'platform/howto/manage-project',
-        'platform/howto/add-project-members',
-        'platform/reference/project-member-privileges',
-        'platform/howto/manage-unassigned-projects',
+        {
+          type: 'category',
+          label: 'Organizations and units',
+          link: {
+            type: 'doc',
+            id: 'platform/concepts/orgs-and-units',
+          },
+          items: [
+            'tools/aiven-console/howto/create-accounts',
+            'platform/howto/manage-organizations',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Projects',
+          link: {
+            type: 'doc',
+            id: 'platform/concepts/projects',
+          },
+          items: [
+            'platform/howto/manage-project',
+            'platform/howto/add-project-members',
+            'platform/reference/project-member-privileges',
+            'platform/howto/technical-emails',
+            'platform/howto/manage-unassigned-projects',
+            'platform/howto/reactivate-suspended-project',
+          ],
+        },
         'platform/concepts/carbon-footprint',
       ],
     },
@@ -160,8 +182,6 @@ const sidebars: SidebarsConfig = {
             'tools/aiven-console/howto/create-manage-teams',
           ],
         },
-        'platform/howto/technical-emails',
-        'platform/howto/reactivate-suspended-project',
       ],
     },
     {


### PR DESCRIPTION
## Describe your changes

Move project related docs to orgs and projects section and add another level to that section to group these docs.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](../styleguide.md).
- [X] My links start with `/docs/`.
