### PR TITLE
update: remove AE from ECE doc

### DIFF
--- a/docs/platform/concepts/enhanced-compliance-env.md
+++ b/docs/platform/concepts/enhanced-compliance-env.md
@@ -24,7 +24,6 @@ following are requirements to utilize an ECE:
 -   You use Amazon Web Services (AWS), Google Cloud, or Microsoft Azure (excluding
     Azure Germany).
 -   You have a commitment deal with Aiven.
--   You have Aiven Enterprise.
 -   You have the [Advanced or Premium support tier](/docs/platform/howto/support).
 
 ## Cost of ECE


### PR DESCRIPTION
## Describe your changes
Remove Aiven Enterprise as a requirement.

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
