### PR TITLE
fix: link to AWS Marketplace

### DIFF
--- a/docs/marketplace-setup.md
+++ b/docs/marketplace-setup.md
@@ -12,7 +12,7 @@ Aiven makes its services available through the various Marketplaces and you can 
 <Tabs groupId="group1">
 <TabItem value="AWS" label="AWS Marketplace" default>
 
-1. Go to [Aiven Managed Database on AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-vylwtm6t2c7fk).
+1. Go to [Aiven Managed Database on AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-fx7pxfq5uaxha.
 
 1. Click **View purchase options**.
 

--- a/docs/marketplace-setup.md
+++ b/docs/marketplace-setup.md
@@ -12,7 +12,7 @@ Aiven makes its services available through the various Marketplaces and you can 
 <Tabs groupId="group1">
 <TabItem value="AWS" label="AWS Marketplace" default>
 
-1. Go to [Aiven Managed Database on AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-fx7pxfq5uaxha.
+1. Go to [Aiven Managed Database on AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-fx7pxfq5uaxha).
 
 1. Click **View purchase options**.
 


### PR DESCRIPTION
## Describe your changes

Fix link to Aiven on AWS Marketplace.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](../styleguide.md).
- [X] My links start with `/docs/`.
