### PR TITLE
add: Custom dictionary files for OS

### DIFF
--- a/docs/products/opensearch/howto/custom-dictionary-files.md
+++ b/docs/products/opensearch/howto/custom-dictionary-files.md
@@ -1,0 +1,259 @@
+---
+title: Custom dictionay files
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
+
+Custom dictionary files are user-defined files that enhance query analysis and improve search relevance in OpenSearch. By adding domain-specific vocabulary and rules, these files refine search results to be more accurate and relevant.
+
+Custom dictionary files are categorized into three types:
+
+- **Stopwords**: Exclude common words like "the" and "is" to refine search results.
+- **Synonyms**: Equate similar terms, such as "car" and "automobile," to improve
+  query matching.
+- **WordNet**: Provide semantic relationships between words, such as synonyms and antonyms.
+
+:::note
+Ensure your custom dictionary files are in plain text (UTF-8 encoded) format.
+:::
+
+
+
+## Upload files
+
+Upload new custom dictionary files to your OpenSearch service.
+
+<Tabs groupId="upload-method">
+<TabItem value="Console" label="Console" default>
+
+1. Log in to the [Aiven Console](https://console.aiven.io), select your project,
+   and select your Aiven for OpenSearch service.
+1. Click **Indexes** on the sidebar.
+1. Click **Upload file** in the **Custom dictionary files** section.
+1. In the **Upload a custom dictionary file** modal:
+   - Select **File type** (Stopwords, Synonyms, WordNet).
+   - Enter a **File name**.
+   - Choose the file from your system and click **Upload**.
+
+</TabItem>
+<TabItem value="CLI" label="CLI">
+
+Run:
+
+```bash
+  avn service custom-file upload --project <project> \
+  --file_type <stopwords|synonyms|wordnet> \
+  --file_path <file_path> \
+  --file_name <file_name> <service_name>
+```
+
+Parameters:
+
+- `<project>`: Your Aiven project name.
+- `<stopwords|synonyms|wordnet>`: The type of dictionary file to upload.
+- `<file_path>`: Path to the local file on your system.
+- `<file_name>`: The name of the file to appear in Aiven for OpenSearch.
+- `<service_name>`: Name of your OpenSearch service.
+
+</TabItem>
+</Tabs>
+
+## List files
+
+List all custom dictionary files associated with your OpenSearch service.
+
+<Tabs groupId="list-method">
+<TabItem value="Console" label="Console" default>
+
+In the **Aiven Console**, all uploaded custom dictionary files are listed in the
+**Custom dictionary files** section, showing the file path, type, size, and
+latest upload timestamp.
+
+</TabItem>
+<TabItem value="CLI" label="CLI">
+
+Run:
+```bash
+  avn service custom-file list --project <project> <service_name>
+```
+Parameters:
+
+- `<project>`: Your Aiven project name.
+- `<service_name>`: Name of your OpenSearch service.
+
+</TabItem>
+</Tabs>
+
+## Replace files
+
+Once you upload a custom dictionary file, you can only replace it, not delete it.
+To update an existing custom dictionary file, replace it with a new file containing
+the updated words.
+
+<Tabs groupId="replace-method">
+<TabItem value="Console" label="Console" default>
+
+1. Log in to the [Aiven Console](https://console.aiven.io), select your project,
+   and select your Aiven for OpenSearch service.
+1. Click **Indexes** on the sidebar.
+1. In the **Custom dictionary files** section, locate the desired file.
+1. Click <ConsoleLabel name="actions"/> > <ConsoleLabel name="replace file"/>.
+1. Choose the new file from your system and click **Upload**.
+
+</TabItem>
+<TabItem value="CLI" label="CLI">
+
+Run:
+
+```bash
+  avn service custom-file update --project <project> \
+    --file_path <file_path> \
+    --file_id <file_id> <service_name>
+```
+
+Parameters:
+
+- `<project>`: Your Aiven project name.
+- `<file_path>`: Path to the local file on your system.
+- `<file_id>`: ID of the file to replace. Obtain this ID using the
+  [List](#list-files) command.
+- `<service_name>`: Name of your OpenSearch service.
+
+</TabItem>
+</Tabs>
+
+## Download files
+
+Download a custom dictionary file to your local system.
+
+<Tabs groupId="download-method">
+<TabItem value="Console" label="Console" default>
+
+1. Log in to the [Aiven Console](https://console.aiven.io), select your project,
+   and select your Aiven for OpenSearch service.
+1. Click **Indexes** on the sidebar.
+1. In the **Custom dictionary files** section, locate the desired file.
+1. Click <ConsoleLabel name="actions"/> > <ConsoleLabel name="download"/>.
+1. Choose you location and click **Save**.
+
+
+</TabItem>
+<TabItem value="CLI" label="CLI">
+Run:
+
+```bash
+  avn service custom-file get --project <project> \
+  --file_id <file_id> \
+  --target_filepath <file_path> \
+  --stdout_write <service_name>
+```
+
+Parameters:
+
+- `<project>`: Your Aiven project name.
+- `<file_id>`: ID of the file to replace to download. Obtain this ID using the
+  [List](#list-files) command.
+- `<file_path>`: Path where the file should be saved locally.
+- `<service_name>`: Name of your OpenSearch service.
+
+</TabItem>
+</Tabs>
+
+## Limitations
+
+- Files cannot be deleted. They can only be replaced.
+- The file location is fixed and cannot be customized.
+- If you move to a different cloud or project, files will be copied or moved accordingly.
+- For OpenSearch Cross-Cluster Replication (CCR), files must be uploaded to
+  both services manually.
+- Use alphanumeric characters and underscores only for file names.
+
+
+## Example: How to use custom dictionary files with indexes
+
+After uploading a custom dictionary file, you can use it in your index settings by
+specifying custom filters or analyzers. This example demonstrates how to create an
+index that uses a custom stopwords file.
+
+### Create a stopwords file
+
+Create a file named `demo_stopwords.txt` with your stopwords.
+
+```plaintext
+cat <<EOF > demo_stopwords.txt
+a
+fox
+jumps
+the
+EOF
+```
+
+### Upload the stopwords file
+
+[Upload](#upload-files) this file using the Aiven Console or CLI.
+
+### Create an index that uses the stopwords file
+
+Create an index using the stopwords file via the Aiven Console or CLI.
+
+<Tabs groupId="create-index-method">
+<TabItem value="Console" label="Console" default>
+
+1. Log in to the [Aiven Console](https://console.aiven.io), select your project,
+   and select your Aiven for OpenSearch service.
+1. Click **Indexes** from the sidebar.
+1. In the **Index retention patterns** section, click **Add pattern**.
+1. Enter the pattern to use and the maximum index count for the pattern.
+1. Click **Create**.
+
+</TabItem>
+<TabItem value="CLI" label="CLI">
+
+Replace `<service_url>` with your service's URL and run the following command to
+create the index:
+
+```curl
+  curl -X PUT -H "Content-Type: application/json" -d'{
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "default": {
+            "tokenizer": "whitespace",
+            "filter": ["custom_stop_words_filter"]
+          }
+        },
+        "filter": {
+          "custom_stop_words_filter": {
+            "type": "stop",
+            "ignore_case": true,
+            "stopwords_path": "custom/stopwords/nofox"
+          }
+        }
+      }
+    }
+}' `<service_url>/demo-index?pretty`
+
+```
+
+</TabItem>
+</Tabs>
+
+### Verify the stopwords filter
+
+Use the `_analyze ` API to verify that the stopwords filter is working.
+Replace `<service_url>` with your service's URL.
+
+```bash
+  curl -H 'Content-Type: application/json' -d'{
+    "text": "a quick brown fox jumps over the lazy dog"
+  } ' <service_url>/demo-index/_analyze?pretty
+```
+
+Expected output tokens: "quick," "brown," "over," "lazy," and "dog."
+
+
+## Related pages
+
+- [OpenSearch text analysis](https://opensearch.org/docs/2.13/analyzers/)

--- a/docs/products/opensearch/howto/custom-dictionary-files.md
+++ b/docs/products/opensearch/howto/custom-dictionary-files.md
@@ -1,5 +1,6 @@
 ---
 title: Custom dictionay files
+enterprise: true
 ---
 
 import Tabs from '@theme/Tabs';
@@ -163,6 +164,7 @@ Parameters:
 
 ## Limitations
 
+- This feature requires Aiven Enterprise.
 - Files cannot be deleted. They can only be replaced.
 - The file location is fixed and cannot be customized.
 - If you move to a different cloud or project, files will be copied or moved accordingly.

--- a/docs/products/opensearch/howto/set_index_retention_patterns.md
+++ b/docs/products/opensearch/howto/set_index_retention_patterns.md
@@ -23,7 +23,7 @@ To define index retention policies for your OpenSearch indices:
 </TabItem>
 <TabItem value="API" label="API">
 
-Alternatively, you can use our [API](https://api.aiven.io/doc/) with a request similar
+Alternatively, you can use the [API](https://api.aiven.io/doc/) with a request similar
 to the following:
 
 ```bash

--- a/docs/products/opensearch/howto/set_index_retention_patterns.md
+++ b/docs/products/opensearch/howto/set_index_retention_patterns.md
@@ -2,29 +2,53 @@
 title: Set index retention patterns
 ---
 
-This article describes how to configure the maximum number of indices to
-keep in your Aiven for OpenSearch® instance. For more information on
-OpenSearch® indices and shards, see
-[this article](/docs/products/opensearch/concepts/indices).
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-To create cleanup patterns for OpenSearch indices:
 
-1.  Log in to the [Aiven web console](https://console.aiven.io) and
-    select your service.
+Learn to set index retention patterns and manage maximum indices in your Aiven for OpenSearch® instance.
 
-2.  Select **Indexes** from the left sidebar.
+To define index retention policies for your OpenSearch indices:
 
-    The **Indexes** section lists the patterns that are currently in
-    use.
+<Tabs groupId="retention-method">
+<TabItem value="Console" label="Console" default>
 
-3.  Select **Add pattern**.
+1. Log in to the [Aiven Console](https://console.aiven.io), select your project,
+   and select your Aiven for OpenSearch service.
+1. Click **Indexes** on the sidebar.
+   The **Indexes** section lists the patterns that are currently in use.
+1. Click **Add pattern**.
+1. Enter the pattern to use and the maximum index count for the pattern.
+1. Click **Create**.
 
-4.  Enter the pattern to use and the maximum index count
-    for the pattern, then select **Create**.
+</TabItem>
+<TabItem value="API" label="API">
 
-Alternatively, you can use our [API](https://api.aiven.io/doc/) with a
-request similar to the following:
+Alternatively, you can use our [API](https://api.aiven.io/doc/) with a request similar to the following:
+
+```bash
+ curl -X PUT --data '{
+  "user_config": {
+    "index_patterns": [
+      {"pattern": "logs*", "max_index_count": 2},
+      {"pattern": "test.?", "max_index_count": 3}
+    ]
+  }
+}' \
+  --header "content-type: application/json" \
+  --header "authorization: aivenv1 <YOUR TOKEN HERE>" \
+  https://api.aiven.io/v1beta/project/<project>/service/<service_name>
 
 ```
-curl -X PUT --data '{"user_config":{"index_patterns": [{"pattern": "logs*", "max_index_count": 2},{"pattern":"test.?", "max_index_count": 3}]}' header "content-type: application-json" --header "authorization: aivenv1 <YOUR TOKEN HERE>" https://api.aiven.io/v1beta/project/<project>/service/<service_name>
-```
+
+Parameters:
+
+- `<project>`: Your Aiven project name.
+- `<service_name>`: Name of your Aiven for OpenSearch service.
+
+</TabItem>
+</Tabs>
+
+## Related pages
+
+- [Indices in Aiven for OpenSearch](/docs/products/opensearch/concepts/indices)

--- a/docs/products/opensearch/howto/set_index_retention_patterns.md
+++ b/docs/products/opensearch/howto/set_index_retention_patterns.md
@@ -5,7 +5,6 @@ title: Set index retention patterns
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 Learn to set index retention patterns and manage maximum indices in your Aiven for OpenSearch® instance.
 
 To define index retention policies for your OpenSearch indices:
@@ -24,7 +23,8 @@ To define index retention policies for your OpenSearch indices:
 </TabItem>
 <TabItem value="API" label="API">
 
-Alternatively, you can use our [API](https://api.aiven.io/doc/) with a request similar to the following:
+Alternatively, you can use our [API](https://api.aiven.io/doc/) with a request similar
+to the following:
 
 ```bash
  curl -X PUT --data '{

--- a/docs/products/opensearch/howto/set_index_retention_patterns.md
+++ b/docs/products/opensearch/howto/set_index_retention_patterns.md
@@ -1,5 +1,5 @@
 ---
-title: Set index retention patterns
+title: Index retention patterns
 ---
 
 import Tabs from '@theme/Tabs';
@@ -7,6 +7,7 @@ import TabItem from '@theme/TabItem';
 
 Learn to set index retention patterns and manage maximum indices in your Aiven for OpenSearch® instance.
 
+## Set index retention patterns
 To define index retention policies for your OpenSearch indices:
 
 <Tabs groupId="retention-method">
@@ -48,6 +49,7 @@ Parameters:
 
 </TabItem>
 </Tabs>
+
 
 ## Related pages
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1817,6 +1817,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'products/opensearch/howto/restore_opensearch_backup',
                     'products/opensearch/howto/set_index_retention_patterns',
+                    'products/opensearch/howto/custom-dictionary-files',
                     'products/opensearch/howto/opensearch-alerting-api',
                     'products/opensearch/howto/handle-low-disk-space',
                     'products/opensearch/howto/resolve-shards-too-large',

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -220,6 +220,12 @@ export default function ConsoleLabel({name}): ReactElement {
           <ConsoleIconWrapper icon={ConsoleIcons.download} /> <b>Download</b>
         </>
       );
+    case 'replacefile':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.refresh} /> <b>Replace file</b>
+        </>
+      );
     default:
       return (
         <span style={{padding: 2, backgroundColor: 'red', color: '#ffffff'}}>


### PR DESCRIPTION
## Describe your changes
OS Custom dictionary upload features allow customers to upload certain text files and run queries against it. 
[DOC-854](https://aiven.atlassian.net/browse/DOC-854)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.


[DOC-854]: https://aiven.atlassian.net/browse/DOC-854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ