### PR TITLE
fix(platform): BYOC typos

### DIFF
--- a/docs/platform/howto/byoc/download-infrastructure-template.md
+++ b/docs/platform/howto/byoc/download-infrastructure-template.md
@@ -26,7 +26,7 @@ Download a Terraform template that defines the infrastructure of your [custom cl
 
 ## Download the template via CLI
 
-[Run the `avn byoc templete terraform get-template` command](/docs/tools/cli/byoc#avn-byoc-templete-terraform-get-template)
+[Run the `avn byoc template terraform get-template` command](/docs/tools/cli/byoc#avn-byoc-template-terraform-get-template)
 to download your infrastructure template.
 
 ## Related pages

--- a/docs/tools/cli/byoc.md
+++ b/docs/tools/cli/byoc.md
@@ -111,7 +111,7 @@ other than the ones you've just granted using this command.
 
 Manage a custom cloud Terraform infrastructure template.
 
-### `avn byoc templete terraform get-template`
+### `avn byoc template terraform get-template`
 
 Downloads a custom cloud Terraform template.
 
@@ -120,7 +120,7 @@ Downloads a custom cloud Terraform template.
 | `--organization-id` | Yes      | Identifier of an organization where the custom cloud is located           |
 | `--byoc-id`         | Yes      | Identifier of the custom cloud for which to download a Terraform template |
 
-### `avn byoc templete terraform get-vars`
+### `avn byoc template terraform get-vars`
 
 Downloads a custom cloud Terraform variables file.
 


### PR DESCRIPTION
## Describe your changes

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
