### PR TITLE
fix: clarify OS ACL scope in docs

### DIFF
--- a/docs/products/opensearch/concepts/access_control.md
+++ b/docs/products/opensearch/concepts/access_control.md
@@ -26,6 +26,11 @@ for each user by setting up individual \"pattern/permission\" rules. The
 applies and uses glob-style matching, where \* matches any number of
 characters (including none) and ? matches any single character.
 
+:::note
+ACLs apply only to indices and do not control access to other OpenSearch APIs,
+including OpenSearch Dashboards.
+:::
+
 For more information about access control, patterns and permissions, see
 [Understanding access control in Aiven for OpenSearch®](/docs/products/opensearch/concepts/users-access-controls).
 

--- a/docs/products/opensearch/concepts/users-access-controls.md
+++ b/docs/products/opensearch/concepts/users-access-controls.md
@@ -2,30 +2,29 @@
 title: Understanding access control in Aiven for OpenSearch®
 ---
 
-Implementing access control and permissions is essential in maintaining
-secure access to data stored in Aiven for OpenSearch®. This article
-provides an overview of how access control works in Aiven for
-OpenSearch®, including the different types of permissions that can be
-used to control access.
+Implement access control and permissions to secure data in Aiven for OpenSearch®. Understand how access control works and the various permissions used to manage access effectively.
+
+:::note
+ACLs apply only to indices and do not control access to other OpenSearch APIs,
+including OpenSearch Dashboards.
+:::
 
 ## Patterns and permissions
 
-Access control in OpenSearch is achieved through the use of patterns and
-permissions. A pattern is a string in glob-style that specifies the
-indices to which the permission applies, while the permission defines
-the level of access granted to the user for the matching indices.
+Access control in OpenSearch uses patterns and permissions to manage access to indices.
+Patterns are glob-style strings that specify the indices to which the permission applies,
+and permissions define the level of access granted to the user for the matching indices.
 
 ### Patterns
 
-Patterns are glob-style strings that use the following syntax:
+Patterns use the following syntax:
 
 -   `*`: Matches any number of characters (including none)
 -   `?`: Matches any single character
 
 ### Permissions
 
-The permissions available in Aiven for OpenSearch®, ordered by
-importance, are:
+The available permissions in Aiven for OpenSearch®, ordered by importance, are:
 
 -   `deny`: Explicitly denies access
 -   `admin`: Allows unlimited access to the index
@@ -46,10 +45,12 @@ The permission also determines which index APIs the user can access:
     and `_delete_by_query` APIs
 
 :::note
-\* When no rules match, access is implicitly denied. \* The `write`
-permission allows creating indices that match the rule's index pattern
-but does not allow deleting them. Indices can only be deleted when a
-matching `admin` permission rule exists.
+
+ - When no rules match, access is implicitly denied.
+ - The `write` permission allows creating indices that match the rule's index pattern
+   but does not allow deleting them. Indices can only be deleted when a matching
+   `admin` permission rule exists.
+
 :::
 
 ## Example
@@ -79,35 +80,44 @@ This same set of rules would deny the service user from:
 -   Write to or use the API `for logs_20171230` (the first rule only
     grants `read` permission)
 
+:::note
+These rules apply only to index access and not to OpenSearch Dashboards or other
+OpenSearch APIs.
+:::
+
 ## Access control for aliases
 
+Aliases are virtual indices that can reference one or more physical indices,
+simplifying data management and search.
 Access control and aliases are key concepts in OpenSearch. Aliases are
 virtual indices that can reference one or more physical indices,
-simplifying the management and search of data. You can define access
-control rules for aliases to ensure proper security and control over
-data access.
+simplifying the management and search of data. You can define access control rules
+for aliases to ensure proper security and control over data access.
 
-When working with aliases in OpenSearch, it's essential to remember how
-access control rules apply to them:
+When working with aliases in OpenSearch, remember how access control rules apply:
 
 -   Aliases are not automatically expanded in access control. Therefore,
     the ACL must explicitly include a rule that matches the alias
     pattern.
--   Only access control rules that match the alias pattern will be
-    applied, while rules that match the physical indices the alias
-    expands to will not be used.
+-   Only access control rules that match the alias pattern will be applied.
+    Rules that match the physical indices the alias expands to will not be used.
 
 ## Access to top-level APIs
 
-You can control access to \"top-level\" APIs in addition to indices
-using ACLs. This can be achieved by creating an API-specific rule to
-manage access to these APIs.
+You can control access to top-level APIs in addition to indices using ACLs. To manage
+access to these APIs, create an API-specific rule.
 
 ### Service controlled APIs
 
 The following top-level APIs are controlled by the OpenSearch service
-and not by the ACLs defined by you: \* `_cluster` \* `_cat` \* `_tasks`
-\* `_scripts` \* `_snapshot` \* `_nodes`
+and not by the ACLs defined by you:
+
+- `_cluster`
+- `_cat`
+- `_tasks`
+- `_scripts`
+- `_snapshot`
+- `_nodes`
 
 :::note
 Enabling OpenSearch Security management provides control over the
@@ -116,10 +126,10 @@ top-level APIs - `_mget`, `_msearch`, and `_bulk`.
 
 ### Using ACLs to control access
 
-Only rules starting with `_`are considered for controlling access to
-top-level APIs, and normal index rules do not grant access to these
-APIs. For example, a rule like `*search/admin` only grants access to
-indices that match the pattern, not to `_msearch`.
+Only rules starting with `_` are considered for controlling access to top-level APIs,
+and standard index rules do not grant access to these APIs. For example,
+a rule like `*search/admin` only grants access to indices that match the pattern,
+not to `_msearch`.
 
 Example:
 
@@ -129,7 +139,7 @@ Example:
 ACLs **only control access to the API** and not its usage. Granting
 access to the top-level API will effectively bypass index-specific
 rules. For example, granting `_msearch/admin` access allows searching
-any index via the API as the indices to search are defined in the
+any index via the API, as the indices to search are defined in the
 request body itself.
 
 :::warning
@@ -154,4 +164,5 @@ service user.
 ## Next steps
 
 Learn how to
-[enable and manage access control](/docs/products/opensearch/howto/control_access_to_content) for your Aiven for OpenSearch® service.
+[enable and manage access control](/docs/products/opensearch/howto/control_access_to_content)
+for your Aiven for OpenSearch® service.

--- a/docs/products/opensearch/howto/control_access_to_content.md
+++ b/docs/products/opensearch/howto/control_access_to_content.md
@@ -1,6 +1,7 @@
 ---
 title: Manage users and access control in Aiven for OpenSearch®
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 Effective access control and permissions management are crucial for
 Aiven for OpenSearch service users. In Aiven for OpenSearch, you can
@@ -13,23 +14,26 @@ service, you can manage access control and permissions for your service
 users. You can create new users, modify their details, and assign index
 patterns and permissions for each user.
 
-:::note
 Alternatively, you can enable
 [OpenSearch Security management](/docs/products/opensearch/howto/enable-opensearch-security) for your Aiven for OpenSearch service and manage users and
 permissions via the OpenSearch Security dashboard.
+
+:::note
+ACLs apply only to indices and do not control access to other OpenSearch APIs,
+including OpenSearch Dashboards.
 :::
 
-## Create user without access control
+## Create a user without access control
 
 To create a service new user without any access control in Aiven
 Console, follow these steps:
 
-1.  In the [Aiven Console](https://console.aiven.io), open the Aiven for
-    OpenSearch service where you want to add a user.
-2.  Select **Users** from the left sidebar.
-3.  Select **Create users**, enter a username, and select **Save**.
+1.  In the [Aiven Console](https://console.aiven.io), open the Aiven for OpenSearch
+    service to add a user.
+1.  Click **Users** from the left sidebar.
+1.  Click **Create users**, enter a username, and click **Save**.
 
-By default, newly created users will be granted **full access rights**.
+By default, newly created users are granted **full access rights**.
 However, to limit their access, you can enable access control and
 specify an Access Control List (ACL) for them, defining the relevant
 permissions and patterns.
@@ -40,54 +44,57 @@ To enable access control for the Aiven for OpenSearch service through
 the [Aiven Console](https://console.aiven.io), go to the **Users**
 tab and toggle the **Access Control** switch to enable it.
 
-## Create user with access control
+## Create a user with access control
 
 To create a service new user with access control, follow these steps:
 
-1.  In your Aiven for OpenSearch service, select **Users** from the left
+1.  In your Aiven for OpenSearch service, click **Users** from the left
     sidebar.
-2.  Select **Create user**.
-3.  In the **Create service user** screen, enter a **username**.
-4.  Specify an **index** pattern and set the desired **permissions**.
-5.  Add multiple rules to the user by selecting **Add another rule**.
-6.  Select **Save** to finish, and view the new user in the list.
+1.  Click **Create user**.
+1.  In the **Create service user** screen, enter a **username**.
+1.  Specify an **Index pattern** and set the desired **permissions**.
+1.  To add multiple rules to the user,click **Add another rule**.
+1.  Click **Save**.
 
 :::note
 The password for service users is automatically generated and can be
 reset if necessary.
 :::
 
-After creating a new service user, the next step is for them to log in
-to the
-[OpenSearch Dashboard](/docs/products/opensearch/dashboards) using their assigned credentials. This will grant them
-access to the dashboard, where they can perform various actions based on
-their assigned permissions.
+After creating a new service user, log in to the
+[OpenSearch Dashboard](/docs/products/opensearch/dashboards) with the assigned
+credentials. This grants access to the dashboard, where they can perform actions
+based on their permissions.
 
 ## Manage users
 
-Aiven for OpenSearch provides several additional operations you can
-perform on service users, such as viewing, copying, resetting passwords,
-editing ACL rules, and deleting users.
+Aiven for OpenSearch provides several additional operations you can perform on
+service users.
 
-To access the additional operations, go to the **Users** tab
-within your Aiven for OpenSearch service, select the ellipsis (More
-options) in the respective user row, and choose the desired operation.
+To access these operations:
 
-:::note
-Deleting a service user will terminate all existing database sessions,
-and the user will lose access immediately.
+1. In your Aiven for OpenSearch service, click **Users** from the left sidebar.
+1. Click <ConsoleLabel name="actions"/> in the respective user row and
+   choose the desired operation:
+
+   - Click <ConsoleLabel name="show password"/> to view the password.
+   - Click <ConsoleLabel name="reset password"/> to reset the password.
+   - Click <ConsoleLabel name="reset password"/> to reset the password.
+   - Click <ConsoleLabel name="delete user"/> to delete the user.
+
+:::warning
+Deleting a service user terminates all existing database sessions, and the user
+loses access immediately.
 :::
 
 ## Disable access control
 
-Disabling access control for your Aiven for OpenSearch service will
-grant admin access to all users and override any previously defined user
-permissions. Therefore, it is essential to carefully consider the
-outcomes of disabling access control before proceeding.
+Disabling access control for your Aiven for OpenSearch service grants admin access to
+all users and overrides any previously defined user
+permissions. Carefully consider the outcomes of disabling access control
+before proceeding.
 
 To disable access control:
 
-1.  Select **Users** from the left sidebar within your Aiven for
-    OpenSearch service, toggle the **Access Control** switch to off.
-2.  Confirm the decision to disable access control by clicking
-    **Disable** when prompted.
+1.  In the **Users** tab, toggle the **Access Control** switch off.
+1.  Click **Disable** to confirm.

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -33,7 +33,7 @@ export default function ConsoleLabel({name}): ReactElement {
           <ConsoleIconWrapper icon={ConsoleIcons.projects} /> <b>Projects</b>
         </>
       );
-      case 'projectsettings':
+    case 'projectsettings':
       return (
         <>
           <ConsoleIconWrapper icon={ConsoleIcons.cog} /> <b>Settings</b>
@@ -310,6 +310,13 @@ export default function ConsoleLabel({name}): ReactElement {
       return (
         <>
           <ConsoleIconWrapper icon={ConsoleIcons.plus} /> <b>Plus</b>
+        </>
+      );
+    case 'showpassword':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.eyeOpen} />{' '}
+          <b>Show password</b>
         </>
       );
     default:


### PR DESCRIPTION
## Describe your changes

This PR updates the documentation to clarify that ACLs apply only to indices and do not control access to other OpenSearch APIs, including OpenSearch Dashboards. 
Issue reported in [MA-2772](https://aiven.atlassian.net/browse/MA-2772).


## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
