### PR TITLE
Remove region specificity from free tier docs

### DIFF
--- a/docs/platform/concepts/free-plan.md
+++ b/docs/platform/concepts/free-plan.md
@@ -34,11 +34,9 @@ Free plans include:
 -   Backups
 -   Integrations between different Aiven services including free, paid,
     and trial services
--   DigitalOcean hosting in a limited number of regions:
-    -   EMEA: do-ams (Amsterdam), do-ldn (London), do-fra (Frankfurt)
-    -   Americas: do-nyc (New York), do-sfo (San Francisco), do-tor
-        (Toronto)
-    -   APAC: do-blr (Bangalore)
+-   DigitalOcean hosting in a limited number of regions across EMEA,
+    AMER, and APAC. (Full list available during the
+    [signup](https://console.aiven.io/signup) process.)
 
 There are some limitations of the free plan services:
 


### PR DESCRIPTION
It was raised at https://aiven.io/community/forum/t/free-plan-postgresql-getting-moved-to-digital-ocean-docs-say-aws/751/3?u=nikkee that our list of free tier servers is no longer accurate. This strikes me as the type of information that's at risk of falling out of date periodically, so one suggestion is to remove the specificity.

## Describe your changes

## Checklist

- [X] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [X] My links start with `/docs/`.
