### PR TITLE
update(postgresql): connection limits with free plan limit/platform usage

### DIFF
--- a/docs/products/postgresql/reference/pg-connection-limits.md
+++ b/docs/products/postgresql/reference/pg-connection-limits.md
@@ -9,12 +9,16 @@ follows:
 
 | Plan                                                    | Max Connections |
 | ------------------------------------------------------- | --------------- |
+| Free (DigitalOcean only)                                | 20              |
 | Hobbyist (Google Cloud, DigitalOcean, and UpCloud only) | 25              |
 | Startup/Business/Premium-4                              | 100             |
 | Startup/Business/Premium-8                              | 200             |
 | Startup/Business/Premium-16                             | 400             |
 | Startup/Business/Premium-32                             | 800             |
 | Startup/Business/Premium-64 and above                   | 1000            |
+
+Three connections are reserved for the platform for administrative purposes,
+and others may be used for replication.
 
 When several clients or client threads are connecting to the database,
 Aiven recommends using

--- a/docs/products/postgresql/reference/pg-connection-limits.md
+++ b/docs/products/postgresql/reference/pg-connection-limits.md
@@ -1,13 +1,13 @@
 ---
 title: Connection limits per plan for Aiven for PostgreSQL®
+sidebar_label: Connection limits per plan
 ---
 
-Aiven for PostgreSQL® instances limit the number of allowed connections
-to make sure that the database is able to serve them all. The
-`max_connections` setting varies according to the service plan as
-follows:
+Aiven for PostgreSQL® instances limit the number of allowed connections to make sure that the database is able to serve them all.
 
-| Plan                                                    | Max Connections |
+The `max_connections` setting varies according to the service plan as follows:
+
+| Plan                                                    | Max connections |
 | ------------------------------------------------------- | --------------- |
 | Free (DigitalOcean only)                                | 20              |
 | Hobbyist (Google Cloud, DigitalOcean, and UpCloud only) | 25              |
@@ -16,9 +16,6 @@ follows:
 | Startup/Business/Premium-16                             | 400             |
 | Startup/Business/Premium-32                             | 800             |
 | Startup/Business/Premium-64 and above                   | 1000            |
-
-Three connections are reserved for the platform for administrative purposes,
-and others may be used for replication.
 
 When several clients or client threads are connecting to the database,
 Aiven recommends using


### PR DESCRIPTION
## Describe your changes

Add max_connections for free plan, based on querying it in a PG 16 instance.
Note administrative reservation (res_for_super = 3) and potential use by replication.
(I lack the privileges to determine whether Aiven's replication uses superuser, or is a separate allocation.)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
