### PR TITLE
fix: remove inaccurate list of free tier regions

### DIFF
--- a/docs/platform/concepts/free-plan.md
+++ b/docs/platform/concepts/free-plan.md
@@ -34,9 +34,8 @@ Free plans include:
 -   Backups
 -   Integrations between different Aiven services including free, paid,
     and trial services
--   DigitalOcean hosting in a limited number of regions across EMEA,
-    AMER, and APAC. (Full list available during the
-    [signup](https://console.aiven.io/signup) process.)
+-   [DigitalOcean hosting](https://aiven.io/docs/platform/reference/list_of_clouds#digitalocean)
+    in a limited number of regions
 
 There are some limitations of the free plan services:
 

--- a/docs/platform/concepts/free-plan.md
+++ b/docs/platform/concepts/free-plan.md
@@ -34,11 +34,9 @@ Free plans include:
 -   Backups
 -   Integrations between different Aiven services including free, paid,
     and trial services
--   DigitalOcean hosting in a limited number of regions:
-    -   EMEA: do-ams (Amsterdam), do-ldn (London), do-fra (Frankfurt)
-    -   Americas: do-nyc (New York), do-sfo (San Francisco), do-tor
-        (Toronto)
-    -   APAC: do-blr (Bangalore)
+-   DigitalOcean hosting in a limited number of regions across EMEA,
+    AMER, and APAC. (Full list available during the
+    [signup](https://console.aiven.io/signup) process.)
 
 There are some limitations of the free plan services:
 


### PR DESCRIPTION
## Describe your changes
It was pointed out at https://aiven.io/community/forum/t/free-plan-postgresql-getting-moved-to-digital-ocean-docs-say-aws/751/3?u=aiven_angie that our free tier docs currently list incorrect region availability. This list as it stands requires manual updates and it's hard for us to remember to do so.

Proposed resolution: Instead, link to the DigitalOcean section of https://aiven.io/docs/platform/reference/list_of_clouds so that the canonical list is the point of reference.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [X] I applied the [style guide](../styleguide.md).
- [X] My links start with `/docs/`.
