### PR TITLE
update(platform): bring back LA for BTAR

### DIFF
--- a/docs/platform/concepts/backup-to-another-region.md
+++ b/docs/platform/concepts/backup-to-another-region.md
@@ -1,9 +1,15 @@
 ---
 title: About backup to another region for Aiven services
+limited: true
 sidebar_label: About backup to another region
 ---
 
 In addition to the primary service backup, you can have a secondary backup in an alternative location.
+
+:::important
+This feature is in [limited availability](/docs/platform/concepts/beta_services).
+Contact your account team to enable it.
+:::
 
 ## About BTAR
 

--- a/docs/platform/howto/btar/disable-backup-to-another-region.md
+++ b/docs/platform/howto/btar/disable-backup-to-another-region.md
@@ -1,6 +1,7 @@
 ---
 title: Delete a cross-region backup
 sidebar_label: Delete cross-region backup
+limited: true
 ---
 
 Delete an [additional service backup](/docs/platform/concepts/backup-to-another-region) [created](/docs/platform/howto/btar/enable-backup-to-another-region) in a region different from your primary backup region.

--- a/docs/platform/howto/btar/enable-backup-to-another-region.md
+++ b/docs/platform/howto/btar/enable-backup-to-another-region.md
@@ -1,6 +1,7 @@
 ---
 title: Add a backup to another region
 sidebar_label: Add cross-region backup
+limited: true
 ---
 
 Enable [the backup to another region (BTAR) feature](/docs/platform/concepts/backup-to-another-region) and create an additional cross-region service backup on top of a regular backup stored in the region where your service is hosted.
@@ -14,7 +15,8 @@ To add an additional service backup for your service, you can use the Aiven
 
 ## Prerequisites
 
-- Enable BTAR for your organization by [contacting the sales team](mailto:sales@aiven.io).
+- This feature is in [limited availability](/docs/platform/concepts/beta_services).
+  Enable it by contacting your account team.
 - Make sure you have at least one running Aiven for MySQL® or Aiven for PostgreSQL® service.
 - Depending on your preferred tool to manage BTAR with, make sure you can access or use:
 

--- a/docs/platform/howto/btar/manage-backup-to-another-region.md
+++ b/docs/platform/howto/btar/manage-backup-to-another-region.md
@@ -1,6 +1,7 @@
 ---
 title: Manage a cross-region backup
 sidebar_label: Manage cross-region backup
+limited: true
 ---
 
 For a service that has the [backup to another region (BTAR)](/docs/platform/concepts/backup-to-another-region) feature [enabled](/docs/platform/howto/btar/enable-backup-to-another-region), you can check the service backup status, change the backup region, monitor the replication lag, fork and restore using [the cross-region backup](/docs/platform/concepts/backup-to-another-region), or migrate to another cloud or region.


### PR DESCRIPTION
BTAR is back to LA from GA. Bringing back the relevant info.
https://aiven.atlassian.net/browse/AD-2586

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
