### PR TITLE
fix: remove extra comment in supported ClickHouse IO formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 .env.test.local
 .env.production.local
 
+# JetBrains IDEs
+.idea
+
 # Yarn
 !.yarn/patches
 !.yarn/plugins

--- a/docs/products/clickhouse/reference/supported-input-output-formats.md
+++ b/docs/products/clickhouse/reference/supported-input-output-formats.md
@@ -5,8 +5,6 @@ title: Formats for ClickHouse®-Kafka® data exchange
 When connecting ClickHouse® to Kafka® using Aiven integrations, data
 exchange is possible with the following formats only:
 
-Here's the modified HTML with backticks enclosed in `<code>` and asterisks enclosed in `<strong>`:
-
 | Format name                   | Notes                                                                                                                      |
 | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | **Avro**                      | Binary Avro format with embedded schema. Libraries and documentation: [https://avro.apache.org/](https://avro.apache.org/) |


### PR DESCRIPTION
## Describe your changes

The comment must have slipped in by mistake and shouldn't be in the article.
Also ignore some IDE files for contributors.

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
