### PR TITLE
update: modified TOC link for Flink applications page

### DIFF
--- a/docs/products/flink/howto/create-integration.md
+++ b/docs/products/flink/howto/create-integration.md
@@ -1,11 +1,9 @@
 ---
 title: Create Apache Flink® data service integrations
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-With Apache Flink®, you can create streaming data pipelines across
-services. Aiven for Apache Flink® currently supports Aiven for Apache
-Kafka®, Aiven for PostgreSQL®, and Aiven for OpenSearch® as sources and
-targets for Flink applications.
+With Apache Flink®, you can create streaming data pipelines across services. Aiven for Apache Flink® currently supports Aiven for Apache Kafka®, Aiven for PostgreSQL®, and Aiven for OpenSearch® as sources and targets for Flink applications.
 
 To use Aiven for Apache Kafka, Aiven for PostgreSQL, or Aiven for
 OpenSearch as a source or target for a Flink application, you will need
@@ -13,26 +11,26 @@ to integrate the related service with Aiven for Apache Flink.
 
 ## Create data service integration
 
-You can easily create Aiven for Apache Flink® data service integrations
+You can create Aiven for Apache Flink® data service integrations
 via the [Aiven Console](https://console.aiven.io/) by following these
 steps:
 
 1.  Go to the Aiven for Apache Flink® service page.
 
 2.  If you are setting up the first integration for the selected Aiven
-    for Apache Flink service, select **Get Started** in the service
+    for Apache Flink service, click **Get Started** in the service
     **Overview** screen.
 
     ![Image of the Aiven for Apache Flink Overview page with focus on the Get Started Icon](/images/content/products/flink/integrations-get-started.png)
 
-3.  To configure the data flow with Apache Flink®, select the Aiven for
+3.  To configure the data flow with Apache Flink®, click the Aiven for
     Apache Kafka®, Aiven for PostgreSQL®, or Aiven for OpenSearch®
-    service that you wish to integrate. Click the **Integrate** button
+    service that you wish to integrate. Click  <ConsoleLabel name="integrations"/>.
     to complete the integration process.
 
     ![Image of the Aiven for Apache Flink Integration page showing an Aiven for Apache Kafka® and an Aiven for PostgreSQL® services](/images/content/products/flink/integrations-select-services.png)
 
-4.  You can include additional integrations using the plus(**+**) button
-    in the **Data Flow** section
+4.  You can include additional integrations by clicking <ConsoleLabel name="plus"/>
+    in the **Data Flow** section.
 
     ![Image of the Aiven for Apache Flink Integration page showing an existing Aiven for Apache Kafka integration and the + icon to add additional integrations](/images/content/products/flink/integrations-add.png)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1037,10 +1037,13 @@ const sidebars: SidebarsConfig = {
                 {
                   type: 'category',
                   label: 'Aiven for Apache Flink applications',
+                  link: {
+                    type: 'doc',
+                    id: 'products/flink/howto/create-flink-applications',
+                  },
                   items: [
                     'products/flink/howto/create-sql-application',
                     'products/flink/howto/create-jar-application',
-                    'products/flink/howto/create-flink-applications',
                     'products/flink/howto/manage-flink-applications',
                     'products/flink/howto/restart-strategy-jar-applications',
                     'products/flink/howto/manage-credentials-jars',

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -89,7 +89,8 @@ export default function ConsoleLabel({name}): ReactElement {
     case 'pools':
       return (
         <>
-          <ConsoleIconWrapper icon={ConsoleIcons.pools} /> <b>Connection pools</b>
+          <ConsoleIconWrapper icon={ConsoleIcons.pools} />{' '}
+          <b>Connection pools</b>
         </>
       );
     case 'backups':
@@ -263,6 +264,19 @@ export default function ConsoleLabel({name}): ReactElement {
       return (
         <>
           <ConsoleIconWrapper icon={ConsoleIcons.trash} /> <b>Delete user</b>
+        </>
+      );
+    case 'pluscircle':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.plusCircle} />{' '}
+          <b>Plus Circle</b>
+        </>
+      );
+    case 'plus':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.plus} /> <b>Plus</b>
         </>
       );
     default:


### PR DESCRIPTION
## Describe your changes
Updated side nav link for Aiven for Apache Flink applications to point to /howto/create-flink-applications

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
