### PR TITLE
update: removed ® trademark from Caching across docs

### DIFF
--- a/.github/vale/styles/Aiven/First_Caching_is_registered copy.yml
+++ b/.github/vale/styles/Aiven/First_Caching_is_registered copy.yml
@@ -1,8 +1,0 @@
-extends: conditional
-message: "At least one '%s' must be marked as ®*"
-level: error
-scope: text
-ignorecase: false
-
-first: '\b(Caching)(?!®)'
-second: '(Caching)(?:®)'

--- a/docs/platform/concepts/free-plan.md
+++ b/docs/platform/concepts/free-plan.md
@@ -3,9 +3,9 @@ title: Free plans
 ---
 
 The free plan is available for Aiven for PostgreSQL®, Aiven for MySQL,
-and Aiven for Caching® services. You don't need a credit card to sign
+and Aiven for Caching services. You don't need a credit card to sign
 up and you can create one free service for each type. This means you can
-create one free PostgreSQL, one free MySQL, and one free Caching® service.
+create one free PostgreSQL, one free MySQL, and one free Caching service.
 
 To try a different service, you may want to consider a
 30-day

--- a/docs/platform/concepts/maintenance-window.md
+++ b/docs/platform/concepts/maintenance-window.md
@@ -23,7 +23,7 @@ Aiven service upgrades are performed in rolling forward style, which
 means that new service nodes are first created alongside with the older
 nodes one at a time, after which the old nodes are retired.
 
-For **MySQL®**, **PostgreSQL®** and **Caching®**, the maintenance
+For **MySQL®**, **PostgreSQL®** and **Caching**, the maintenance
 window usually lasts around several seconds. The downtime comes from old
 master stopping itself in a controlled manner and new master executing
 promotion sequence after this. Once the promotion is complete the old

--- a/docs/platform/concepts/service-forking.md
+++ b/docs/platform/concepts/service-forking.md
@@ -33,7 +33,7 @@ You can fork the following Aiven services:
 
 -   PostgreSQL®
 -   MySQL
--   Caching®
+-   Caching
 -   Apache Cassandra® (Limitation: you cannot fork to a lower amount of
     nodes)
 -   Elasticsearch

--- a/docs/platform/concepts/service_backups.md
+++ b/docs/platform/concepts/service_backups.md
@@ -57,7 +57,7 @@ backups with the appropriate tooling:
     `pgdump`
 -   [MySQL®](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html):
     `mysqldump`
--   [Caching®](https://redis.io/docs/connect/cli/#remote-backups-of-rdb-files):
+-   [Caching](https://redis.io/docs/connect/cli/#remote-backups-of-rdb-files):
     `redis-cli`
 -   [Cassandra®](https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlshCopy.html)
     `cqlsh`
@@ -115,7 +115,7 @@ data.
       <td>Single day backup</td>
     </tr>
     <tr>
-      <td>Aiven for Caching®</td>
+      <td>Aiven for Caching</td>
       <td>Single backup only for disaster recovery</td>
       <td>Backup every 12 hours up to 1 day</td>
       <td>Backup every 12 hours up to 3 days</td>
@@ -268,9 +268,9 @@ point-in-time recovery (PITR) feature is currently not available.
 To be notified once the PITR feature is available for Cassandra, contact the Aiven support.
 :::
 
-### Aiven for Caching®
+### Aiven for Caching
 
-Aiven for Caching® backups are taken every 12 hours.
+Aiven for Caching backups are taken every 12 hours.
 
 For persistence, Aiven supports Redis Database Backup (RDB).
 
@@ -288,7 +288,7 @@ You can control the persistence feature using `redis_persistence` under
 
 :::note
 AOF persistence is currently not supported by Aiven for the managed
-Aiven for Caching® service.
+Aiven for Caching service.
 :::
 
 ### Aiven for ClickHouse®

--- a/docs/platform/howto/integrations/prometheus-metrics.md
+++ b/docs/platform/howto/integrations/prometheus-metrics.md
@@ -190,7 +190,7 @@ your service.
    sure to include the replica DNS names in the list. If you have
    `<PROMETHEUS_SERVICE_URI>` as `public-example.aivencloud.com`, then you
    will need to add `public-replica-example.aivencloud.com`. This applies
-   to PostgreSQL®, MySQL®, Apache Kafka®, and Caching® services.
+   to PostgreSQL®, MySQL®, Apache Kafka®, and Caching services.
    :::
 
 ### View full list of metrics

--- a/docs/platform/howto/migrate-services-cloud-region.md
+++ b/docs/platform/howto/migrate-services-cloud-region.md
@@ -9,7 +9,7 @@ does not affect your service until the service has been rebuilt at the
 new region. The migration includes the DNS update for the named service
 to point to the new region. Most of the services have usually no service
 interruption expected. However, for services like PostgreSQL®, MySQL®,
-and Caching®, it may cause a short interruption (5 to 10 seconds) in
+and Caching, it may cause a short interruption (5 to 10 seconds) in
 service while the DNS changes are propagated.
 
 The short interruption does not include potential

--- a/docs/platform/howto/migrate-services-vpc.md
+++ b/docs/platform/howto/migrate-services-vpc.md
@@ -154,4 +154,4 @@ the process. Always equip your client applications with failure and
 retry logic to adapt to changes in servers and IP addresses. While this
 is typically straightforward for clustered services like Apache Kafka®
 and OpenSearch®, additional configurations might be necessary for
-services like PostgreSQL® and Caching®.
+services like PostgreSQL® and Caching.

--- a/docs/platform/howto/search-services.md
+++ b/docs/platform/howto/search-services.md
@@ -65,7 +65,7 @@ To filter the services by service type, use these filter values:
 | MySQL®                      | `mysql`         |
 | OpenSearch®                 | `opensearch`    |
 | PostgreSQL®                 | `pg`            |
-| Caching®                    | `redis`         |
+| Caching                    | `redis`         |
 
 ### Filter by status
 

--- a/docs/platform/howto/use-azure-privatelink.md
+++ b/docs/platform/howto/use-azure-privatelink.md
@@ -19,7 +19,7 @@ Azure Private Link is supported for the following services:
 - Aiven for MySQL®
 - Aiven for OpenSearch®
 - Aiven for PostgreSQL®
-- Aiven for Caching®
+- Aiven for Caching
 
 ## Prerequisites
 

--- a/docs/products/caching.md
+++ b/docs/products/caching.md
@@ -1,8 +1,8 @@
 ---
-title: Aiven for Caching®
+title: Aiven for Caching
 ---
 
-Aiven for Caching®, formerly known as Aiven for Redis®, is a fully managed in-memory NoSQL database. Deployable in the cloud of your choice, it helps you store and access data efficiently.
+Aiven for Caching, formerly known as Aiven for Redis®, is a fully managed in-memory NoSQL database. Deployable in the cloud of your choice, it helps you store and access data efficiently.
 
 For insights into he service name change and the latest updates, read the
 [blog post](https://aiven.io/blog/aiven-for-redis-becomes-aiven-for-caching).

--- a/docs/products/caching/concepts/high-availability-redis.md
+++ b/docs/products/caching/concepts/high-availability-redis.md
@@ -1,8 +1,8 @@
 ---
-title: High availability in Aiven for Caching®
+title: High availability in Aiven for Caching
 ---
 
-Explore high availability with Aiven for Caching® across multiple plans. Gain insights into service continuity and understand the approach to handling failures.
+Explore high availability with Aiven for Caching across multiple plans. Gain insights into service continuity and understand the approach to handling failures.
 
 Compare Aiven for Caching plans in the table below. Each plan offers unique
 configurations and features. Choose what best fits your needs.

--- a/docs/products/caching/concepts/lua-scripts-caching.md
+++ b/docs/products/caching/concepts/lua-scripts-caching.md
@@ -1,8 +1,8 @@
 ---
-title: Lua scripts with Aiven for Caching®
+title: Lua scripts with Aiven for Caching
 ---
 
-Learn how to leverage the built-in support for Lua scripting in Aiven for Caching®.
+Learn how to leverage the built-in support for Lua scripting in Aiven for Caching.
 
 Aiven for Caching has inbuilt support for running Lua scripts to perform various
 actions directly on the Redis server. Scripting is typically controlled

--- a/docs/products/caching/concepts/memory-usage.md
+++ b/docs/products/caching/concepts/memory-usage.md
@@ -1,8 +1,8 @@
 ---
-title: Memory Management and persistence in Aiven for Caching®
+title: Memory Management and persistence in Aiven for Caching
 ---
 
-Learn how Aiven for Caching®, compatible with legacy Redis® OSS up to version 7.2.4, addresses the challenges of high memory usage and high change rate. Discover how it implements robust memory management and persistence strategies.
+Learn how Aiven for Caching, compatible with legacy Redis® OSS up to version 7.2.4, addresses the challenges of high memory usage and high change rate. Discover how it implements robust memory management and persistence strategies.
 
 Aiven for Caching functions primarily as a database cache. Data fetched from a database
 is stored in the caching system. Subsequent queries with the same parameters first check

--- a/docs/products/caching/concepts/overview.md
+++ b/docs/products/caching/concepts/overview.md
@@ -1,8 +1,8 @@
 ---
-title: Aiven for Caching® overview
+title: Aiven for Caching overview
 ---
 
-Aiven for Caching®, a fully managed **in-memory NoSQL database**, offers efficient storage and quick data access in your preferred cloud. This service is compatible with legacy Redis® OSS up to version 7.2.4, facilitating seamless transitions and compatibility.
+Aiven for Caching, a fully managed **in-memory NoSQL database**, offers efficient storage and quick data access in your preferred cloud. This service is compatible with legacy Redis® OSS up to version 7.2.4, facilitating seamless transitions and compatibility.
 
 For insights into he service name change and the latest updates, read the
 [blog post](https://aiven.io/blog/aiven-for-redis-becomes-aiven-for-caching).

--- a/docs/products/caching/concepts/restricted-redis-commands.md
+++ b/docs/products/caching/concepts/restricted-redis-commands.md
@@ -1,8 +1,8 @@
 ---
-title: Restricted Aiven for Caching® commands
+title: Restricted Aiven for Caching commands
 ---
 
-To ensure the stability and security of the caching environment, the Aiven for Caching® service restricts certain commands.
+To ensure the stability and security of the caching environment, the Aiven for Caching service restricts certain commands.
 This section aims to provide you with a list of disabled/restricted commands.
 
 ## Disabled commands

--- a/docs/products/caching/get-started.md
+++ b/docs/products/caching/get-started.md
@@ -1,8 +1,8 @@
 ---
-title: Get started with Aiven for Caching®
+title: Get started with Aiven for Caching
 ---
 
-The first step in using Aiven for Caching® is to create a service. You can do so either using the [Aiven Web Console](https://console.aiven.io/) or the [Aiven CLI](https://github.com/aiven/aiven-client).
+The first step in using Aiven for Caching is to create a service. You can do so either using the [Aiven Web Console](https://console.aiven.io/) or the [Aiven CLI](https://github.com/aiven/aiven-client).
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/products/caching/howto/benchmark-performance.md
+++ b/docs/products/caching/howto/benchmark-performance.md
@@ -1,7 +1,7 @@
 ---
-title: Benchmarking Aiven for Caching® performance
+title: Benchmarking Aiven for Caching performance
 ---
-Aiven for Caching® uses `memtier_benchmark`, a command-line tool by Redis, for load generation and performance evaluation of NoSQL key-value databases.
+Aiven for Caching uses `memtier_benchmark`, a command-line tool by Redis, for load generation and performance evaluation of NoSQL key-value databases.
 
 
 

--- a/docs/products/caching/howto/configure-acl-permissions.md
+++ b/docs/products/caching/howto/configure-acl-permissions.md
@@ -1,12 +1,12 @@
 ---
-title: Configure ACL permissions in Aiven for Caching®
+title: Configure ACL permissions in Aiven for Caching
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 
-Aiven for Caching®  uses [Access Control Lists (ACLs)](https://redis.io/docs/management/security/acl/) o manage the usage of commands and keys based on specific username and password combinations.
+Aiven for Caching  uses [Access Control Lists (ACLs)](https://redis.io/docs/management/security/acl/) o manage the usage of commands and keys based on specific username and password combinations.
 Direct use of [ACL commands](https://redis.io/commands/acl-list/) is restricted to
 ensure the reliability of replication, configuration management, and disaster recovery
 backups for the default user. However, you can create custom ACLs using either the

--- a/docs/products/caching/howto/connect-go.md
+++ b/docs/products/caching/howto/connect-go.md
@@ -4,7 +4,7 @@ title: Connect with Go
 import CodeBlock from '@theme/CodeBlock';
 import MyComponentSource1 from '!!raw-loader!/code/products/redis/connect.go';
 
-Learn how to establish a connection to an Aiven for Caching® service using Go.
+Learn how to establish a connection to an Aiven for Caching service using Go.
 This example demonstrates how to establish a connection to an Aiven for Caching service
 from Go using the `go-redis/redis` library, which is compatible with the Redis protocol.
 

--- a/docs/products/caching/howto/connect-java.md
+++ b/docs/products/caching/howto/connect-java.md
@@ -5,7 +5,7 @@ title: Connect with Java
 import CodeBlock from '@theme/CodeBlock';
 import MyComponentSource1 from '!!raw-loader!/code/products/redis/connect.java';
 
-Learn how to establish a connection to your Aiven for Caching® service using Java and the `jedis` library.
+Learn how to establish a connection to your Aiven for Caching service using Java and the `jedis` library.
 
 ## Variables
 

--- a/docs/products/caching/howto/connect-node.md
+++ b/docs/products/caching/howto/connect-node.md
@@ -5,7 +5,7 @@ title: Connect with NodeJS
 import CodeBlock from '@theme/CodeBlock';
 import MyComponentSource1 from '!!raw-loader!/code/products/redis/connect.js';
 
-Learn how to connect to an Aiven for Caching® service using NodeJS with the `ioredis` library.
+Learn how to connect to an Aiven for Caching service using NodeJS with the `ioredis` library.
 
 
 ## Variables

--- a/docs/products/caching/howto/connect-php.md
+++ b/docs/products/caching/howto/connect-php.md
@@ -5,7 +5,7 @@ title: Connect with PHP
 import CodeBlock from '@theme/CodeBlock';
 import MyComponentSource1 from '!!raw-loader!/code/products/redis/connect.php';
 
-Learn how to connect to an Aiven for Caching® service using PHP and the `predis` library, complete with code examples and setup instructions.
+Learn how to connect to an Aiven for Caching service using PHP and the `predis` library, complete with code examples and setup instructions.
 
 ## Variables
 

--- a/docs/products/caching/howto/connect-python.md
+++ b/docs/products/caching/howto/connect-python.md
@@ -5,7 +5,7 @@ title: Connect with Python
 import CodeBlock from '@theme/CodeBlock';
 import MyComponentSource1 from '!!raw-loader!/code/products/redis/connect.py';
 
-Learn how to connect to an Aiven for Caching® service using Python and the `redis-py` library.
+Learn how to connect to an Aiven for Caching service using Python and the `redis-py` library.
 
 ## Variables
 

--- a/docs/products/caching/howto/connect-redis-cli.md
+++ b/docs/products/caching/howto/connect-redis-cli.md
@@ -2,7 +2,7 @@
 title: Connect with redis-cli
 ---
 
-Learn how to establish a connection to an Aiven for Caching® service using the `redis-cli`.
+Learn how to establish a connection to an Aiven for Caching service using the `redis-cli`.
 
 
 ## Variables

--- a/docs/products/caching/howto/estimate-max-number-of-connections.md
+++ b/docs/products/caching/howto/estimate-max-number-of-connections.md
@@ -2,7 +2,7 @@
 title: Estimate maximum number of connection
 ---
 
-The number of simultaneous connections for Aiven for Caching® depends on the total available memory on the server.
+The number of simultaneous connections for Aiven for Caching depends on the total available memory on the server.
 
 
 You can use the following to estimate:

--- a/docs/products/caching/howto/list-code-samples.md
+++ b/docs/products/caching/howto/list-code-samples.md
@@ -1,5 +1,5 @@
 ---
-title: Connect to Aiven for Caching®
+title: Connect to Aiven for Caching
 ---
 
-Connect to Aiven for Caching® using various programming languages.
+Connect to Aiven for Caching using various programming languages.

--- a/docs/products/caching/howto/manage-ssl-connectivity.md
+++ b/docs/products/caching/howto/manage-ssl-connectivity.md
@@ -2,7 +2,7 @@
 title: Manage SSL connectivity
 ---
 
-Manage SSL connectivity for your Aiven for Caching® service, including enabling secure connections and configuring stunnel for clients without SSL support.
+Manage SSL connectivity for your Aiven for Caching service, including enabling secure connections and configuring stunnel for clients without SSL support.
 
 ## Client support for SSL-encrypted connections
 

--- a/docs/products/caching/howto/migrate-redis-aiven-cli.md
+++ b/docs/products/caching/howto/migrate-redis-aiven-cli.md
@@ -1,10 +1,10 @@
 ---
-title: Migrate from Redis®* to Aiven for Caching® using the CLI
+title: Migrate from Redis®* to Aiven for Caching using the CLI
 ---
 
-Move your data from a source, standalone Redis®* data store to an Aiven-managed Caching® service. The migration process first attempts to use the `replication` method, and if it fails, it switches to `scan`.
+Move your data from a source, standalone Redis®* data store to an Aiven-managed Caching service. The migration process first attempts to use the `replication` method, and if it fails, it switches to `scan`.
 
-Create an Aiven for Caching® service and migrate data from AWS ElastiCache Redis. The Aiven project
+Create an Aiven for Caching service and migrate data from AWS ElastiCache Redis. The Aiven project
 name is `test`, and the service name for the target Aiven for Caching is `redis`.
 
 :::important

--- a/docs/products/caching/howto/migrate-redis-aiven-via-console.md
+++ b/docs/products/caching/howto/migrate-redis-aiven-via-console.md
@@ -1,10 +1,10 @@
 ---
-title: Migrate from Redis®* to Aiven for Caching® using Aiven Console
+title: Migrate from Redis®* to Aiven for Caching using Aiven Console
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-Migrate your Redis®* databases, whether on-premise or cloud-hosted, to Aiven for Caching®, using Aiven Console's guided wizard.
+Migrate your Redis®* databases, whether on-premise or cloud-hosted, to Aiven for Caching, using Aiven Console's guided wizard.
 
 :::important
 Migrating from Google Cloud Memorystore for Redis is not currently
@@ -46,7 +46,7 @@ and require project VPC and peering connection.
 
 ## Migrate a Redis database
 
-Follow these steps to migrate a Redis database to Aiven for Caching® service:
+Follow these steps to migrate a Redis database to Aiven for Caching service:
 
 1.  Log in to the [Aiven Console](https://console.aiven.io/), and select the target
     Aiven for Caching service for migrating the Redis® database.

--- a/docs/products/caching/howto/migrate-redis-db.md
+++ b/docs/products/caching/howto/migrate-redis-db.md
@@ -2,4 +2,4 @@
 title: Redis®* data migration
 ---
 
-Aiven provides you with the flexibility to migrate data from Redis®* to Aiven for Caching® managed service using either the [Aiven CLI](/docs/tools/cli) or [Aiven Console](https://console.aiven.io/).
+Aiven provides you with the flexibility to migrate data from Redis®* to Aiven for Caching managed service using either the [Aiven CLI](/docs/tools/cli) or [Aiven Console](https://console.aiven.io/).

--- a/docs/products/caching/howto/warning-overcommit_memory.md
+++ b/docs/products/caching/howto/warning-overcommit_memory.md
@@ -2,7 +2,7 @@
 title: Handle warning overcommit_memory
 ---
 
-When starting a Aiven for Caching® service on [Aiven
+When starting a Aiven for Caching service on [Aiven
 console](https://console.aiven.io/), you may notice on **Logs** the
 following **warning** `overcommit_memory`:
 

--- a/docs/products/caching/reference/advanced-params.md
+++ b/docs/products/caching/reference/advanced-params.md
@@ -1,9 +1,9 @@
 ---
-title: Advanced parameters for Aiven for Caching®
+title: Advanced parameters for Aiven for Caching
 ---
 
 Find a summary of every configuration option available for
-Aiven for Caching® service:
+Aiven for Caching service:
 
 import Reference from '@site/static/includes/config-caching.md';
 

--- a/docs/products/caching/troubleshooting/troubleshoot-redis-connection-issues.md
+++ b/docs/products/caching/troubleshooting/troubleshoot-redis-connection-issues.md
@@ -2,7 +2,7 @@
 title: Troubleshoot Caching connection issues
 ---
 
-Learn troubleshooting techniques for your Aiven for Caching® service and resolve common connection issues.
+Learn troubleshooting techniques for your Aiven for Caching service and resolve common connection issues.
 
 ## Important notes
 By default,

--- a/docs/products/dragonfly.md
+++ b/docs/products/dragonfly.md
@@ -4,7 +4,7 @@ title: Aiven for Dragonfly®
 ---
 
 Aiven for Dragonfly is an advanced,
-**high-scale, and Aiven for Caching® compatible in-memory database service**
+**high-scale, and Aiven for Caching compatible in-memory database service**
 that can be deployed in your preferred cloud environment.
 It provides lightning-fast data storage and retrieval capabilities, making it ideal for
 businesses that handle large-scale data operations.

--- a/docs/products/dragonfly/get-started.md
+++ b/docs/products/dragonfly/get-started.md
@@ -71,6 +71,6 @@ languages:
 - Learn about how Aiven for Dragonfly supports
   [high availability](/docs/products/dragonfly/concepts/ha-dragonfly).
 - Migrate data from
-  [Aiven for Caching® to Aiven for Dragonfly](/docs/products/dragonfly/howto/migrate-aiven-caching-df-console).
+  [Aiven for Caching to Aiven for Dragonfly](/docs/products/dragonfly/howto/migrate-aiven-caching-df-console).
 - Migrate data from
   [external Dragonfly to Aiven for Dragonfly](/docs/products/dragonfly/howto/migrate-ext-redis-df-console).

--- a/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
+++ b/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
@@ -1,10 +1,10 @@
 ---
-title: Migrate Aiven for Caching® to Aiven for Dragonfly®
+title: Migrate Aiven for Caching to Aiven for Dragonfly®
 ---
 import DragonflyLimitations from '@site/static/includes/dragonfly-limitations.md';
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-Migrate your Aiven for Caching® databases to Aiven for Dragonfly using the Aiven Console migration tool.
+Migrate your Aiven for Caching databases to Aiven for Dragonfly using the Aiven Console migration tool.
 
 import Note from "@site/static/includes/dragonflysla-note.md"
 

--- a/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink.md
@@ -60,7 +60,7 @@ target Redis database upfront:
     password, only needed when using Avro as data format
 
 :::note
-If you're using Aiven for Caching® and Aiven for Apache Kafka, the above
+If you're using Aiven for Caching and Aiven for Apache Kafka, the above
 details are available in the [Aiven console](https://console.aiven.io/)
 service *Overview tab* or via the dedicated `avn service get` command
 with the [Aiven CLI](/docs/tools/cli/service-cli#avn_service_get).

--- a/docs/products/opensearch/howto/opensearch-log-integration.md
+++ b/docs/products/opensearch/howto/opensearch-log-integration.md
@@ -6,7 +6,7 @@ import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 Aiven provides a service integration that allows you to send your logs
 from several services, such as Aiven for Apache Kafka®, PostgreSQL®,
-Apache Cassandra®, OpenSearch®, Caching®, and Grafana®, to
+Apache Cassandra®, OpenSearch®, Caching, and Grafana®, to
 Aiven for OpenSearch®. Making it possible for you to use OpenSearch to
 gain more insight and control over your logs.
 

--- a/docs/tools/cli/service-cli.md
+++ b/docs/tools/cli/service-cli.md
@@ -74,7 +74,7 @@ avn service cli pg-doc
 ### `avn service connection-info`
 
 Retrieves the connection information for Aiven for Apache Kafka®, Aiven
-for PostgreSQL® and Aiven for Caching® in a variety of formats.
+for PostgreSQL® and Aiven for Caching in a variety of formats.
 
 More information on `connection-info` can be found in
 [the dedicated page](service/connection-info).
@@ -149,7 +149,7 @@ avn service credentials-reset kafka-demo
 ### `avn service current-queries`
 
 List current service connections/queries for an Aiven for PostgreSQL®,
-Aiven for MySQL or Aiven for Caching® service.
+Aiven for MySQL or Aiven for Caching service.
 
 | Parameter      | Information             |
 | -------------- | ----------------------- |
@@ -612,7 +612,7 @@ m3db               M3DB - Distributed time series database
 mysql              MySQL - Relational Database Management System
 opensearch         OpenSearch - Search & Analyze Data in Real Time, derived from Elasticsearch v7.10.2
 pg                 PostgreSQL - Object-Relational Database Management System
-caching            Caching® - Compatible with legacy Redis® OSS
+caching            Caching - Compatible with legacy Redis® OSS
 ```
 
 The service types command in verbose mode also shows all the

--- a/docs/tools/cli/service/connection-info.md
+++ b/docs/tools/cli/service/connection-info.md
@@ -130,7 +130,7 @@ psql postgres://avnadmin:XXXXXXXXXXXX@demo-pg-dev-advocates.aivencloud.com:13039
 
 ### `avn service connection-info redis uri`
 
-Retrieves the connection URI needed to connect to an Aiven for Caching®
+Retrieves the connection URI needed to connect to an Aiven for Caching
 service.
 
 | Parameter                     | Information                                                                                                   |
@@ -143,7 +143,7 @@ service.
 | `--db`                        | The database name to use to connect                                                                           |
 
 **Example:** Retrieve the connection URI needed to connect to an Aiven
-for Caching® service named `demo-redis`:
+for Caching service named `demo-redis`:
 
 ```
 avn service connection-info redis uri demo-redis

--- a/docs/tools/cli/service/user.md
+++ b/docs/tools/cli/service/user.md
@@ -15,10 +15,10 @@ Creates a new user for the selected service.
 | `service_name`           | The name of the service                                                    |
 | `--username`             | The new username to be created                                             |
 | `--m3-group`             | The name of the group the user belongs to (for Aiven for M3 services only) |
-| `--redis-acl-keys`       | The ACL rules for keys (Aiven for Caching® services only)                  |
-| `--redis-acl-commands`   | The ACL rules for commands (Aiven for Caching® services only)              |
-| `--redis-acl-categories` | The ACL rules for categories (Aiven for Caching® services only)            |
-| `--redis-acl-channels`   | The ACL rules for channels (Aiven for Caching® services only)              |
+| `--redis-acl-keys`       | The ACL rules for keys (Aiven for Caching services only)                  |
+| `--redis-acl-commands`   | The ACL rules for commands (Aiven for Caching services only)              |
+| `--redis-acl-categories` | The ACL rules for categories (Aiven for Caching services only)            |
+| `--redis-acl-channels`   | The ACL rules for channels (Aiven for Caching services only)              |
 
 **Example:** Create new user named `janedoe` for a service named
 `pg-demo`.
@@ -167,4 +167,4 @@ avn service user-password-reset pg-doc --username avnadmin --new-password VerySe
 
 ### `avn service user-set-access-control`
 
-Set Caching® service user access control
+Set Caching service user access control

--- a/docs/tools/kubernetes.md
+++ b/docs/tools/kubernetes.md
@@ -8,7 +8,7 @@ through the Kubernetes® API by using [Custom Resource Definitions
 
 :::note
 Only Aiven for PostgreSQL®, Aiven for Apache Kafka®, Aiven for
-ClickHouse®, Aiven for Caching®, and Aiven for OpenSearch® are supported
+ClickHouse®, Aiven for Caching, and Aiven for OpenSearch® are supported
 at this time.
 
 Kubernetes, also known as K8s, is an open-source system for automating

--- a/docs/tools/terraform/get-started.md
+++ b/docs/tools/terraform/get-started.md
@@ -3,7 +3,7 @@ title: Get started with Aiven Provider for Terraform
 ---
 
 This example shows you how to use the Aiven Provider to set up your data
-infrastructure by creating a single Aiven for Caching® service in an
+infrastructure by creating a single Aiven for Caching service in an
 [Aiven project](/docs/platform/concepts/orgs-units-projects).
 
 :::caution

--- a/static/_redirects
+++ b/static/_redirects
@@ -62,6 +62,7 @@
 
 /products/redis                                            https://aiven.io/docs/products/caching
 /products/redis/concepts/overview                          https://aiven.io/docs/products/caching/concepts/overview
+/docs/products/redis/get-started                           https://aiven.io/docs/products/caching/get-started
 /docs/products/redis/concepts                              https://aiven.io/docs/products/caching/concepts
 /products/redis/concepts/high-availability-redis           https://aiven.io/docs/products/caching/concepts/high-availability-redis
 /products/redis/concepts/lua-scripts-redis                 https://aiven.io/docs/products/caching/concepts/lua-scripts-caching


### PR DESCRIPTION
## Describe your changes
Removed the ® trademark for all content of Aiven for Caching as that is not required. 
## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
