### PR TITLE
fix: CLI service integration-update fails adding custom metrics

### DIFF
--- a/docs/products/kafka/howto/datadog-customised-metrics.md
+++ b/docs/products/kafka/howto/datadog-customised-metrics.md
@@ -23,10 +23,10 @@ independent monitoring of each `topic` and `partition`.
 
 These are the placeholders you will need to replace in the code samples.
 
- | Variable         | Description                                                              |
- | ---------------- | ------------------------------------------------------------------------ |
- | `SERVICE_NAME`   | Aiven for Apache Kafka® service name                                     |
- | `INTEGRATION_ID` | ID of the integration between Aiven for Apache Kafka service and Datadog |
+ | Variable         | Description                                                               |
+ | ---------------- | ------------------------------------------------------------------------- |
+ | `SERVICE_NAME`   | Aiven for Apache Kafka® service name                                      |
+ | `INTEGRATION_ID` | ID of the integration between Aiven for Apache Kafka® service and Datadog |
 
 You can find the `INTEGRATION_ID` parameter by executing this command:
 
@@ -48,18 +48,18 @@ parameters:
 
 -   `kafka_custom_metrics`: defining the comma-separated list of custom
     metrics to include (within `kafka.log.log_size`,
-    `kafka.log.log_start_offset` and `kafka.log.log_end_offset`)
+    `kafka.log.log_start_offset` and `kafka.log.log_end_offset`).
 
 For example, to send the `kafka.log.log_size` and
 `kafka.log.log_end_offset` metrics, execute the following code:
 
 ```
 avn service integration-update                                                \
-    -c kafka_custom_metrics=['kafka.log.log_size','kafka.log.log_end_offset'] \
+    -c 'kafka_custom_metrics=["kafka.log.log_size","kafka.log.log_end_offset"]' \
     INTEGRATION_ID
 ```
 
-After you successfully update and the metrics are collected and sent to
+After you successfully updated and the metrics are collected and sent to
 Datadog, you can view them in your Datadog explorer.
 
 Also see [Datadog and Aiven](/docs/integrations/datadog).
@@ -94,10 +94,10 @@ For example, to include topics `topic1` and `topic2`, and exclude
 
 ```
 avn service integration-update                                                  \
-    -c kafka_custom_metrics="['kafka.log.log_size','kafka.log.log_end_offset']" \
-    -c include_topics="['topic1','topic2']"                                     \
+    -c 'kafka_custom_metrics=["kafka.log.log_size","kafka.log.log_end_offset"]' \
+    -c 'include_topics=["topic1","topic2"]'                                     \
     INTEGRATION_ID
 ```
 
-After you successfully update and the metrics are collected and sent to
+After you successfully updated and the metrics are collected and sent to
 Datadog, you can view them in your Datadog explorer.

--- a/docs/products/kafka/howto/datadog-customised-metrics.md
+++ b/docs/products/kafka/howto/datadog-customised-metrics.md
@@ -2,10 +2,9 @@
 title: Configure Apache Kafka® metrics sent to Datadog
 ---
 
-When creating a [Datadog service
-integration](https://docs.datadoghq.com/integrations/kafka/?tab=host#kafka-consumer-integration),
-customize which metrics are sent to the Datadog endpoint using the
-[Aiven CLI](/docs/tools/cli).
+When creating a [Datadog service integration](https://docs.datadoghq.com/integrations/kafka/?tab=host#kafka-consumer-integration), you can customize which metrics are sent to the Datadog endpoint using the [Aiven CLI](/docs/tools/cli).
+
+## Supported metrics
 
 The following metrics are currently supported for each topic and
 partition in Apache Kafka®:
@@ -14,32 +13,31 @@ partition in Apache Kafka®:
 -   `kafka.log.log_start_offset`
 -   `kafka.log.log_end_offset`
 
-:::note
-All metrics are tagged with `topic` and `partition`, enabling
-independent monitoring of each `topic` and `partition`.
-:::
+All metrics are tagged with `topic` and `partition`, enabling independent monitoring
+of each `topic` and `partition`.
 
 ## Variables
 
-These are the placeholders you will need to replace in the code samples.
+Replace the following placeholders in the code samples:
 
  | Variable         | Description                                                               |
  | ---------------- | ------------------------------------------------------------------------- |
  | `SERVICE_NAME`   | Aiven for Apache Kafka® service name                                      |
  | `INTEGRATION_ID` | ID of the integration between Aiven for Apache Kafka® service and Datadog |
 
-You can find the `INTEGRATION_ID` parameter by executing this command:
+To find the `INTEGRATION_ID` parameter, execute this command:
 
 ```
 avn service integration-list SERVICE_NAME
 ```
 
-## Customize Apache Kafka® metrics for Datadog
+## Customize metrics for Datadog
 
 Before customizing metrics, ensure a Datadog endpoint is configured and
 enabled in your Aiven for Apache Kafka service. For setup instructions,
 see
-[Send metrics to Datadog](/docs/integrations/datadog/datadog-metrics). Format any listed parameters as a comma-separated list:
+[Send metrics to Datadog](/docs/integrations/datadog/datadog-metrics).
+Format any listed parameters as a comma-separated list:
 `['value0', 'value1', 'value2', ...]`.
 
 To customize the metrics sent to Datadog, you can use the
@@ -59,14 +57,11 @@ avn service integration-update                                                \
     INTEGRATION_ID
 ```
 
-After you successfully updated and the metrics are collected and sent to
-Datadog, you can view them in your Datadog explorer.
+After updating settings, view the collected metrics in your Datadog explorer.
 
-Also see [Datadog and Aiven](/docs/integrations/datadog).
+## Customize consumer metrics for Datadog
 
-## Customize Apache Kafka® consumer metrics for Datadog
-
-[Kafka Consumer
+[Apache Kafka Consumer
 Integration](https://docs.datadoghq.com/integrations/kafka/?tab=host#kafka-consumer-integration)
 collects metrics for message offsets. To customize the metrics sent from
 this Datadog integration to Datadog, you can use the
@@ -90,7 +85,7 @@ parameters:
     consumer groups to exclude.
 
 For example, to include topics `topic1` and `topic2`, and exclude
-`topic3`, execute the following code:
+`topic3`, execute the following command:
 
 ```
 avn service integration-update                                                  \
@@ -99,5 +94,8 @@ avn service integration-update                                                  
     INTEGRATION_ID
 ```
 
-After you successfully updated and the metrics are collected and sent to
-Datadog, you can view them in your Datadog explorer.
+After updating settings, view the collected metrics in your Datadog explorer.
+
+## Related pages
+
+- [Datadog and Aiven](/docs/integrations/datadog)

--- a/docs/products/kafka/kafka-mirrormaker/howto/datadog-customised-metrics.md
+++ b/docs/products/kafka/kafka-mirrormaker/howto/datadog-customised-metrics.md
@@ -1,0 +1,63 @@
+---
+title: Configure Apache Kafka® MirrorMaker 2 metrics sent to Datadog
+---
+
+When creating a [Datadog service
+integration](https://docs.datadoghq.com/integrations/kafka/?tab=host#kafka-consumer-integration),
+customize which metrics are sent to the Datadog endpoint using the
+[Aiven CLI](/docs/tools/cli).
+
+The following metrics are currently supported for each replication-flow
+in Apache Kafka® MirrorMaker 2:
+
+-   `kafka_mirrormaker_summary.replication_lag`
+
+:::note
+The metric is tagged with `replication-flow`, enabling
+independent monitoring of each one of them.
+:::
+
+## Variables
+
+These are the placeholders you will need to replace in the code samples.
+
+ | Variable         | Description                                                                             |
+ | ---------------- | --------------------------------------------------------------------------------------- |
+ | `SERVICE_NAME`   | Aiven for Apache Kafka® MirrorMaker 2 service name                                      |
+ | `INTEGRATION_ID` | ID of the integration between Aiven for Apache Kafka® MirrorMaker 2 service and Datadog |
+
+You can find the `INTEGRATION_ID` parameter by executing this command:
+
+```
+avn service integration-list SERVICE_NAME
+```
+
+## Customize Apache Kafka® MirrorMaker 2 metrics for Datadog
+
+Before customizing metrics, ensure a Datadog endpoint is configured and
+enabled in your Aiven for Apache Kafka service. For setup instructions,
+see
+[Send metrics to Datadog](/docs/integrations/datadog/datadog-metrics). Format any listed parameters as a comma-separated list:
+`['value0', 'value1', 'value2', ...]`.
+
+To customize the metrics sent to Datadog, you can use the
+`service integration-update` passing the following customized
+parameters:
+
+-   `mirrormaker_custom_metrics`: defining the comma-separated list of custom
+    metrics to include (currently, only `kafka_mirrormaker_summary.replication_lag` is
+    supported).
+
+For example, to send the `kafka_mirrormaker_summary.replication_lag`
+metric, execute the following code:
+
+```
+avn service integration-update                                                \
+    -c 'mirrormaker_custom_metrics=["kafka_mirrormaker_summary.replication_lag"]' \
+    INTEGRATION_ID
+```
+
+After you successfully updated and the metrics are collected and sent to
+Datadog, you can view them in your Datadog explorer.
+
+Also see [Datadog and Aiven](/docs/integrations/datadog).

--- a/docs/products/kafka/kafka-mirrormaker/howto/datadog-customised-metrics.md
+++ b/docs/products/kafka/kafka-mirrormaker/howto/datadog-customised-metrics.md
@@ -2,54 +2,57 @@
 title: Configure Apache Kafka® MirrorMaker 2 metrics sent to Datadog
 ---
 
-When creating a [Datadog service
-integration](https://docs.datadoghq.com/integrations/kafka/?tab=host#kafka-consumer-integration),
-customize which metrics are sent to the Datadog endpoint using the
-[Aiven CLI](/docs/tools/cli).
+When creating a [Datadog service integration](https://docs.datadoghq.com/integrations/kafka/?tab=host#kafka-consumer-integration), customize which metrics are sent to the Datadog endpoint using the [Aiven CLI](/docs/tools/cli).
 
-The following metrics are currently supported for each replication-flow
-in Apache Kafka® MirrorMaker 2:
+## Supported metrics
+
+The following metric is supported for each replication flow in
+Apache Kafka® MirrorMaker 2:
 
 -   `kafka_mirrormaker_summary.replication_lag`
 
+The metric is tagged with `replication-flow`, enabling independent monitoring of
+each one of them.
+
 :::note
-The metric is tagged with `replication-flow`, enabling
-independent monitoring of each one of them.
+The `kafka_mirrormaker_summary.replication_lag` metric is available as a custom metric
+in our Datadog integration. As a custom metric, it may be subject to separate
+billing by Datadog.
 :::
 
 ## Variables
 
-These are the placeholders you will need to replace in the code samples.
+Replace the following placeholders in the code samples:
 
  | Variable         | Description                                                                             |
  | ---------------- | --------------------------------------------------------------------------------------- |
  | `SERVICE_NAME`   | Aiven for Apache Kafka® MirrorMaker 2 service name                                      |
  | `INTEGRATION_ID` | ID of the integration between Aiven for Apache Kafka® MirrorMaker 2 service and Datadog |
 
-You can find the `INTEGRATION_ID` parameter by executing this command:
+To find the `INTEGRATION_ID` parameter, execute this command:
 
 ```
 avn service integration-list SERVICE_NAME
 ```
 
-## Customize Apache Kafka® MirrorMaker 2 metrics for Datadog
+## Customize metrics for Datadog
 
 Before customizing metrics, ensure a Datadog endpoint is configured and
 enabled in your Aiven for Apache Kafka service. For setup instructions,
 see
-[Send metrics to Datadog](/docs/integrations/datadog/datadog-metrics). Format any listed parameters as a comma-separated list:
+[Send metrics to Datadog](/docs/integrations/datadog/datadog-metrics).
+Format any listed parameters as a comma-separated list:
 `['value0', 'value1', 'value2', ...]`.
 
-To customize the metrics sent to Datadog, you can use the
-`service integration-update` passing the following customized
-parameters:
+To customize the metrics sent to Datadog, use the `service integration-update`
+command with the following customized parameter:
 
--   `mirrormaker_custom_metrics`: defining the comma-separated list of custom
-    metrics to include (currently, only `kafka_mirrormaker_summary.replication_lag` is
+-   `mirrormaker_custom_metrics`: Define the comma-separated list of custom metrics to
+    include (currently, only `kafka_mirrormaker_summary.replication_lag` is
     supported).
 
 For example, to send the `kafka_mirrormaker_summary.replication_lag`
-metric, execute the following code:
+metric, execute the following command:
 
 ```
 avn service integration-update                                                \
@@ -57,7 +60,8 @@ avn service integration-update                                                \
     INTEGRATION_ID
 ```
 
-After you successfully updated and the metrics are collected and sent to
-Datadog, you can view them in your Datadog explorer.
+After updating settings, view the collected metrics in your Datadog explorer.
 
-Also see [Datadog and Aiven](/docs/integrations/datadog).
+## Related pages
+
+- [Datadog and Aiven](/docs/integrations/datadog)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -898,6 +898,7 @@ const sidebars: SidebarsConfig = {
                     'products/kafka/kafka-mirrormaker/howto/integrate-external-kafka-cluster',
                     'products/kafka/kafka-mirrormaker/howto/setup-replication-flow',
                     'products/kafka/kafka-mirrormaker/howto/remove-mirrormaker-prefix',
+                    'products/kafka/kafka-mirrormaker/howto/datadog-customised-metrics',
                   ],
                 },
                 {


### PR DESCRIPTION
## Describe your changes

The syntax provided by the documentation fails with error `no matches found` and a new custom metric was added for mm.

[DOC-1054]
[EC-324]

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.


[DOC-1054]: https://aiven.atlassian.net/browse/DOC-1054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EC-324]: https://aiven.atlassian.net/browse/EC-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ