### PR TITLE
fix: clarify permissions for billing groups access

### DIFF
--- a/docs/platform/concepts/billing-groups.md
+++ b/docs/platform/concepts/billing-groups.md
@@ -19,7 +19,8 @@ cannot use a billing group for projects that are in other organizations.
 Aiven credits are also assigned to a billing group and are automatically
 used to cover charges of any project assigned to that billing group.
 
-To access billing groups, you must be a super admin or account owner.
+To access billing groups in the Aiven Console, you must be a
+super admin or account owner.
 
 You can also track spending by exporting cost information to business
 intelligence tools using the [invoice


### PR DESCRIPTION
## Describe your changes
Clarify that access to billing groups requires super admin access in the Console specifically.

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
