### PR TITLE
update(platform): BYOC contact sales replacement and editorial fixes

### DIFF
--- a/docs/platform/concepts/byoc.md
+++ b/docs/platform/concepts/byoc.md
@@ -57,7 +57,7 @@ not all cloud providers support it yet. Meet a few requirements to be eligible f
     :::note
     View the [Aiven support tiers](https://aiven.io/support-services) and
     [Aiven responsibility matrix](https://aiven.io/responsibility-matrix) for BYOC. Contact
-    the [sales team](mailto:sales@aiven.io) to learn more or upgrade your support tier.
+    your account team to learn more or upgrade your support tier.
     :::
 
 ## When to use the regular Aiven deployment
@@ -72,7 +72,7 @@ utilizing a regular Aiven deployment or
 
 :::tip
 If you would like to understand BYOC better or are unsure which
-deployment model is the best fit for you, contact [the sales team](mailto:sales@aiven.io).
+deployment model is the best fit for you, contact your account team.
 :::
 
 ## BYOC pricing and billing
@@ -89,7 +89,7 @@ may have and potentially leverage committed use discounts (CUDs) in
 certain cases.
 
 :::note
-For a cost estimate and analysis, contact [the sales team](mailto:sales@aiven.io).
+For a cost estimate and analysis, contact your account team.
 :::
 
 ## BYOC AWS private deployment {#byoc-deployment}

--- a/docs/platform/howto/byoc/assign-project-custom-cloud.md
+++ b/docs/platform/howto/byoc/assign-project-custom-cloud.md
@@ -84,8 +84,7 @@ custom cloud, you can:
 
 - Create new services in the custom cloud
 - Migrate existing services to your custom cloud if your service and networking
-  configuration allows it. For more information, contact the
-  [sales team](mailto:sales@aiven.io).
+  configuration allows it. For more information, contact your account team.
 
 ## Verify the update
 

--- a/docs/platform/howto/byoc/create-custom-cloud.md
+++ b/docs/platform/howto/byoc/create-custom-cloud.md
@@ -62,8 +62,7 @@ contacts for your custom cloud.
     :::note
     See [Aiven support tiers](https://aiven.io/support-services) and
     [Aiven responsibility matrix](https://aiven.io/responsibility-matrix) for BYOC.
-    Contact the [sales team](mailto:sales@aiven.io) to learn more or upgrade your support
-    tier.
+    Contact your account team to learn more or upgrade your support tier.
     :::
 
 -   To build your custom cloud with a cloud provider other
@@ -593,7 +592,7 @@ Select in what projects you'll be able to use your new custom cloud as a hosting
 services. In the projects where you enable your custom cloud, you can create new
 services in the custom cloud or migrate your existing services to the custom cloud if your
 service and networking configuration allows it. For more information on migrating your
-existing services to the custom cloud, contact the [sales team](mailto:sales@aiven.io).
+existing services to the custom cloud, contact your account team.
 
 Your cloud can be available in:
 
@@ -674,7 +673,7 @@ custom cloud is ready to use and you can see it on the list of your custom cloud
 **Bring your own cloud** view. Now you can create new services in the custom cloud or
 migrate your existing services to the custom cloud if your service and networking
 configuration allows it. For more information on migrating your existing services to the
-custom cloud, contact the [sales team](mailto:sales@aiven.io).
+custom cloud, contact your account team.
 
 #### Destroy the Terraform resources
 
@@ -697,7 +696,7 @@ When creating a service in the [Aiven Console](https://console.aiven.io/), at th
 ### Migrate existing services to the custom cloud
 
 Whether you can migrate existing services to the custom cloud depends on your service and
-networking configuration. Contact the [sales team](mailto:sales@aiven.io) for more
+networking configuration. Contact your account team for more
 information.
 
 ## Related pages

--- a/docs/platform/howto/byoc/enable-byoc.md
+++ b/docs/platform/howto/byoc/enable-byoc.md
@@ -60,12 +60,10 @@ BYOC is supported with the
     request.
 
 1.  Using the scheduling assistant, select a date and time when you want
-1.  Using the scheduling assistant, select a date and time when you want
     to talk to our sales team to share your requirements and make sure
     BYOC suits your needs. Confirm the selected time, make sure you add
     the call to your calendar, and close the the scheduling assistant.
 
-1.  Join the scheduled call with our sales team to follow up with them
 1.  Join the scheduled call with our sales team to follow up with them
     on enabling BYOC in your environment.
 


### PR DESCRIPTION
Swapping "contact sales" for "contact your account team"

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
