### PR TITLE
fix: icons for users, app users, and groups

### DIFF
--- a/docs/platform/howto/create_new_service_user.md
+++ b/docs/platform/howto/create_new_service_user.md
@@ -23,17 +23,12 @@ To increase the maximum number of users allowed for a service,
 
 1.  Log in to [Aiven Console](https://console.aiven.io/).
 1.  On the **Services** page, select your service.
-1.  From the sidebar, click <ConsoleLabel name="users"/>.
-1.  Click **Add service user**:
-
-    1.  Enter a name for your service user.
-
-        If a password is required, a new random password is
-        generated automatically. This can be modified later.
-
-    1.  Set up all the other configuration options, such as
-        authentication, roles, or replication, and
-        click **Add service user**.
+1.  From the sidebar, click <ConsoleLabel name="serviceusers"/>.
+1.  Click **Add service user** or **Create user**.
+1.  Enter a name for your service user.
+1.  Set up all the other configuration options. If a password is required,
+    a random password is generated automatically. You can modify it later.
+1.  Click **Add service user**.
 <!-- vale off -->
 ## Related pages
 

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -47,6 +47,13 @@ export default function ConsoleLabel({name}): ReactElement {
           <b>Metrics</b>
         </>
       );
+    case 'serviceusers':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.people} />{' '}
+          <b>Users</b>
+        </>
+      );
     case 'services':
       return (
         <>
@@ -135,6 +142,13 @@ export default function ConsoleLabel({name}): ReactElement {
           <ConsoleIconWrapper icon={ConsoleIcons.user} /> <b>Users</b>
         </>
       );
+    case 'viewuserprofile':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.user} />{' '}
+          <b>View profile</b>
+        </>
+      );
     case 'groups':
       return (
         <>
@@ -208,7 +222,7 @@ export default function ConsoleLabel({name}): ReactElement {
           <b>Application users</b>
         </>
       );
-    case 'viewprofile':
+    case 'viewappuserprofile':
       return (
         <>
           <ConsoleIconWrapper icon={ConsoleIcons.appUsers} />{' '}

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -132,7 +132,13 @@ export default function ConsoleLabel({name}): ReactElement {
     case 'users':
       return (
         <>
-          <ConsoleIconWrapper icon={ConsoleIcons.people} /> <b>Users</b>
+          <ConsoleIconWrapper icon={ConsoleIcons.user} /> <b>Users</b>
+        </>
+      );
+    case 'groups':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.people} /> <b>Groups</b>
         </>
       );
     case 'billing':
@@ -198,7 +204,8 @@ export default function ConsoleLabel({name}): ReactElement {
     case 'applicationusers':
       return (
         <>
-          <ConsoleIconWrapper icon={ConsoleIcons.appUsers} /> <b>Users</b>
+          <ConsoleIconWrapper icon={ConsoleIcons.appUsers} />{' '}
+          <b>Application users</b>
         </>
       );
     case 'viewprofile':


### PR DESCRIPTION
## Describe your changes

* Fixed the users icon
* Fixed the copy for the application users icon
* Added Groups

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
