### PR TITLE
fix: managed users introduction

### DIFF
--- a/docs/platform/concepts/managed-users.md
+++ b/docs/platform/concepts/managed-users.md
@@ -4,7 +4,7 @@ title: Managed users
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-The managed users feature lets you centrally manage your organization's users, including editing their profiles, resetting passwords, and [setting authentication policies](/docs/platform/howto/set-authentication-policies).
+The managed users feature lets you centrally manage your organization's users, including editing their profiles and resetting passwords.
 
 A managed user cannot create new organizations
 unless they are a [super admin](/docs/platform/howto/make-super-admin) of the organization.


### PR DESCRIPTION
## Describe your changes

Fix the introduction to the managed users doc as authentication policies can be set for all org users, not just managed users.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](../styleguide.md).
- [X] My links start with `/docs/`.
