### PR TITLE
fix: clickhouse spelling

### DIFF
--- a/docs/products/clickhouse/howto/connect-with-go.md
+++ b/docs/products/clickhouse/howto/connect-with-go.md
@@ -20,7 +20,7 @@ go get github.com/ClickHouse/clickhouse-go/v2
 
 :::note
 If the version of Go is lower than 1.18.4 (visible via `go version`),
-you need to install an older version of `clickhouse-go`. For this
+install an older version of `clickhouse-go`. For this
 purpose, use command
 `go get github.com/ClickHouse/clickhouse-go/v2@v2.2`.
 :::
@@ -191,6 +191,6 @@ configured. You can proceed to
 -   For instructions on how to configure connection settings, see
     [Connection
     Details](https://clickhouse.com/docs/en/integrations/go#connection-details).
--   For information on how to connect to the Aiven for Clickhouse
+-   For information on how to connect to the Aiven for ClickHouse
     service with the ClickHouse client, see
     [Connect with the ClickHouse client](/docs/products/clickhouse/howto/connect-with-clickhouse-cli).

--- a/docs/products/clickhouse/howto/connect-with-java.md
+++ b/docs/products/clickhouse/howto/connect-with-java.md
@@ -79,6 +79,6 @@ Now you have your service connection set up and you can proceed to
 
 ## Related pages
 
-For information on how to connect to the Aiven for Clickhouse service
+For information on how to connect to the Aiven for ClickHouse service
 with the ClickHouse client, see
 [Connect with the ClickHouse client](/docs/products/clickhouse/howto/connect-with-clickhouse-cli).

--- a/docs/products/clickhouse/howto/connect-with-nodejs.md
+++ b/docs/products/clickhouse/howto/connect-with-nodejs.md
@@ -58,6 +58,6 @@ Now you have your service connection set up and you can proceed to
 
 ## Related pages
 
-For information on how to connect to the Aiven for Clickhouse service
+For information on how to connect to the Aiven for ClickHouse service
 with the ClickHouse client, see
 [Connect with the ClickHouse client](/docs/products/clickhouse/howto/connect-with-clickhouse-cli).

--- a/docs/products/clickhouse/howto/connect-with-python.md
+++ b/docs/products/clickhouse/howto/connect-with-python.md
@@ -3,8 +3,7 @@ title: Connect to the Aiven for ClickHouse® service with Python
 ---
 
 To connect to your Aiven for ClickHouse® service with Python, you can
-use either the native protocol or the HTTPS protocol. This article
-provides you with instructions for both scenarios.
+use either the native protocol or the HTTPS protocol.
 
 ## Connect with the native protocol
 
@@ -25,7 +24,7 @@ the following variables:
  | `PASSOWRD`    | `Password` for the ClickHouse connection available in the Aiven console: Service **Overview** > **Connection information** > **ClickHouse native** |
  | `HOST`        | `Host` for the ClickHouse connection available in the Aiven console: Service **Overview** > **Connection information** > **ClickHouse native**     |
  | `NATIVE_PORT` | `Port` for the ClickHouse connection available in the Aiven console: Service **Overview** > **Connection information** > **ClickHouse native**     |
- | `query`       | Query you want to run, for example `SELECT 1`                                                                                                      |
+ | `query`       | Query to run, for example `SELECT 1`                                                                                                      |
 
 ### Connect to the service
 
@@ -53,7 +52,7 @@ the following variables:
 |         Variable          |                                                                           Description                                                                           |
 |---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `https://HOST:HTTPS_PORT` | `Host` and `Port` for the ClickHouse connection available in the Aiven console: Service **Overview** > **Connection information** > **ClickHouse HTTPS & JDBC** |
-| `query`                   | Query you want to run, for example `SELECT 1`                                                                                                                   |
+| `query`                   | Query to run, for example `SELECT 1`                                                                                                                   |
 | `X-ClickHouse-Database`   | `Database Name` available in the Aiven console: Service **Overview** > **Connection information** > **ClickHouse HTTPS & JDBC**, for example `system`           |
 | `X-ClickHouse-User`       | `User` for the ClickHouse connection available in the Aiven console: Service **Overview** > **Connection information** > **ClickHouse HTTPS & JDBC**            |
 | `X-ClickHouse-Key`        | `Password` for the ClickHouse connection available in the Aiven console: Service **Overview** > **Connection information** > **ClickHouse HTTPS & JDBC**        |
@@ -81,6 +80,6 @@ print(response.text)
 Now you have your service connection set up and you can proceed to
 [uploading data into your database](/docs/products/clickhouse/howto/load-dataset).
 
-For information on how to connect to the Aiven for Clickhouse service
+For information on how to connect to the Aiven for ClickHouse service
 with the ClickHouse client, see
 [Connect with the ClickHouse client](/docs/products/clickhouse/howto/connect-with-clickhouse-cli).

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1271,7 +1271,7 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
-          label: 'Clickhouse',
+          label: 'ClickHouse',
           link: {
             type: 'doc',
             id: 'products/clickhouse',


### PR DESCRIPTION
## Describe your changes
Clickhouse --> ClickHouse

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
