### PR TITLE
Fix readme link to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- vale off -->
 
-The Aiven docs repo generates the content located at [https://www.aiven.io/docs](www.aiven.io/docs).
+The Aiven docs repo generates the content located at [www.aiven.io/docs](https://www.aiven.io/docs).
 We use [Docusaurus](https://docusaurus.io/) to build the docs.
 
 ## 🤲 Contributing

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- vale off -->
 
-The Aiven docs repo generates the content located at [www.aiven.io/docs](www.aiven.io/docs).
+The Aiven docs repo generates the content located at [https://www.aiven.io/docs](https://www.aiven.io/docs).
 We use [Docusaurus](https://docusaurus.io/) to build the docs.
 
 ## 🤲 Contributing

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- vale off -->
 
-The Aiven docs repo generates the content located at [https://www.aiven.io/docs](https://www.aiven.io/docs).
+The Aiven docs repo generates the content located at [https://www.aiven.io/docs](www.aiven.io/docs).
 We use [Docusaurus](https://docusaurus.io/) to build the docs.
 
 ## 🤲 Contributing


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ x] The first paragraph of the page is on one line.
- [ x] The other lines have a line break at 90 characters.
- [ x] I checked the output.
- [ x] I applied the [style guide](../styleguide.md).
- [ x] My links start with `/docs/`.
