### PR TITLE
fix: Redirect for support topic

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -66,3 +66,6 @@
 /platform/howto/enable-aiven-password                                  https://aiven.io/docs/platform/reference/password-policy
 /tools/terraform/reference/cookbook/kafka-connect-terraform-recipe     https://aiven.io/docs/tools/terraform/get-started
 /tools/terraform/reference/cookbook/multicloud-postgresql-recipe       https://aiven.io/developer/multicloud-postgresql-terraform
+
+
+/platform/howto/project-support-center                   https://aiven.io/docs/platform/howto/support


### PR DESCRIPTION
## Describe your changes
Fix redirect for support topic. The support centre link in this [article](https://aiven.io/support-services) points to an older support page. 

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
