### PR TITLE
update: Okta attribute statements

### DIFF
--- a/docs/platform/howto/saml/add-okta-idp.md
+++ b/docs/platform/howto/saml/add-okta-idp.md
@@ -33,12 +33,11 @@ to the Aiven Console's login page:
     necessary for IdP-initiated login to function correctly.
     :::
 
-1.  Add 2 entries to the **Attribute statements** with the following:
+1.  Add an entry to the **Attribute Statements** with the following:
 
     | **Name** | **Name format** |  **Value**   |
     | -------- | --------------- | ------------ |
-    | `name`   | `Unspecified`   | `email`      |
-    | `value`  | `Unspecified`   | `user.email` |
+    | `email`  | `Unspecified`   | `user.email` |
 
 1.  Click **Next** and **Finish**. You are redirected to your
     application in Okta.


### PR DESCRIPTION
## Describe your changes
Change attribute statements for Okta config.

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
