### PR TITLE
update: Missing label for file replacement action

### DIFF
--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -152,7 +152,8 @@ export default function ConsoleLabel({name}): ReactElement {
     case 'makesuperadmin':
       return (
         <>
-          <ConsoleIconWrapper icon={ConsoleIcons.superadmin} /> <b>Make super admin</b>
+          <ConsoleIconWrapper icon={ConsoleIcons.superadmin} />{' '}
+          <b>Make super admin</b>
         </>
       );
     case 'viewuserprofile':
@@ -258,6 +259,12 @@ export default function ConsoleLabel({name}): ReactElement {
         <>
           <ConsoleIconWrapper icon={ConsoleIcons.refresh} />{' '}
           <b>Reset password</b>
+        </>
+      );
+    case 'replacefile':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.refresh} /> <b>Replace file</b>
         </>
       );
     case 'editaclrules':


### PR DESCRIPTION
## Describe your changes

Replace files step missing replace file icon. 
https://aiven.io/docs/products/opensearch/howto/custom-dictionary-files#replace-files
## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
