### PR TITLE
fix: information about persistence for Caching service backup

### DIFF
--- a/docs/platform/concepts/service_backups.md
+++ b/docs/platform/concepts/service_backups.md
@@ -270,26 +270,34 @@ To be notified once the PITR feature is available for Cassandra, contact the Aiv
 
 ### Aiven for Caching
 
-Aiven for Caching backups are taken every 12 hours.
+Aiven for Caching automatically backs up data every 12 hours and supports configurable
+data persistence using Redis Database Backup (RDB).
 
-For persistence, Aiven supports Redis Database Backup (RDB).
+#### Persistence settings
 
-You can control the persistence feature using `redis_persistence` under
-**Advanced configuration** in [Aiven Console](https://console.aiven.io/)
-(the service's **Service settings** page):
+You can configure the `redis_persistence` settings from the **Advanced configuration**
+section on your **Service settings** page in the [Aiven Console](https://console.aiven.io).
 
-- When `redis_persistence` is set to `rdb`, Aiven for Caching does RDB dumps every
-  10 minutes if any key is changed. Also, RDB dumps are done according
-  to the backup schedule for backup purposes.
-- When `redis_persistence` is `off`, no RDB dumps or backups are done,
-  so data can be lost at any moment if the service is restarted for
-  any reason or if the service is powered off. This also means the
-  service can't be forked.
+- **Enabled (`rdb`)**: When you set `redis_persistence` to `rdb`, Aiven for Caching
+  performs RDB dumps every 10 minutes whenever a key changes. These dumps align with
+  the regular backup schedule to enhance data protection.
+- **Disabled (`off`)**: Setting `redis_persistence` to `off` stops all RDB dumps and
+  backups. If the service restarts or powers off for any reason, you may lose any
+  data not yet backed up. Additionally, you cannot fork or replicate the service,
+  which can affect potential scaling or disaster recovery plans.
+
+  :::warning
+  If you disable `redis_persistence`, the system immediately deletes all existing
+  backups, preventing any data recovery from those backups. Re-enabling persistence
+  starts a new backup cycle, but it won't restore any previously stored data.
+  :::
 
 :::note
-AOF persistence is currently not supported by Aiven for the managed
+The Append Only File (AOF) persistence method is not supported for the managed
 Aiven for Caching service.
 :::
+
+
 
 ### Aiven for ClickHouse®
 

--- a/docs/platform/concepts/service_backups.md
+++ b/docs/platform/concepts/service_backups.md
@@ -276,7 +276,7 @@ data persistence using Redis Database Backup (RDB).
 #### Persistence settings
 
 You can configure the `redis_persistence` settings from the **Advanced configuration**
-section on your **Service settings** page in the [Aiven Console](https://console.aiven.io).
+section on your <ConsoleLabel name="service settings"/> page in the [Aiven Console](https://console.aiven.io).
 
 - **Enabled (`rdb`)**: When you set `redis_persistence` to `rdb`, Aiven for Caching
   performs RDB dumps every 10 minutes whenever a key changes. These dumps provide

--- a/docs/platform/concepts/service_backups.md
+++ b/docs/platform/concepts/service_backups.md
@@ -284,7 +284,7 @@ section on your **Service settings** page in the [Aiven Console](https://console
   loss to a maximum of 10 minutes. However, full backups are created only according to
   the backup schedule (every 12 hours) or when the service is shut down.
 - **Disabled (`off`)**: When you set `redis_persistence` to `off`, Aiven for Caching
-  stops all Redis RDB dumps and backups If the service restarts or powers off for
+  stops all Redis RDB dumps and backups. If the service restarts or powers off for
   any reason, you may lose any data not yet backed up. Additionally, you cannot
   fork or replicate the service,
   which can affect potential scaling or disaster recovery plans.

--- a/docs/platform/concepts/service_backups.md
+++ b/docs/platform/concepts/service_backups.md
@@ -279,25 +279,27 @@ You can configure the `redis_persistence` settings from the **Advanced configura
 section on your **Service settings** page in the [Aiven Console](https://console.aiven.io).
 
 - **Enabled (`rdb`)**: When you set `redis_persistence` to `rdb`, Aiven for Caching
-  performs RDB dumps every 10 minutes whenever a key changes. These dumps align with
-  the regular backup schedule to enhance data protection.
-- **Disabled (`off`)**: Setting `redis_persistence` to `off` stops all RDB dumps and
-  backups. If the service restarts or powers off for any reason, you may lose any
-  data not yet backed up. Additionally, you cannot fork or replicate the service,
+  performs RDB dumps every 10 minutes whenever a key changes. These dumps provide
+  additional data protection against Caching service incidents, limiting potential data
+  loss to a maximum of 10 minutes. However, full backups are created only according to
+  the backup schedule (every 12 hours) or when the service is shut down.
+- **Disabled (`off`)**: When you set `redis_persistence` to `off`, Aiven for Caching
+  stops all Redis RDB dumps and backups If the service restarts or powers off for
+  any reason, you may lose any data not yet backed up. Additionally, you cannot
+  fork or replicate the service,
   which can affect potential scaling or disaster recovery plans.
 
   :::warning
   If you disable `redis_persistence`, the system immediately deletes all existing
-  backups, preventing any data recovery from those backups. Re-enabling persistence
-  starts a new backup cycle, but it won't restore any previously stored data.
+  backups, preventing any data recovery from those backups. When you re-enable
+  persistence, it starts a new backup cycle, but it won't restore any previously
+  stored data.
   :::
 
 :::note
 The Append Only File (AOF) persistence method is not supported for the managed
 Aiven for Caching service.
 :::
-
-
 
 ### Aiven for ClickHouse®
 


### PR DESCRIPTION
## Describe your changes

This pull request updates docs to reflect the current behavior of Redis Persistence, specifically regarding the deletion of all existing backups when persistence is switched off.

[DOC-1023](https://aiven.atlassian.net/browse/DOC-1023)


## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.


[DOC-1023]: https://aiven.atlassian.net/browse/DOC-1023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ