### PR TITLE
update: billing permissions

### DIFF
--- a/docs/platform/concepts/hourly-billing-model.md
+++ b/docs/platform/concepts/hourly-billing-model.md
@@ -2,14 +2,12 @@
 title: Billing
 ---
 
-In the **Billing** section of the [Aiven
-Console](https://console.aiven.io), you can manage your
-[billing groups](/docs/platform/concepts/billing-groups),
-[payment cards](/docs/platform/howto/manage-payment-card), and view and download your invoices.
+In the **Billing** section of the [Aiven Console](https://console.aiven.io), you can manage your [billing groups](/docs/platform/concepts/billing-groups), [payment cards](/docs/platform/howto/manage-payment-card), and view and download your invoices.
 
-:::info
-You must be a [super admin](/docs/platform/howto/make-super-admin) to access this feature.
-:::
+To access the **Billing** section of the Aiven Console for an organization,
+you have to be a [super admin](/docs/platform/howto/make-super-admin).
+Other users have read-only access to some billing information like billing group
+details and invoices using the API.
 
 ## Service charges
 
@@ -26,19 +24,24 @@ While network traffic is not charged separately, your application cloud
 service provider may charge you for the network traffic going to or from
 their services.
 
-Use of PrivateLink and additional storage will incur additional costs on
+Use of PrivateLink and additional storage incurs additional costs on
 top of the hourly service usage rate.
 :::
 
 The minimum hourly charge unit is one hour. For example, when you launch
-an Aiven service and terminate it after 40 minutes, you will be charged
+an Aiven service and terminate it after 40 minutes, you are charged
 for one full hour. Likewise, if you terminate a service after 40.5
-hours, you will be charged for 41 hours.
+hours, you are charged for 41 hours.
 
 [Terminating or pausing a service](/docs/platform/concepts/service-power-cycle) stops
 the accumulation of new charges immediately.
-However, the minimum hourly charge unit still applies prior to terminating or pausing
+However, the minimum hourly charge unit still applies before terminating or pausing
 a service.
 
 Migrating a service to another cloud region or to a different cloud provider does not
 incur any additional costs.
+
+## Related pages
+
+- [Billing groups](/docs/platform/concepts/billing-groups)
+- [Payment methods](/docs/platform/howto/list-billing)

--- a/docs/platform/howto/billing-assign-projects.md
+++ b/docs/platform/howto/billing-assign-projects.md
@@ -5,10 +5,11 @@ title: Assign projects to billing groups
 You can assign multiple projects to a billing group to [use the same payment card and consolidate the costs](/docs/platform/concepts/billing-groups).
 
 Each project can only be assigned to one billing group. If a project is already assigned
-to a billing group and you assign it to another, it will be removed from the first group.
+to a billing group and you assign it to another, it's removed from the first group.
 
 :::info
-You must be a [super admin](/docs/platform/howto/make-super-admin) to access this feature.
+You must be a [super admin](/docs/platform/howto/make-super-admin) to access this
+feature in the Aiven Console.
 :::
 
 To assign projects to a billing group:

--- a/docs/platform/howto/change-billing-contact.md
+++ b/docs/platform/howto/change-billing-contact.md
@@ -1,6 +1,0 @@
----
-title: Change billing contacts
----
-
-To change the billing contact to a different email address,
-[update your billing information](/docs/platform/howto/use-billing-groups) in the billing group.

--- a/docs/platform/howto/create-billing-groups.md
+++ b/docs/platform/howto/create-billing-groups.md
@@ -5,23 +5,23 @@ title: Create billing groups
 With [billing groups](/docs/platform/concepts/billing-groups) you can set up billing profiles to be used across all the projects in an organization. A consolidated [invoice](/docs/platform/howto/use-billing-groups) is created for each billing group.
 
 :::info
-You must be a [super admin](/docs/platform/howto/make-super-admin) to access this feature.
+You must be a [super admin](/docs/platform/howto/make-super-admin) to access this
+feature in the Aiven Console.
 :::
 
 ## Create a billing group
 
-1.  In the organization to add a billing group to, click
-    **Billing**.
-2.  Click **Create billing group**.
-3.  Enter a name for the billing group and click **Continue**.
-4.  Enter the billing details. You can also copy these details from
+1.  In the organization, click **Billing**.
+1.  Click **Create billing group**.
+1.  Enter a name for the billing group and click **Continue**.
+1.  Enter the billing details. You can also copy these details from
     another billing group by selecting it from the list. Click
     **Continue**.
-5.  Select the projects to add to this billing group. You
+1.  Select the projects to add to this billing group. You
     can also skip this and add projects later. Click **Continue**.
-6.  Check the information in the **Summary** step. To make changes to
+1.  Check the information in the **Summary** step. To make changes to
     any section, click **Edit**.
-7.  When you have confirmed everything is correct, click **Create**.
+1.  When you have confirmed everything is correct, click **Create**.
 
 ## Related pages
 

--- a/docs/platform/howto/list-billing.md
+++ b/docs/platform/howto/list-billing.md
@@ -1,6 +1,5 @@
 ---
-title: Billing and payments
+title: Payment methods
 ---
 
-Browse through instructions for common Aiven platform tasks related to
-billing.
+You can add payment methods to your organization that you use across your different [billing groups](/docs/platform/concepts/billing-groups) to pay for your Aiven services.

--- a/docs/platform/howto/update-tax-status.md
+++ b/docs/platform/howto/update-tax-status.md
@@ -5,18 +5,18 @@ title: Update your tax status
 You can add your VAT ID in the billing information in the [Aiven Console](https://console.aiven.io).
 
 :::info
-You must be a [super admin](/docs/platform/howto/make-super-admin) to access this feature.
+You must be a [super admin](/docs/platform/howto/make-super-admin) to access this
+feature in the Aiven Console.
 :::
 
 1.  Click **Billing**.
-2.  Click **Billing groups**.
-3.  Select the billing group to update.
-4.  Click **Billing information**.
-5.  In the **Billing details** section, click **Edit**.
-6.  Enter your **VAT ID** and click **Save**.
+1.  Click **Billing groups**.
+1.  Select the billing group to update.
+1.  Click **Billing information**.
+1.  In the **Billing details** section, click **Edit**.
+1.  Enter your **VAT ID** and click **Save**.
 
-You can change also the billing address by clicking **Edit** in the
-**Company details** section. Once the billing country has been updated,
-it will be used in all future invoices. Billing estimates are updated
-approximately once an hour, so it may take up to an hour for the new tax
-status to become visible on the invoice estimates.
+You can also change the billing address by clicking **Edit** in the
+**Company details** section. Once the billing country is updated, it's used in all
+future invoices. Billing estimates are updated approximately once an hour, so it can
+take up to an hour for the new tax status to be visible on the invoice estimates.

--- a/docs/platform/howto/use-billing-groups.md
+++ b/docs/platform/howto/use-billing-groups.md
@@ -7,7 +7,8 @@ import ConsoleLabel from "@site/src/components/ConsoleIcons"
 To view and update your billing groups in the [Aiven Console](https://console.aiven.io/) go to the organization and click **Billing**.
 
 :::info
-You must be a [super admin](/docs/platform/howto/make-super-admin) to access this feature.
+You must be a [super admin](/docs/platform/howto/make-super-admin) to access this
+feature in the Aiven Console.
 :::
 
 ## Rename billing groups
@@ -49,11 +50,8 @@ will unassign it from that billing group.
 ## Delete billing groups
 
 1.  Select the name of the billing group to delete.
-1.  On the **Projects** tab, confirm that no projects are assigned to
-    this billing group. If there are projects listed, move them to a
-    different billing group.
-1.  Click the three dots next to the current accumulated monthly bill
+1.  On the **Projects** tab, confirm that the billing group has no projects.
+    If there are projects listed, move them to a different billing group.
+1.  Click <ConsoleLabel name="actions"/> next to the current accumulated monthly bill
     amount.
-1.  Select **Delete** and **Confirm**.
-
-You are taken back to the Billing page.
+1.  Click **Delete** and **Confirm**.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -99,7 +99,6 @@ const sidebars: SidebarsConfig = {
             'platform/howto/create-billing-groups',
             'platform/howto/use-billing-groups',
             'platform/howto/billing-assign-projects',
-            'platform/howto/change-billing-contact',
           ],
         },
         'platform/howto/payment-issues-plan-upgrades',

--- a/static/_redirects
+++ b/static/_redirects
@@ -61,3 +61,4 @@
 /tools/terraform/reference/troubleshooting             https://aiven.io/docs/tools/terraform
 /tools/terraform/reference/troubleshooting/private-access-error https://aiven.io/docs/tools/terraform
 /tools/cli/ticket                                      https://aiven.io/docs/platform/howto/support
+/platform/howto/change-billing-contact.md              https://aiven.io/docs/platform/howto/use-billing-groups


### PR DESCRIPTION
## Describe your changes

This changes the super admin notice to be clear
that the sections cannot be accessed in the Console and also adds details on the billing main page
about the differences in Console and API access to some billing information.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](../styleguide.md).
- [X] My links start with `/docs/`.
