### PR TITLE
fix: Kafka tiered storage GA

### DIFF
--- a/docs/products/kafka/concepts/kafka-tiered-storage.md
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.md
@@ -89,9 +89,6 @@ You set a local retention time of 10 TB. Consider the following:
 
 - You pay a fixed monthly cost for the local storage allocated to your service,
   which includes the 10 TB retained locally.
-- You are charged for storing 40 TB of data in S3, even if some data is available locally
-  within the most recent 10 TB.This is because data is automatically transferred to S3,
-  and billing is based on the highest usage level within each hour.
 - You are charged for storing **approximately 40 TB** of data in S3, even if some data
   is available locally within the most recent 10 TB. This is because data is
   automatically transferred to S3, and billing is based on the highest usage

--- a/docs/products/kafka/concepts/kafka-tiered-storage.md
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.md
@@ -38,7 +38,7 @@ Tiered storage offers multiple benefits, including:
 - **Transparency:** Even older Kafka clients can benefit from tiered
   storage without needing to be explicitly aware of it.
 
-## When to and why use it
+## When and why use it
 
 Understanding when and why to use tiered storage in Aiven for Apache
 Kafka helps you maximize its benefits, particularly around cost

--- a/docs/products/kafka/concepts/kafka-tiered-storage.md
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.md
@@ -10,12 +10,13 @@ can store data on specific topics indefinitely without running out of space. Onc
 you configure tiered storage per topic, which gives you granular control over
 your data storage.
 
-:::note
+::note
 
--  Tiered storage for Aiven for Apache Kafka® is supported starting
-   from Apache Kafka® version 3.6.
--  Tiered storage for Aiven for Apache Kafka® is not available for
-   startup-2 plans.
+- Aiven for Apache Kafka® supports tiered storage starting from Apache Kafka® version
+  3.6 or later. It is recommended to upgrade to the latest default version and apply
+  [maintenance updates](/docs/platform/concepts/maintenance-window#maintenance-updates)
+  when using tiered storage for the latest fixes and improvements.
+- Tiered storage is not available on startup-2 plans.
 
 :::
 

--- a/docs/products/kafka/concepts/kafka-tiered-storage.md
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.md
@@ -85,8 +85,8 @@ AWS S3. This means you pay for:
 Imagine having a tiered topic with 40 TB of data for local and tiered storage. You set a
 local retention time of 7 days. Consider the following:
 
-- You will pay a fixed monthly cost for the 40 TB of local storage.
-- You will be charged for storing 40 TB of data in S3, even if some data is over 7 days.
+- You pay a fixed monthly cost for the 40 TB of local storage.
+- You are charged for storing 40 TB of data in S3, even if some data is over 7 days.
   This is because data is automatically transferred to S3, and billing is based on the
   highest usage level within each hour.
 
@@ -95,7 +95,6 @@ A tiered topic means all data is eventually stored in S3. If you plan for 80 TB 
 tiered topic, expect to pay for 80 TB on S3 regardless of local retention settings. Even
 if you configure retention to keep 40 TB local and 40 TB tiered, eager loading means up
 to 78 TB of the 80 TB can reside in the object store.
-
 :::
 
 ### BYOC (Bring your own cloud) billing
@@ -103,13 +102,12 @@ to 78 TB of the 80 TB can reside in the object store.
 BYOC billing for tiered storage can vary depending on your specific agreement
 with Aiven. Potential scenarios include:
 
-- **Customer responsibility:** In all BYOC setups, you are responsible for the full
+- **Customer costs:** In all BYOC setups, you are responsible for the full
   cost of the underlying cloud storage used by tiered storage. This includes the
-  entire storage used, regardless of local retention settings (for example,
-  80 TB in this example).
-- **Aiven management fee:** Typically, you also pay the Aiven management fee
-  for the data stored in S3 in addition to the underlying S3 storage costs. However,
-there might be scenarios where the management fee does not apply.
+  entire storage used, regardless of local retention settings (80 TB in this example).
+- **Aiven management fee:** In addition to the underlying S3 storage costs, you also pay
+  an Aiven management fee for the data stored in S3. This fee is based on the amount of
+  storage added via tiered storage
 
 ## Related pages
 

--- a/docs/products/kafka/concepts/kafka-tiered-storage.md
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.md
@@ -5,10 +5,10 @@ title: Tiered storage in Aiven for Apache Kafka® overview
 Tiered storage in Aiven for Apache Kafka® helps you manage data more effectively by using two different storage types: local disk and remote cloud storage solutions like AWS S3, Google Cloud Storage, and Azure Blob Storage.
 
 This feature lets you allocate frequently accessed data to high-speed local disks while
-moving less critical or infrequently accessed data to more cost-effective remote storage
-solutions. You can store data on specific topics indefinitely without running out of
-space. Once enabled, you configure tiered storage per topic, giving you granular
-control over your data storage needs.
+keeping an extended data retention on more cost-effective remote storage solutions. You
+can store data on specific topics indefinitely without running out of space. Once
+enabled, you configure tiered storage per topic, giving you granular control over
+your data storage needs.
 
 :::note
 
@@ -69,33 +69,29 @@ Charges are based on the highest usage level within each hour.
 
 ### Tiered storage charges
 
-Aiven charges for tiered storage data based on the data transmitted and stored in
+Aiven charges for tiered storage data based on the data stored in remote tier, such as
 AWS S3. This means you pay for:
 
-- **Data transferred to S3:** Aiven automatically transfers data to S3 based on your
-  tier configuration, regardless of local storage retention settings.
 - **Data stored in S3:** Billing is based on the highest amount of data stored in S3
   within each hour, not the total amount stored over the hour.
 - **Local storage on the Aiven platform:** Local storage has a fixed cost based on the
   provisioned capacity. You pay a set amount each month for a fixed amount of
   local storage.
 
+Tiered Storage is designed to transfer **all** topic data to the remote tier, except
+for the active log segment where the latest data is being appended. This transfer occurs
+regardless of local storage retention settings.
+
 #### Example
 
-Imagine having a tiered topic with 40 TB of data for local and tiered storage. You set a
-local retention time of 7 days. Consider the following:
+Imagine having a tiered topic with 40 TB of data and with tiered storage enabled.
+You set a local retention time of 10 TB. Consider the following:
 
-- You pay a fixed monthly cost for the 40 TB of local storage.
-- You are charged for storing 40 TB of data in S3, even if some data is over 7 days.
-  This is because data is automatically transferred to S3, and billing is based on the
-  highest usage level within each hour.
-
-:::note
-A tiered topic means all data is eventually stored in S3. If you plan for 80 TB on a
-tiered topic, expect to pay for 80 TB on S3 regardless of local retention settings. Even
-if you configure retention to keep 40 TB local and 40 TB tiered, eager loading means up
-to 78 TB of the 80 TB can reside in the object store.
-:::
+- You pay a fixed monthly cost for the local storage allocated to your service,
+  which includes the 10 TB retained locally.
+- You are charged for storing 40 TB of data in S3, even if some data is available locally
+  within the most recent 10 TB.This is because data is automatically transferred to S3,
+  and billing is based on the highest usage level within each hour.
 
 ### BYOC (Bring your own cloud) billing
 

--- a/docs/products/kafka/concepts/kafka-tiered-storage.md
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.md
@@ -101,7 +101,7 @@ You set a local retention time of 10 TB. Consider the following:
 
 ### BYOC (Bring your own cloud) billing
 
-BYOC billing for tiered storage can vary depending on your specific agreement
+[BYOC](/docs/platform/concepts/byoc) billing for tiered storage can vary depending on your specific agreement
 with Aiven. Potential scenarios include:
 
 - **Customer costs:** In all BYOC setups, you are responsible for the full

--- a/docs/products/kafka/concepts/kafka-tiered-storage.md
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.md
@@ -1,18 +1,13 @@
 ---
 title: Tiered storage in Aiven for Apache Kafka® overview
-early: true
 ---
 
-Tiered storage in Aiven for Apache Kafka® enables more effective data
-management by utilizing two different storage types--local disk and
-remote cloud storage solutions such as AWS S3, Google Cloud Storage, and
-Azure Blob Storage. This feature offers a tailored approach to data
-storage, allowing you to allocate frequently accessed data to high-speed
-local disks while offloading less critical or infrequently accessed data
-to more cost-effective remote storage solutions. Tiered storage enables
-you to indefinitely store data on specific topics without running out of
-space. Once enabled, it is configured per topic, giving you granular
-control over data storage needs.
+Tiered storage in Aiven for Apache Kafka® helps you manage data more effectively by using two different storage types: local disk and remote cloud storage solutions like AWS S3, Google Cloud Storage, and Azure Blob Storage.
+This feature lets you allocate frequently accessed data to high-speed local disks while
+moving less critical or infrequently accessed data to more cost-effective remote storage
+solutions. You can store data on specific topics indefinitely without running out of
+space. Once enabled, you configure tiered storage per topic, giving you granular
+control over your data storage needs.
 
 :::note
 
@@ -27,58 +22,93 @@ control over data storage needs.
 
 Tiered storage offers multiple benefits, including:
 
--   **Scalability:** With tiered storage in Aiven for Apache Kafka,
-    storage and computing are effectively decoupled, enabling them to
-    scale independently. This flexibility ensures that while the storage
-    capacity can expand almost infinitely with cloud solutions, compute
-    resources can also be adjusted based on demand, thereby eliminating any
-    concerns about storage or processing limitations.
--   **Cost efficiency:** By moving less frequently accessed data to a
-    cost-effective storage tier, you can achieve significant financial
-    savings.
--   **Operational speed:** With the bulk of data offloaded to remote
-    storage, service rebalancing in Aiven for Apache Kafka becomes
-    faster, making for a smoother operational experience.
--   **Infinite data retention:** With the scalability of cloud storage,
-    you can achieve unlimited data retention, valuable for analytics and
-    compliance.
--   **Transparency:** Even older Kafka clients can benefit from tiered
-    storage without needing to be explicitly aware of it.
+- **Scalability:** Tiered storage in Aiven for Apache Kafka decouples storage and
+  computing, allowing them to scale independently. Storage capacity can expand almost
+  infinitely with cloud solutions, and compute resources can adjust based on demand,
+  eliminating concerns about storage or processing limitations.
+- **Cost efficiency:** By moving less frequently accessed data to a
+  cost-effective storage tier, you can achieve significant financial
+  savings.
+- **Operational speed:** With the bulk of data offloaded to remote
+  storage, service rebalancing in Aiven for Apache Kafka becomes
+  faster, making for a smoother operational experience.
+- **Infinite data retention:** Offloading bulk data to remote storage speeds up service
+  rebalancing in Aiven for Apache Kafka, enhancing operational efficiency.
+- **Transparency:** Even older Kafka clients can benefit from tiered
+  storage without needing to be explicitly aware of it.
 
 ## When to and why use it
 
 Understanding when and why to use tiered storage in Aiven for Apache
-Kafka will help you maximize its benefits, particularly around cost
+Kafka helps you maximize its benefits, particularly around cost
 savings and system performance.
 
 **Scenarios for use:**
 
--   **Long-term data retention**: Many organizations require large-scale
-    data storage for extended periods, either for regulatory compliance
-    or historical data analysis. Cloud services provide an almost
-    limitless storage capacity, making it possible to keep data
-    accessible for as long as required at a reasonable cost. This is
-    where tiered storage becomes especially valuable.
--   **High-speed data ingestion**: Tiered storage can offer a solution
-    when dealing with unpredictable or sudden influxes of data. By
-    supplementing the local disks with cloud storage, sudden increases
-    in incoming data can be managed, ensuring optimum system
-    performance.
--   **Unlock unexplored opportunities:** Tiered storage in Aiven for
-    Apache Kafka addresses existing storage challenges and opens the
-    door to new and innovative use cases that were once unfeasible or
-    cost-prohibitive. By eliminating traditional storage limitations,
-    organizations gain the flexibility to support a wide range of
-    applications and workflows, even those where Apache Kafka might have
-    been considered impractical before. We encourage users to leverage
-    this newfound flexibility to think creatively and redefine their
-    experience with Apache Kafka.
+- **Long-term data retention**: Many organizations require large-scale
+  data storage for extended periods, either for regulatory compliance
+  or historical data analysis. Cloud services provide an almost
+  limitless storage capacity, making it possible to keep data
+  accessible for as long as required at a reasonable cost. This is
+  where tiered storage becomes especially valuable.
+- **High-speed data ingestion**: Tiered storage can manage unpredictable or sudden data
+  influxes by supplementing local disks with cloud storage, ensuring optimal performance.
+- **Unlock unexplored opportunities:**Tiered storage in Aiven for Apache Kafka addresses
+  current storage challenges and enables new and innovative use cases that were
+  previously impractical or too expensive. By eliminating traditional storage
+  limitations, organizations gain the flexibility to support a wide range of
+  applications and workflows, including scenarios where using Apache Kafka was once
+  deemed impractical. This flexibility encourages creative thinking and redefines the
+  experience with Apache Kafka.
 
-## Pricing
+## Pricing and charges
 
-Tiered storage costs are determined by the amount of remote storage
-used, measured in GB/hour. The highest usage level within each hour is
-the basis for calculating charges.
+Tiered storage costs depend on the amount of remote storage used, measured in GB/hour.
+Charges are based on the highest usage level within each hour.
+
+### Tiered storage charges
+
+Aiven charges for tiered storage data based on the data transmitted and stored in
+AWS S3. This means you pay for:
+
+- **Data transferred to S3:** Aiven automatically transfers data to S3 based on your
+  tier configuration, regardless of local storage retention settings.
+- **Data stored in S3:** Billing is based on the highest amount of data stored in S3
+  within each hour, not the total amount stored over the hour.
+- **Local storage on the Aiven platform:** Local storage has a fixed cost based on the
+  provisioned capacity. You pay a set amount each month for a fixed amount of
+  local storage.
+
+#### Example
+
+Imagine having a tiered topic with 40 TB of data for local and tiered storage. You set a
+local retention time of 7 days. Consider the following:
+
+- You will pay a fixed monthly cost for the 40 TB of local storage.
+- You will be charged for storing 40 TB of data in S3, even if some data is over 7 days.
+  This is because data is automatically transferred to S3, and billing is based on the
+  highest usage level within each hour.
+
+:::note
+A tiered topic means all data is eventually stored in S3. If you plan for 80 TB on a
+tiered topic, expect to pay for 80 TB on S3 regardless of local retention settings. Even
+if you configure retention to keep 40 TB local and 40 TB tiered, eager loading means up
+to 78 TB of the 80 TB can reside in the object store.
+
+:::
+
+### BYOC (Bring your own cloud) billing
+
+BYOC billing for tiered storage can vary depending on your specific agreement
+with Aiven. Potential scenarios include:
+
+- **Customer responsibility:** In all BYOC setups, you are responsible for the full
+  cost of the underlying cloud storage used by tiered storage. This includes the
+  entire storage used, regardless of local retention settings (for example,
+  80 TB in this example).
+- **Aiven management fee:** Typically, you also pay the Aiven management fee
+  for the data stored in S3 in addition to the underlying S3 storage costs. However,
+there might be scenarios where the management fee does not apply.
 
 ## Related pages
 

--- a/docs/products/kafka/concepts/kafka-tiered-storage.md
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.md
@@ -54,7 +54,7 @@ savings and system performance.
   where tiered storage becomes especially valuable.
 - **High-speed data ingestion**: Tiered storage can manage unpredictable or sudden data
   influxes by supplementing local disks with cloud storage, ensuring optimal performance.
-- **Unlock unexplored opportunities:**Tiered storage in Aiven for Apache Kafka addresses
+- **Unlock unexplored opportunities:** Tiered storage in Aiven for Apache Kafka addresses
   current storage challenges and enables new and innovative use cases that were
   previously impractical or too expensive. By eliminating traditional storage
   limitations, organizations gain the flexibility to support a wide range of
@@ -92,6 +92,15 @@ You set a local retention time of 10 TB. Consider the following:
 - You are charged for storing 40 TB of data in S3, even if some data is available locally
   within the most recent 10 TB.This is because data is automatically transferred to S3,
   and billing is based on the highest usage level within each hour.
+- You are charged for storing **approximately 40 TB** of data in S3, even if some data
+  is available locally within the most recent 10 TB. This is because data is
+  automatically transferred to S3, and billing is based on the highest usage
+  level within each hour.
+
+  :::note
+  The estimated storage size of 40 TB excludes the active log segments, which are only
+  stored locally. For more information, see [local vs. remote data retention](/docs/products/kafka/concepts/tiered-storage-how-it-works#local-vs-remote-data-retention).
+  :::
 
 ### BYOC (Bring your own cloud) billing
 

--- a/docs/products/kafka/concepts/kafka-tiered-storage.md
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.md
@@ -6,9 +6,9 @@ Tiered storage in Aiven for Apache Kafka® helps you manage data more effectivel
 
 This feature lets you allocate frequently accessed data to high-speed local disks while
 keeping an extended data retention on more cost-effective remote storage solutions. You
-can store data on specific topics indefinitely without running out of space. Once
-enabled, you configure tiered storage per topic, giving you granular control over
-your data storage needs.
+can store data on specific topics indefinitely without running out of space. Once enabled,
+you configure tiered storage per topic, which gives you granular control over
+your data storage.
 
 :::note
 
@@ -35,8 +35,8 @@ Tiered storage offers multiple benefits, including:
   faster, making for a smoother operational experience.
 - **Infinite data retention:** Offloading bulk data to remote storage speeds up service
   rebalancing in Aiven for Apache Kafka, enhancing operational efficiency.
-- **Transparency:** Even older Kafka clients can benefit from tiered
-  storage without needing to be explicitly aware of it.
+- **Transparency:** Even older Kafka clients can benefit from tiered storage even
+  if unaware of it.
 
 ## When and why use it
 
@@ -53,7 +53,7 @@ savings and system performance.
   accessible for as long as required at a reasonable cost. This is
   where tiered storage becomes especially valuable.
 - **High-speed data ingestion**: Tiered storage can manage unpredictable or sudden data
-  influxes by supplementing local disks with cloud storage, ensuring optimal performance.
+  influxes by supplementing local disks with cloud storage, to ensure optimal performance.
 - **Unlock unexplored opportunities:** Tiered storage in Aiven for Apache Kafka addresses
   current storage challenges and enables new and innovative use cases that were
   previously impractical or too expensive. By eliminating traditional storage
@@ -109,7 +109,7 @@ with Aiven. Potential scenarios include:
   entire storage used, regardless of local retention settings (80 TB in this example).
 - **Aiven management fee:** In addition to the underlying S3 storage costs, you also pay
   an Aiven management fee for the data stored in S3. This fee is based on the amount of
-  storage added via tiered storage
+  storage added via tiered storage.
 
 ## Related pages
 

--- a/docs/products/kafka/concepts/kafka-tiered-storage.md
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.md
@@ -10,14 +10,12 @@ can store data on specific topics indefinitely without running out of space. Onc
 you configure tiered storage per topic, which gives you granular control over
 your data storage.
 
-::note
-
+:::note
 - Aiven for Apache Kafka® supports tiered storage starting from Apache Kafka® version
   3.6 or later. It is recommended to upgrade to the latest default version and apply
   [maintenance updates](/docs/platform/concepts/maintenance-window#maintenance-updates)
   when using tiered storage for the latest fixes and improvements.
 - Tiered storage is not available on startup-2 plans.
-
 :::
 
 ## Benefits of tiered storage

--- a/docs/products/kafka/concepts/kafka-tiered-storage.md
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.md
@@ -3,6 +3,7 @@ title: Tiered storage in Aiven for Apache Kafka® overview
 ---
 
 Tiered storage in Aiven for Apache Kafka® helps you manage data more effectively by using two different storage types: local disk and remote cloud storage solutions like AWS S3, Google Cloud Storage, and Azure Blob Storage.
+
 This feature lets you allocate frequently accessed data to high-speed local disks while
 moving less critical or infrequently accessed data to more cost-effective remote storage
 solutions. You can store data on specific topics indefinitely without running out of

--- a/docs/products/kafka/concepts/tiered-storage-guarantees.md
+++ b/docs/products/kafka/concepts/tiered-storage-guarantees.md
@@ -1,17 +1,15 @@
 ---
 title: Guarantees
-early: true
 ---
 
 With Aiven for Apache Kafka®'s tiered storage, there are two primary
 types of data retention guarantees: *total retention* and *local
 retention*.
 
-**Total retention**: Tiered storage ensures that your data will be
-available up to the limit defined by the total retention threshold,
-regardless of whether it is stored locally or remotely. This means that
-your data will not be deleted until the total retention threshold,
-whether on local or remote storage, is reached.
+**Total retention**: Tiered storage ensures that your data remains available up to the
+limit defined by the total retention threshold, whether stored locally or remotely.
+This means your data is not deleted until reaching the total retention threshold,
+regardless of storage location.
 
 **Local retention**: Log segments are only removed from local storage
 after successfully being uploaded to remote storage, even if the data
@@ -23,16 +21,15 @@ Let's say you have a topic with a **total retention threshold** of
 **1000 GB** and a **local retention threshold** of **200 GB**. This
 means that:
 
--   All data for the topic will be retained, regardless of whether it is
-    stored locally or remotely, as long as the total size of the data
-    does not exceed 1000 GB.
--   If tiered storage is enabled per topic, older segments will be
-    uploaded immediately to remote storage, irrespective of whether the
-    local retention threshold of 200 GB is exceeded. Data will be
-    deleted from local storage only after it has been safely transferred
-    to remote storage.
--   If the total size of the data exceeds 1000 GB, Apache Kafka will
-    begin deleting the oldest data from remote storage.
+- All data for the topic is retained, regardless of whether it is stored locally or
+  remotely, as long as the total size of the data does not exceed 1000 GB.
+- If tiered storage is enabled per topic, older segments are
+  uploaded immediately to remote storage, irrespective of whether the
+  local retention threshold of 200 GB is exceeded. Data is deleted from local storage
+  only after it has been safely transferred
+  to remote storage.
+- If the total size of the data exceeds 1000 GB, Apache Kafka begins deleting the
+  oldest data from remote storage.
 
 ## Related pages
 

--- a/docs/products/kafka/concepts/tiered-storage-guarantees.md
+++ b/docs/products/kafka/concepts/tiered-storage-guarantees.md
@@ -2,8 +2,7 @@
 title: Guarantees
 ---
 
-With Aiven for Apache Kafka®'s tiered storage, there are two primary
-types of data retention guarantees: *total retention* and *local
+With Aiven for Apache Kafka®'s tiered storage, there are two primary types of data retention guarantees: *total retention* and *local
 retention*.
 
 **Total retention**: Tiered storage ensures that your data remains available up to the

--- a/docs/products/kafka/concepts/tiered-storage-guarantees.md
+++ b/docs/products/kafka/concepts/tiered-storage-guarantees.md
@@ -10,7 +10,7 @@ This means your data is not deleted until reaching the total retention threshold
 regardless of storage location.
 
 **Local retention**: Log segments are only removed from local storage
-after successfully uploaded to remote storage, even if the data exceeds the local
+after being successfully uploaded to remote storage, even if the data exceeds the local
 retention threshold.
 
 ## Example
@@ -26,7 +26,7 @@ means that:
   local retention threshold of 200 GB is exceeded. Data is deleted from local storage
   only after it has been safely transferred
   to remote storage.
-- If the total size of the data exceeds 1000 GB, Apache Kafka begins deleting the
+- If the total size of the data exceeds 1000 GB, Aiven for Apache Kafka begins deleting the
   oldest data from remote storage.
 
 ## Related pages

--- a/docs/products/kafka/concepts/tiered-storage-guarantees.md
+++ b/docs/products/kafka/concepts/tiered-storage-guarantees.md
@@ -2,8 +2,7 @@
 title: Guarantees
 ---
 
-With Aiven for Apache Kafka®'s tiered storage, there are two primary types of data retention guarantees: *total retention* and *local
-retention*.
+With Aiven for Apache Kafka®'s tiered storage, there are two primary types of data retention guarantees: **total retention** and **local retention**.
 
 **Total retention**: Tiered storage ensures that your data remains available up to the
 limit defined by the total retention threshold, whether stored locally or remotely.
@@ -11,8 +10,8 @@ This means your data is not deleted until reaching the total retention threshold
 regardless of storage location.
 
 **Local retention**: Log segments are only removed from local storage
-after successfully being uploaded to remote storage, even if the data
-exceeds the local retention threshold.
+after successfully uploaded to remote storage, even if the data exceeds the local
+retention threshold.
 
 ## Example
 
@@ -20,10 +19,10 @@ Let's say you have a topic with a **total retention threshold** of
 **1000 GB** and a **local retention threshold** of **200 GB**. This
 means that:
 
-- All data for the topic is retained, regardless of whether it is stored locally or
-  remotely, as long as the total size of the data does not exceed 1000 GB.
+- All data for the topic is retained,  whether stored locally or remotely, as long as
+  the total size does not exceed 1000 GB.
 - If tiered storage is enabled per topic, older segments are
-  uploaded immediately to remote storage, irrespective of whether the
+  uploaded immediately to remote storage, regardless of whether the
   local retention threshold of 200 GB is exceeded. Data is deleted from local storage
   only after it has been safely transferred
   to remote storage.

--- a/docs/products/kafka/concepts/tiered-storage-how-it-works.md
+++ b/docs/products/kafka/concepts/tiered-storage-how-it-works.md
@@ -3,25 +3,23 @@ title: How tiered storage works in Aiven for Apache Kafka®
 sidebar_label: How it works
 ---
 
-Aiven for Apache Kafka® tiered storage is a feature that optimizes data management across two distinct storage tiers:
+Aiven for Apache Kafka® tiered storage optimizes data management across two distinct storage tiers:
 
--   **Local tier**: Primarily consists of faster and typically more
-    expensive storage solutions like solid-state drives (SSDs).
--   **Remote tier**: Relies on slower, cost-effective options like cloud
-    object storage.
+- **Local tier**: Uses faster, typically more expensive storage solutions
+  like solid-state drives (SSDs).
+- **Remote tier**: Uses slower, cost-effective options like cloud object storage.
 
 In Aiven for Apache Kafka's tiered storage architecture, **remote storage** refers to
 storage options external to the Kafka broker's
 local disk. This typically includes cloud-based or self-hosted object
 storage solutions like AWS S3 and Google Cloud Storage. Although
 network-attached block storage solutions like AWS EBS are technically
-external to the Kafka broker, Apache Kafka considers them local storage
+external to the Apache Kafka broker, Apache Kafka considers them local storage
 within its tiered storage architecture.
 
-Tiered storage operates in a way that is seamless for both Apache Kafka
-producers and consumers. This means that producers and consumers
-interact with Apache Kafka in the same way, regardless of whether tiered
-storage is enabled or not.
+Tiered storage operates seamlessly for both Apache Kafka producers and consumers,
+meaning they interact with Apache Kafka the same way, whether tiered storage is
+enabled or not.
 
 Administrators can configure tiered storage per topic by defining the
 retention period and retention bytes to specify how much data is retained on the local
@@ -30,8 +28,9 @@ disk instead of remote storage.
 ## Local vs. remote data retention
 
 When tiered storage is enabled, data produced to a topic is initially stored on the
-local disk of the Kafka broker. All but the active (open) segment is then asynchronously
-and orderly transferred to remote storage, regardless of the local retention settings.
+local disk of the Apache Kafka broker. All but the active (open) segment is then
+asynchronously and orderly transferred to remote storage, regardless of the
+local retention settings.
 During periods of high data ingestion or transient errors, such as network connectivity
 issues, local storage might temporarily hold more data than specified by the local
 retention threshold. This continues until the remote tier is back online, at which
@@ -45,14 +44,14 @@ exceeding the retention threshold are removed.
 Data is organized into segments, which are uploaded to remote storage
 individually. The active (newest) segment remains in local storage,
 which means that the segment size can also influence local data
-retention. For instance, if the local retention threshold is 1 GB, but the segment
-size is 2 GB, the local storage exceeds the 1 GB limit until the active segment is
-rolled over and uploaded to remote storage.
+retention. For example, if the local retention threshold is 1 GB, but the segment size
+is 2 GB, the local storage exceeds the 1 GB limit until the active segment is rolled
+over and uploaded to remote storage.
 
 ## Asynchronous uploads and replication
 
 Data is transferred to remote storage asynchronously and does not
-interfere with the producer activity. While the Kafka broker aims to
+interfere with the producer activity. While the Apache Kafka broker aims to
 move data as swiftly as possible, certain conditions, such as high
 ingestion rate or connectivity issues, can cause more data to be stored
 in the local storage than the specified local retention policy.
@@ -70,7 +69,7 @@ downloads and caches these records locally. This allows for quicker
 access in subsequent retrieval operations.
 
 Aiven allocates a small amount of disk space, ranging from 2 GB to 16 GB,
-equivalent to 5% of the Kafka broker's total available disk for the
+equivalent to 5% of the Apache Kafka broker's total available disk for the
 temporary storage of fetched records.
 
 ## Security

--- a/docs/products/kafka/concepts/tiered-storage-how-it-works.md
+++ b/docs/products/kafka/concepts/tiered-storage-how-it-works.md
@@ -10,8 +10,8 @@ Aiven for Apache Kafka® tiered storage is a feature that optimizes data managem
 -   **Remote tier**: Relies on slower, cost-effective options like cloud
     object storage.
 
-In Aiven for Apache Kafka's tiered storage architecture, **remote
-storage** refers to storage options external to the Kafka broker's
+In Aiven for Apache Kafka's tiered storage architecture, **remote storage** refers to
+storage options external to the Kafka broker's
 local disk. This typically includes cloud-based or self-hosted object
 storage solutions like AWS S3 and Google Cloud Storage. Although
 network-attached block storage solutions like AWS EBS are technically
@@ -57,12 +57,11 @@ move data as swiftly as possible, certain conditions, such as high
 ingestion rate or connectivity issues, can cause more data to be stored
 in the local storage than the specified local retention policy.
 
-Any data exceeding the local retention threshold is not be purged by
-the log cleaner until it is successfully uploaded to remote storage. The
-replication factor is not considered during the upload process, and only
-one copy of each segment is uploaded to the remote storage. Most remote
-storage options have their own measures, including data replication, to
-ensure data durability.
+The log cleaner does not purge any data exceeding the local retention threshold until
+it is successfully uploaded to remote storage. The replication factor is not considered
+during the upload process, and only one copy of each segment is uploaded to the remote
+storage. Most remote storage options have their own measures, including data
+replication to ensure data durability.
 
 ## Data retrieval
 
@@ -71,7 +70,7 @@ downloads and caches these records locally. This allows for quicker
 access in subsequent retrieval operations.
 
 Aiven allocates a small amount of disk space, ranging from 2 GB to 16 GB,
-equivalent to 5% of the Kafka broker's total available disk, for the
+equivalent to 5% of the Kafka broker's total available disk for the
 temporary storage of fetched records.
 
 ## Security

--- a/docs/products/kafka/concepts/tiered-storage-how-it-works.md
+++ b/docs/products/kafka/concepts/tiered-storage-how-it-works.md
@@ -1,6 +1,5 @@
 ---
 title: How tiered storage works in Aiven for Apache Kafka®
-early: true
 ---
 
 Aiven for Apache Kafka® tiered storage is a feature that optimizes data
@@ -70,7 +69,7 @@ When consumers fetch records stored in remote storage, the Kafka broker
 downloads and caches these records locally. This allows for quicker
 access in subsequent retrieval operations.
 
-Aiven allocates a small amount of disk space, ranging from 2GB to 16GB,
+Aiven allocates a small amount of disk space, ranging from 2 GB to 16 GB,
 equivalent to 5% of the Kafka broker's total available disk, for the
 temporary storage of fetched records.
 

--- a/docs/products/kafka/concepts/tiered-storage-how-it-works.md
+++ b/docs/products/kafka/concepts/tiered-storage-how-it-works.md
@@ -29,13 +29,14 @@ disk instead of remote storage.
 
 ## Local vs. remote data retention
 
-When tiered storage is enabled, data produced to a topic is initially
-stored on the local disk of the Kafka broker. Data is then
-asynchronously transferred to remote storage based on the pre-defined
-local retention threshold. During periods of high data ingestion or
-transient errors, such as network connectivity issues, the local storage
-might temporarily hold more data than specified by the local retention
-threshold.
+When tiered storage is enabled, data produced to a topic is initially stored on the
+local disk of the Kafka broker. All but the active (open) segment is then asynchronously
+and orderly transferred to remote storage, regardless of the local retention settings.
+During periods of high data ingestion or transient errors, such as network connectivity
+issues, local storage might temporarily hold more data than specified by the local
+retention threshold. This continues until the remote tier is back online, at which
+point the excess local data is transferred to remote storage, and local segments
+exceeding the retention threshold are removed.
 
 ![Diagram depicting the concept of local vs. remote data retention in a tiered storage system.](/images/content/products/kafka/tiered-storage/data-retention.png)
 

--- a/docs/products/kafka/concepts/tiered-storage-how-it-works.md
+++ b/docs/products/kafka/concepts/tiered-storage-how-it-works.md
@@ -1,9 +1,9 @@
 ---
 title: How tiered storage works in Aiven for Apache Kafka®
+sidebar_label: How it works
 ---
 
-Aiven for Apache Kafka® tiered storage is a feature that optimizes data
-management across two distinct storage tiers:
+Aiven for Apache Kafka® tiered storage is a feature that optimizes data management across two distinct storage tiers:
 
 -   **Local tier**: Primarily consists of faster and typically more
     expensive storage solutions like solid-state drives (SSDs).
@@ -24,8 +24,8 @@ interact with Apache Kafka in the same way, regardless of whether tiered
 storage is enabled or not.
 
 Administrators can configure tiered storage per topic by defining the
-retention period and retention bytes to specify how much data should be
-retained on the local disk instead of remote storage.
+retention period and retention bytes to specify how much data is retained on the local
+disk instead of remote storage.
 
 ## Local vs. remote data retention
 
@@ -44,19 +44,19 @@ threshold.
 Data is organized into segments, which are uploaded to remote storage
 individually. The active (newest) segment remains in local storage,
 which means that the segment size can also influence local data
-retention. For instance, if the local retention threshold is 1 GB, but
-the segment size is 2 GB, the local storage will exceed the 1 GB limit
-until the active segment is rolled over and uploaded to remote storage.
+retention. For instance, if the local retention threshold is 1 GB, but the segment
+size is 2 GB, the local storage exceeds the 1 GB limit until the active segment is
+rolled over and uploaded to remote storage.
 
 ## Asynchronous uploads and replication
 
 Data is transferred to remote storage asynchronously and does not
 interfere with the producer activity. While the Kafka broker aims to
 move data as swiftly as possible, certain conditions, such as high
-ingestion rate or connectivity issues, may cause more data to be stored
+ingestion rate or connectivity issues, can cause more data to be stored
 in the local storage than the specified local retention policy.
 
-Any data exceeding the local retention threshold will not be purged by
+Any data exceeding the local retention threshold is not be purged by
 the log cleaner until it is successfully uploaded to remote storage. The
 replication factor is not considered during the upload process, and only
 one copy of each segment is uploaded to the remote storage. Most remote

--- a/docs/products/kafka/concepts/tiered-storage-how-it-works.md
+++ b/docs/products/kafka/concepts/tiered-storage-how-it-works.md
@@ -10,7 +10,7 @@ Aiven for Apache Kafka® tiered storage optimizes data management across two dis
 - **Remote tier**: Uses slower, cost-effective options like cloud object storage.
 
 In Aiven for Apache Kafka's tiered storage architecture, **remote storage** refers to
-storage options external to the Kafka broker's
+storage options external to the Apache Kafka broker's
 local disk. This typically includes cloud-based or self-hosted object
 storage solutions like AWS S3 and Google Cloud Storage. Although
 network-attached block storage solutions like AWS EBS are technically
@@ -43,7 +43,7 @@ exceeding the retention threshold are removed.
 
 Data is organized into segments, which are uploaded to remote storage
 individually. The active (newest) segment remains in local storage,
-which means that the segment size can also influence local data
+so the segment size can also influence local data
 retention. For example, if the local retention threshold is 1 GB, but the segment size
 is 2 GB, the local storage exceeds the 1 GB limit until the active segment is rolled
 over and uploaded to remote storage.
@@ -53,8 +53,8 @@ over and uploaded to remote storage.
 Data is transferred to remote storage asynchronously and does not
 interfere with the producer activity. While the Apache Kafka broker aims to
 move data as swiftly as possible, certain conditions, such as high
-ingestion rate or connectivity issues, can cause more data to be stored
-in the local storage than the specified local retention policy.
+ingestion rate or connectivity issues can temporarily cause local storage to
+exceed the limits set by the local retention policy.
 
 The log cleaner does not purge any data exceeding the local retention threshold until
 it is successfully uploaded to remote storage. The replication factor is not considered
@@ -64,7 +64,7 @@ replication to ensure data durability.
 
 ## Data retrieval
 
-When consumers fetch records stored in remote storage, the Kafka broker
+When consumers fetch records stored in remote storage, the Apache Kafka broker
 downloads and caches these records locally. This allows for quicker
 access in subsequent retrieval operations.
 

--- a/docs/products/kafka/concepts/tiered-storage-limitations.md
+++ b/docs/products/kafka/concepts/tiered-storage-limitations.md
@@ -2,18 +2,18 @@
 title: Trade-offs and limitations
 ---
 
-The main trade-off of tiered storage is the higher latency while accessing and reading data from remote storage compared to local disk storage. While adding local caching can partially solve this problem, it cannot eliminate the latency completely.
+The main trade-off of tiered storage is the higher latency when accessing and reading data from remote storage compared to local disk storage. Adding local caching can partially mitigate this issue, but it cannot eliminate the latency entirely.
 
 ## Limitations
 
 - Tiered storage currently does not support compacted topics.
-- Once you enable tiered storage for a topic, you cannot deactivate it. As a workaround,
+- Once enabled, tiered storage for a topic cannot be deactivated. As a workaround,
   set the local retention to `-2` (the default value) to keep all data available locally.
   For assistance, contact [Aiven support](mailto:support@aiven.io).
-- Increasing the local retention threshold won't move segments
+- Increasing the local retention threshold will not move segments
   already uploaded to remote storage back to local storage. This
   change only affects new data segments.
-- If you enable tiered storage on a service, you can't migrate the
+- If you enable tiered storage on a service, you cannot migrate the
   service to a different region or cloud, except for moving to a
   virtual cloud in the same region. For migration to a different
   region or cloud, contact [Aiven support](mailto:support@aiven.io).

--- a/docs/products/kafka/concepts/tiered-storage-limitations.md
+++ b/docs/products/kafka/concepts/tiered-storage-limitations.md
@@ -1,6 +1,5 @@
 ---
 title: Trade-offs and limitations
-early: true
 ---
 
 The main trade-off of tiered storage is the higher latency while

--- a/docs/products/kafka/concepts/tiered-storage-limitations.md
+++ b/docs/products/kafka/concepts/tiered-storage-limitations.md
@@ -2,22 +2,21 @@
 title: Trade-offs and limitations
 ---
 
-The main trade-off of tiered storage is the higher latency while accessing and reading data from remote storage compared to local disk
-storage. While adding local caching can partially solve this problem, it cannot eliminate the latency completely.
+The main trade-off of tiered storage is the higher latency while accessing and reading data from remote storage compared to local disk storage. While adding local caching can partially solve this problem, it cannot eliminate the latency completely.
 
 ## Limitations
 
--   Tiered storage currently does not support compacted topics.
--   If you enable tiered storage for a topic, you cannot deactivate it
-    without losing data in the remote storage. To deactivate tiered
-    storage, contact [Aiven support](mailto:support@aiven.io).
--   Increasing the local retention threshold won't move segments
-    already uploaded to remote storage back to local storage. This
-    change only affects new data segments.
--   If you enable tiered storage on a service, you can't migrate the
-    service to a different region or cloud, except for moving to a
-    virtual cloud in the same region. For migration to a different
-    region or cloud, contact [Aiven support](mailto:support@aiven.io).
+- Tiered storage currently does not support compacted topics.
+- Once you enable tiered storage for a topic, you cannot deactivate it. As a workaround,
+  set the local retention to `-2` (the default value) to keep all data available locally.
+  For assistance, contact [Aiven support](mailto:support@aiven.io).
+- Increasing the local retention threshold won't move segments
+  already uploaded to remote storage back to local storage. This
+  change only affects new data segments.
+- If you enable tiered storage on a service, you can't migrate the
+  service to a different region or cloud, except for moving to a
+  virtual cloud in the same region. For migration to a different
+  region or cloud, contact [Aiven support](mailto:support@aiven.io).
 
 ## Related pages
 

--- a/docs/products/kafka/concepts/tiered-storage-limitations.md
+++ b/docs/products/kafka/concepts/tiered-storage-limitations.md
@@ -2,19 +2,21 @@
 title: Trade-offs and limitations
 ---
 
-The main trade-off of tiered storage is the higher latency when accessing and reading data from remote storage compared to local disk storage. Adding local caching can partially mitigate this issue, but it cannot eliminate the latency entirely.
+The main trade-off of tiered storage is the higher latency when accessing and reading data from remote storage compared to local disk storage.
+
+Adding local caching can partially mitigate this issue, but it cannot eliminate the latency entirely.
 
 ## Limitations
 
-- Tiered storage currently does not support compacted topics.
+- Tiered storage does not support compacted topics.
 - Once enabled, tiered storage for a topic cannot be deactivated. As a workaround,
   set the local retention to `-2` (the default value) to keep all data available locally.
   For assistance, contact [Aiven support](mailto:support@aiven.io).
-- Increasing the local retention threshold will not move segments
+- Increasing the local retention threshold doesn't move segments
   already uploaded to remote storage back to local storage. This
   change only affects new data segments.
 - If you enable tiered storage on a service, you cannot migrate the
-  service to a different region or cloud, except for moving to a
+  service to a different region or cloud, except for moving it to a
   virtual cloud in the same region. For migration to a different
   region or cloud, contact [Aiven support](mailto:support@aiven.io).
 

--- a/docs/products/kafka/concepts/tiered-storage-limitations.md
+++ b/docs/products/kafka/concepts/tiered-storage-limitations.md
@@ -2,10 +2,8 @@
 title: Trade-offs and limitations
 ---
 
-The main trade-off of tiered storage is the higher latency while
-accessing and reading data from remote storage compared to local disk
-storage. While adding local caching can partially solve this problem, it
-cannot eliminate the latency completely.
+The main trade-off of tiered storage is the higher latency while accessing and reading data from remote storage compared to local disk
+storage. While adding local caching can partially solve this problem, it cannot eliminate the latency completely.
 
 ## Limitations
 

--- a/docs/products/kafka/concepts/tiered-storage-limitations.md
+++ b/docs/products/kafka/concepts/tiered-storage-limitations.md
@@ -20,6 +20,7 @@ The main trade-off of tiered storage is the higher latency while accessing and r
 
 ## Related pages
 
--   [Tiered storage in Aiven for Apache Kafka® overview](/docs/products/kafka/concepts/kafka-tiered-storage)
--   [How tiered storage works in Aiven for Apache Kafka®](/docs/products/kafka/concepts/tiered-storage-how-it-works)
--   [Enabled tiered storage for Aiven for Apache Kafka® service](/docs/products/kafka/howto/enable-kafka-tiered-storage)
+- [Tiered storage in Aiven for Apache Kafka® overview](/docs/products/kafka/concepts/kafka-tiered-storage)
+
+
+- [Enabled tiered storage for Aiven for Apache Kafka® service](/docs/products/kafka/howto/enable-kafka-tiered-storage)

--- a/docs/products/kafka/howto/configure-topic-tiered-storage.md
+++ b/docs/products/kafka/howto/configure-topic-tiered-storage.md
@@ -2,144 +2,122 @@
 title: Enable and configure tiered storage for topics
 ---
 
-Aiven for Apache Kafka® allows you to configure tiered storage and set retention policies for individual topics.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
+
+Aiven for Apache Kafka® allows you to configure tiered storage and set retention policies for individual topics.
 
 ## Prerequisite
 
--   [Tiered storage enabled for the Aiven for Apache Kafka service](/docs/products/kafka/howto/enable-kafka-tiered-storage).
+- [Tiered storage enabled for the Aiven for Apache Kafka service](/docs/products/kafka/howto/enable-kafka-tiered-storage).
 
-## Configure tiered storage for topics via Aiven Console
+## Important information about tiered storage
 
-1.  Access [Aiven console](https://console.aiven.io/), select your
-    project, and select your Aiven for Apache Kafka service.
-1.  Click **Topics** from the sidebar.
-1.  You have the option to either add a new topic with tiered
-    storage configuration or modify an existing topic to use tiered
-    storage.
+When you activate tiered storage for a service, any new topics created in that service
+have tiered storage enabled by default.
 
-### For a new topic
+- **Disable tiered storage for new topics**: You can disable tiered storage by setting
+  **Remote storage enable** to false during the creation of a new topic in the topic
+  advanced configurations. Once you activate tiered storage for a topic, you cannot
+  disable it. Contact Aiven support for assistance.
 
-1.  From the **Topics** page, click **Add topic**.
+- **Tiered storage for existing topics**: For existing topics, tiered storage is disabled.
 
-1.  Set the **"Enable advanced configuration?"** option to **Yes** to enable
-advanced configurations.
+## Enable and configure tiered storage for topics
 
-1.  In the **Topic advanced configuration** drop-down, choose
-    `remote_storage_enable`. This action reveals the **Remote
-    storage enabled** drop-down.
+<Tabs groupId="setup">
+<TabItem value="Console" label="Console" default>
 
-1.  Select **True** to activate tiered storage for the topic.
+1. Access the [Aiven Console](https://console.aiven.io/), select your project,
+   and select your Aiven for Apache Kafka service.
+1. Click <ConsoleLabel name="topics" />.
 
-1.  Additionally, you can also set the values for `local_retention_ms`
-    and `local_retention_bytes` using the respective options from the
-    drop-down list.
+1. On the **Topics** page, either add a new topic with tiered storage or modify an
+   existing one:
+   - **Add a new topic**: Click **Add topic**.
+   - **Modify an existing topic**: Select the topic to modify, then either:
+     - Click the topic name to open the **Topic info** screen, and click **Modify**.
+     - Alternatively, in the topic row, click <ConsoleLabel name="actions"/> >
+       <ConsoleLabel name="Edit topic"/>.
 
-    :::important
-    If the values for `local_retention_bytes` and `local_retention_ms`
-    are not set, they default to -2 or take the configuration from the
-    service level.
+1. The **Enable advanced configuration?** option is set to **Yes** by default.
 
-    When set to -2, the retention in local storage matches the total
-    retention. In this scenario, the data segments sent to remote
-    storage are also retained locally. The remote storage will contain
-    older data segments than in the local storage only when the total
-    retention is set to be greater than the local retention.
-    :::
+1. Ensure the **Remote storage enable** option is set to **True** to activate tiered
+   storage for the topic. To disable it, set it to **False**.
 
-1.  Click **Add topic** to save your changes and add the topic with
-    tiered storage.
+1. Optionally, adjust the default values for `local_retention_ms` and `local_retention_bytes`.
 
-<!-- vale on -->
+   :::important
+   By default, `local_retention_bytes` and `local_retention_ms` are set to `-2` or
+   inherit the configuration from the service level.
 
-### For an existing topic
+   When set to `-2`, the retention in local storage matches the total retention. In this
+   scenario, the data segments sent to remote storage are also retained locally. Remote
+   storage will contain older data segments only if the total retention exceeds the local retention.
+   :::
 
-1.  From the **Topics** page, select the topic for which you wish to
-    enable tiered storage.
-1.  Use the ellipsis or open the topic and choose **Modify**.
-1.  In the **Modify** page, choose `remote_storage_enable` from the
-    drop-down list, followed by selecting **True** from the **Remote
-    storage enable** drop-down.
-1.  Additionally, you can also set the values for `local_retention_ms`
-    and `local_retention_bytes` using the respective options from the
-    drop-down list.
+1. Click **Create topic** or **Update** to save your changes and activate tiered storage.
 
-    :::important
-    If the values for `local_retention_bytes` and `local_retention_ms` are
-    not set, they default to -2 or take the configuration from the service
-    level.
+</TabItem>
+<TabItem value="CLI" label="CLI">
 
-    When set to -2, the retention in local storage matches the total
-    retention. In this scenario, the data segments sent to remote storage
-    are also retained locally. The remote storage will contain older data
-    segments than in the local storage only when the total retention is set
-    to be greater than the local retention.
-    :::
+Using the [Aiven CLI](/docs/tools/cli), you can enable tiered storage for specific
+Apache Kafka® topics and set retention policies.
 
-1.  Click **Update** to save your changes and activate tiered storage.
-
-## (Optional) configure client-side parameter
-
-For optimal performance and reduced risk of broker interruptions when
-using tiered storage, it is recommended to update the client-side
-parameter `fetch.max.wait.ms` from its default value of 500 ms to 5000 ms.
-
-## Enable tiered storage for topics via Aiven CLI
-
-Using the [Aiven CLI](/docs/tools/cli),
-you can enable tiered storage for specific Apache Kafka® topics and set
-retention policies.
-
-### Enable tiered storage for a topic
-
-To enable tiered storage for a Kafka topic, execute the following
-command:
+To create a topic with tiered storage enabled:
 
 ```bash
 avn service topic-create \
     --project demo-kafka-project \
     --service-name demo-kafka-service \
     --topic exampleTopic \
-    --partitions 1 \
+    --partitions 2 \
     --replication 2 \
     --remote-storage-enable
 ```
 
 In this example:
 
--   `demo-kafka-project` is the name of your project.
--   `demo-kafka-service` is the name of your Aiven for Apache Kafka®
-    service.
--   `exampleTopic` is the name of the topic you are creating with tiered
-    storage enabled.
--   The topic will have 1 partition and a replication factor of 2.
+- `demo-kafka-project` is the name of your project.
+- `demo-kafka-service` is the name of your Aiven for Apache Kafka® service.
+- `exampleTopic` is the name of the topic you are creating with tiered storage enabled.
+- The topic has the partition set to `2` and the replication factor set to `2`
 
-### Configure retention policies for a topic with tiered storage
+### Configure retention policies for a topic
 
-After enabling tiered storage, you can configure the retention policies
-for local storage:
+After enabling tiered storage, you can configure the retention policies for local storage:
 
 ```bash
 avn service topic-update \
-    --project demo-kafka-project \
-    --service-name demo-kafka-service \
-    --topic exampleTopic \
-    --local-retention-ms 100 \
-    --local-retention-bytes 10
+  --project demo-kafka-project \
+  --service-name demo-kafka-service \
+  --topic exampleTopic \
+  --local-retention-ms 100 \
+  --local-retention-bytes 10
 ```
 
-This command sets the local retention time to 100 milliseconds and the
-local retention size to 10 bytes for the topic named `exampleTopic` in
-the `demo-kafka-service` of the `demo-kafka-project`.
+This command sets the local retention time to 100 milliseconds and the local retention
+size to 10 bytes for the topic named `exampleTopic` in the `demo-kafka-service` of
+the `demo-kafka-project`.
 
 :::important
-If the values for `local_retention_bytes` and `local_retention_ms` are
-not set, they default to -2 or inherit the configuration from the
-service level.
 
-When set to -2, the retention in local storage matches the total
-retention. Consequently, data segments sent to remote storage are also
-retained locally. The remote storage will contain older data segments
-than the local storage, only if the total retention exceeds the local
+By default, `local_retention_bytes` and `local_retention_ms` are set to `-2` or
+inherit the configuration from the service level.
+
+When set to `-2`, the retention in local storage matches the total retention. In this
+scenario, the data segments sent to remote storage are also retained locally. Remote
+storage will contain older data segments only if the total retention exceeds the local
 retention.
 :::
+
+</TabItem>
+</Tabs>
+
+## (Optional) configure client-side parameter
+
+For optimal performance and reduced risk of broker interruptions when
+using tiered storage, it is recommended to update the client-side
+parameter `fetch.max.wait.ms` from its default value of 500 ms to 5000 ms.

--- a/docs/products/kafka/howto/configure-topic-tiered-storage.md
+++ b/docs/products/kafka/howto/configure-topic-tiered-storage.md
@@ -1,6 +1,5 @@
 ---
 title: Enable and configure tiered storage for topics
-early: true
 ---
 
 Aiven for Apache Kafka® allows you to configure tiered storage and set retention policies for individual topics.

--- a/docs/products/kafka/howto/configure-topic-tiered-storage.md
+++ b/docs/products/kafka/howto/configure-topic-tiered-storage.md
@@ -121,3 +121,7 @@ retention.
 For optimal performance and reduced risk of broker interruptions when
 using tiered storage, it is recommended to update the client-side
 parameter `fetch.max.wait.ms` from its default value of 500 ms to 5000 ms.
+
+However, this consumer configuration is no longer necessary starting from Apache Kafka
+version 3.6.2. Consider upgrading to Apache Kafka version 3.6.2 or later before
+enabling tiered storage.

--- a/docs/products/kafka/howto/configure-topic-tiered-storage.md
+++ b/docs/products/kafka/howto/configure-topic-tiered-storage.md
@@ -4,6 +4,7 @@ title: Enable and configure tiered storage for topics
 
 Aiven for Apache Kafka® allows you to configure tiered storage and set retention policies for individual topics.
 
+
 ## Prerequisite
 
 -   [Tiered storage enabled for the Aiven for Apache Kafka service](/docs/products/kafka/howto/enable-kafka-tiered-storage).
@@ -12,22 +13,20 @@ Aiven for Apache Kafka® allows you to configure tiered storage and set retentio
 
 1.  Access [Aiven console](https://console.aiven.io/), select your
     project, and select your Aiven for Apache Kafka service.
-1.  From the left sidebar, select **Topics**.
+1.  Click **Topics** from the sidebar.
 1.  You have the option to either add a new topic with tiered
     storage configuration or modify an existing topic to use tiered
     storage.
 
 ### For a new topic
 
-<!-- vale off -->
+1.  From the **Topics** page, click **Add topic**.
 
-1.  From the **Topics** page, select **Add topic**.
-
-1.  Set the **Do you want to enable advanced configuration?** option to Yes to enable
+1.  Set the **"Enable advanced configuration?"** option to **Yes** to enable
 advanced configurations.
 
 1.  In the **Topic advanced configuration** drop-down, choose
-    `remote_storage_enable`. This action will reveal the **Remote
+    `remote_storage_enable`. This action reveals the **Remote
     storage enabled** drop-down.
 
 1.  Select **True** to activate tiered storage for the topic.
@@ -41,14 +40,14 @@ advanced configurations.
     are not set, they default to -2 or take the configuration from the
     service level.
 
-    When set to -2, the retention in local storage will match the total
+    When set to -2, the retention in local storage matches the total
     retention. In this scenario, the data segments sent to remote
     storage are also retained locally. The remote storage will contain
     older data segments than in the local storage only when the total
     retention is set to be greater than the local retention.
     :::
 
-1.  Select **Add topic** to save your changes and add the topic with
+1.  Click **Add topic** to save your changes and add the topic with
     tiered storage.
 
 <!-- vale on -->
@@ -70,14 +69,14 @@ advanced configurations.
     not set, they default to -2 or take the configuration from the service
     level.
 
-    When set to -2, the retention in local storage will match the total
+    When set to -2, the retention in local storage matches the total
     retention. In this scenario, the data segments sent to remote storage
     are also retained locally. The remote storage will contain older data
     segments than in the local storage only when the total retention is set
     to be greater than the local retention.
     :::
 
-1.  Select **Update** to save your changes and activate tiered storage.
+1.  Click **Update** to save your changes and activate tiered storage.
 
 ## (Optional) configure client-side parameter
 
@@ -138,7 +137,7 @@ If the values for `local_retention_bytes` and `local_retention_ms` are
 not set, they default to -2 or inherit the configuration from the
 service level.
 
-When set to -2, the retention in local storage will match the total
+When set to -2, the retention in local storage matches the total
 retention. Consequently, data segments sent to remote storage are also
 retained locally. The remote storage will contain older data segments
 than the local storage, only if the total retention exceeds the local

--- a/docs/products/kafka/howto/configure-topic-tiered-storage.md
+++ b/docs/products/kafka/howto/configure-topic-tiered-storage.md
@@ -11,9 +11,9 @@ Aiven for Apache Kafka® allows you to configure tiered storage and set retentio
 
 ## Prerequisite
 
-- [Tiered storage enabled for the Aiven for Apache Kafka service](/docs/products/kafka/howto/enable-kafka-tiered-storage).
+[Tiered storage enabled for the Aiven for Apache Kafka service](/docs/products/kafka/howto/enable-kafka-tiered-storage).
 
-## Important information about tiered storage
+## Tiered storage status for topics
 
 When you activate tiered storage for a service, any new topics created in that service
 have tiered storage enabled by default.
@@ -21,9 +21,9 @@ have tiered storage enabled by default.
 - **Disable tiered storage for new topics**: You can disable tiered storage by setting
   **Remote storage enable** to false during the creation of a new topic in the topic
   advanced configurations. Once you activate tiered storage for a topic, you cannot
-  disable it. Contact Aiven support for assistance.
+  disable it. Contact [Aiven support](mailto:support@aiven.io) for assistance.
 
-- **Tiered storage for existing topics**: For existing topics, tiered storage is disabled.
+- **Tiered storage for existing topics**: Disabled for existing topics.
 
 ## Enable and configure tiered storage for topics
 
@@ -36,8 +36,8 @@ have tiered storage enabled by default.
 
 1. On the **Topics** page, either add a new topic with tiered storage or modify an
    existing one:
-   - **Add a new topic**: Click **Add topic**.
-   - **Modify an existing topic**: Select the topic to modify, then either:
+   - To add a new topic, click **Add topic**.
+   - To modify an existing topic, select the topic to modify, then either:
      - Click the topic name to open the **Topic info** screen, and click **Modify**.
      - Alternatively, in the topic row, click <ConsoleLabel name="actions"/> >
        <ConsoleLabel name="Edit topic"/>.
@@ -55,7 +55,7 @@ have tiered storage enabled by default.
 
    When set to `-2`, the retention in local storage matches the total retention. In this
    scenario, the data segments sent to remote storage are also retained locally. Remote
-   storage will contain older data segments only if the total retention exceeds the local retention.
+   storage contains older data segments only if the total retention exceeds the local retention.
    :::
 
 1. Click **Create topic** or **Update** to save your changes and activate tiered storage.
@@ -99,7 +99,7 @@ avn service topic-update \
 ```
 
 This command sets the local retention time to 100 milliseconds and the local retention
-size to 10 bytes for the topic named `exampleTopic` in the `demo-kafka-service` of
+size to 10 bytes for the `exampleTopic` topic in the `demo-kafka-service` of
 the `demo-kafka-project`.
 
 :::important
@@ -109,19 +109,19 @@ inherit the configuration from the service level.
 
 When set to `-2`, the retention in local storage matches the total retention. In this
 scenario, the data segments sent to remote storage are also retained locally. Remote
-storage will contain older data segments only if the total retention exceeds the local
+storage contains older data segments only if the total retention exceeds the local
 retention.
 :::
 
 </TabItem>
 </Tabs>
 
-## (Optional) configure client-side parameter
+## (Optional) Configure client-side parameter
 
 For optimal performance and reduced risk of broker interruptions when
 using tiered storage, it is recommended to update the client-side
 parameter `fetch.max.wait.ms` from its default value of 500 ms to 5000 ms.
 
-However, this consumer configuration is no longer necessary starting from Apache Kafka
+This consumer configuration is no longer necessary starting from Apache Kafka
 version 3.6.2. Consider upgrading to Apache Kafka version 3.6.2 or later before
 enabling tiered storage.

--- a/docs/products/kafka/howto/create-topic.md
+++ b/docs/products/kafka/howto/create-topic.md
@@ -5,6 +5,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 When working with Apache Kafka®, while it is possible to configure it to [automatically create topics when a message is produced to a non-existent topic](/docs/products/kafka/howto/create-topics-automatically), it is generally recommended to create topics beforehand, especially in production environments.
 
 This approach offers several advantages:
@@ -12,6 +13,9 @@ This approach offers several advantages:
 When working with Apache Kafka®, while it is possible to configure it to [automatically create topics when a message is produced to a non-existent topic](create-topics-automatically), it is generally recommended to create topics beforehand,
 especially in production environments.
 >>>>>>> 80470d1 (fix: editorial and styles)
+=======
+You can configure Aiven for Apache Kafka® to [automatically create topics when a message is produced to a non-existent topic](create-topics-automatically), but it is recommended to create topics beforehand, especially in production environments.
+>>>>>>> 4065624 (fix: address feedback)
 
 This approach offers several advantages:
 
@@ -21,8 +25,8 @@ This approach offers several advantages:
     other mistakes.
 
 :::note
-When tiered storage is activated for your Aiven for Apache Kafka service, all new topics
-will have tiered storage enabled by default.
+When tiered storage is activated for your Aiven for Apache Kafka service, all
+new topics will have tiered storage enabled by default
 [Learn more about tiered storage](/docs/products/kafka/concepts/kafka-tiered-storage).
 :::
 
@@ -55,9 +59,11 @@ Console](https://console.aiven.io/):
 1. If required, set the advanced configuration option to **Yes**.
 1. In the **Topic advanced configuration** section, set properties such as the
    replication factor, number of partitions, and other settings. These settings can be
-   modified later if needed.
-1. Click **Create topic**. The new topic will be visible immediately, but it may take a
-   few minutes before you can update its settings.
+   modified later.
+1. Click **Create topic**.
+
+The new topic is visible immediately, but it may take a few minutes before you can
+update its settings.
 
 </TabItem>
 <TabItem value="CLI" label="CLI">
@@ -65,7 +71,7 @@ Console](https://console.aiven.io/):
 1. Determine the topic specifications, including the number of partitions,
    replication factor, and other settings.
 
-1. Run the following command to create a topic named `exampleTopic`:
+1. Run the following command to create the `exampleTopic` topic:
 
    ```bash
    avn service topic-create             \
@@ -78,7 +84,7 @@ Console](https://console.aiven.io/):
 
    Parameters:
 
-   - `avn service topic-create`: Command to create a topic.
+   - `avn service topic-create`: Creates a topic.
    - `--project demo-kafka-project`: Specifies the project name.
    - `--service-name demo-kafka-service`: Specifies the Aiven for Apache Kafka® service name.
    - `--topic exampleTopic`: Specifies the name of the topic to create.

--- a/docs/products/kafka/howto/create-topic.md
+++ b/docs/products/kafka/howto/create-topic.md
@@ -4,18 +4,7 @@ title: Create an Apache Kafka® topic
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-When working with Apache Kafka®, while it is possible to configure it to [automatically create topics when a message is produced to a non-existent topic](/docs/products/kafka/howto/create-topics-automatically), it is generally recommended to create topics beforehand, especially in production environments.
-
-This approach offers several advantages:
-=======
-When working with Apache Kafka®, while it is possible to configure it to [automatically create topics when a message is produced to a non-existent topic](create-topics-automatically), it is generally recommended to create topics beforehand,
-especially in production environments.
->>>>>>> 80470d1 (fix: editorial and styles)
-=======
 You can configure Aiven for Apache Kafka® to [automatically create topics when a message is produced to a non-existent topic](create-topics-automatically), but it is recommended to create topics beforehand, especially in production environments.
->>>>>>> 4065624 (fix: address feedback)
 
 This approach offers several advantages:
 
@@ -26,31 +15,14 @@ This approach offers several advantages:
 
 :::note
 When tiered storage is activated for your Aiven for Apache Kafka service, all
-new topics will have tiered storage enabled by default
+new topics will have tiered storage enabled by default.
 [Learn more about tiered storage](/docs/products/kafka/concepts/kafka-tiered-storage).
 :::
 
-<<<<<<< HEAD
-To create a topic using the [Aiven
-Console](https://console.aiven.io/):
-
-1.  Log in to [Aiven Console](https://console.aiven.io/) and select the
-    Aiven for Apache Kafka® service where to create the topic.
-1.  From the left sidebar, select **Topics**.
-1.  Select **Create topic** to create a topic and enter a name for
-    the topic.
-1.  If required, set the advanced configuration option to **Yes**.
-1.  In the **Topic advanced configuration** section, you can set
-    properties such as the replication factor, number of partitions, and
-    other settings. These settings can be modified later if needed.
-1.  Select **Create topic**. The new topic will be visible immediately,
-    but may take a few minutes before you can update its settings.
-=======
 ## Steps to create an Apache Kafka® topic
 
 <Tabs groupId="setup">
 <TabItem value="Console" label="Console" default>
->>>>>>> 80470d1 (fix: editorial and styles)
 
 1. Log in to the [Aiven Console](https://console.aiven.io/) and select the Aiven for
    Apache Kafka® service to create the topic.

--- a/docs/products/kafka/howto/create-topic.md
+++ b/docs/products/kafka/howto/create-topic.md
@@ -1,18 +1,32 @@
 ---
-title: Creating an Apache Kafka® topic
+title: Create an Apache Kafka® topic
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
+<<<<<<< HEAD
 When working with Apache Kafka®, while it is possible to configure it to [automatically create topics when a message is produced to a non-existent topic](/docs/products/kafka/howto/create-topics-automatically), it is generally recommended to create topics beforehand, especially in production environments.
 
 This approach offers several advantages:
+=======
+When working with Apache Kafka®, while it is possible to configure it to [automatically create topics when a message is produced to a non-existent topic](create-topics-automatically), it is generally recommended to create topics beforehand,
+especially in production environments.
+>>>>>>> 80470d1 (fix: editorial and styles)
 
--   It allows you to define specific topic settings, such as the number
-    of partitions, replication factor, retention period, and more.
--   It helps prevent the generation of incorrect topics due to typos or
+This approach offers several advantages:
+
+- You can define specific topic settings, such as the number of partitions,
+  replication factor, retention period, and more.
+- It helps prevent the creation of incorrect topics due to typos or
     other mistakes.
 
-## Create an Apache Kafka® topic
+:::note
+When tiered storage is activated for your Aiven for Apache Kafka service, all new topics
+will have tiered storage enabled by default.
+[Learn more about tiered storage](/docs/products/kafka/concepts/kafka-tiered-storage).
+:::
 
+<<<<<<< HEAD
 To create a topic using the [Aiven
 Console](https://console.aiven.io/):
 
@@ -27,7 +41,54 @@ Console](https://console.aiven.io/):
     other settings. These settings can be modified later if needed.
 1.  Select **Create topic**. The new topic will be visible immediately,
     but may take a few minutes before you can update its settings.
+=======
+## Steps to create an Apache Kafka® topic
 
-You can also use the
-[topic-create](/docs/tools/cli/service/topic#avn_cli_service_topic_create) command to create a topic using
-[Aiven CLI](/docs/tools/cli).
+<Tabs groupId="setup">
+<TabItem value="Console" label="Console" default>
+>>>>>>> 80470d1 (fix: editorial and styles)
+
+1. Log in to the [Aiven Console](https://console.aiven.io/) and select the Aiven for
+   Apache Kafka® service to create the topic.
+1. Click **Topics** in the sidebar.
+1. Click **Create topic** and enter a name for the topic.
+1. If required, set the advanced configuration option to **Yes**.
+1. In the **Topic advanced configuration** section, set properties such as the
+   replication factor, number of partitions, and other settings. These settings can be
+   modified later if needed.
+1. Click **Create topic**. The new topic will be visible immediately, but it may take a
+   few minutes before you can update its settings.
+
+</TabItem>
+<TabItem value="CLI" label="CLI">
+
+1. Determine the topic specifications, including the number of partitions,
+   replication factor, and other settings.
+
+1. Run the following command to create a topic named `exampleTopic`:
+
+   ```bash
+   avn service topic-create             \
+       --project demo-kafka-project    \
+       --service-name demo-kafka-service \
+       --topic exampleTopic            \
+       --partitions 2                  \
+       --replication 2
+   ```
+
+   Parameters:
+
+   - `avn service topic-create`: Command to create a topic.
+   - `--project demo-kafka-project`: Specifies the project name.
+   - `--service-name demo-kafka-service`: Specifies the Aiven for Apache Kafka® service name.
+   - `--topic exampleTopic`: Specifies the name of the topic to create.
+   - `--partitions 2`: Specifies the number of partitions for the topic.
+   - `--replication 2`: Specifies the replication factor for the topic.
+
+</TabItem>
+</Tabs>
+
+## Related pages
+
+- [Manage Aiven for Apache Kafka® topics via CLI](/docs/tools/cli/service/topic#avn_cli_service_topic_create)
+- [Create Apache Kafka® topics automatically](/docs/products/kafka/howto/create-topics-automatically)

--- a/docs/products/kafka/howto/create-topics-automatically.md
+++ b/docs/products/kafka/howto/create-topics-automatically.md
@@ -1,7 +1,6 @@
 ---
 title: Create Apache Kafka® topics automatically
 ---
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
@@ -9,9 +8,9 @@ import {ConsoleIcon} from "@site/src/components/ConsoleIcons"
 
 Apache Kafka® provides the capability to automatically create topics when a message is produced to a topic that does not exist.
 
-By default, this feature is disabled in Aiven for Apache Kafka as a precaution against
-accidental topic creation. When a message is produced to a non-existent topic,
-the common error message is:
+By default, Aiven for Apache Kafka disables this feature to prevent accidental
+topic creation. If a message is produced to a non-existent topic, you'll see the
+following error message:
 
 ```bash
 KafkaTimeoutError: Failed to update metadata after 60.0 secs.
@@ -19,19 +18,18 @@ KafkaTimeoutError: Failed to update metadata after 60.0 secs.
 
 In such cases, you have two options:
 
-1. **Create topics in advance**: This approach involves manually
-    [creating the topics](/docs/products/kafka/howto/create-topic) before they are used.
-    It is generally recommended for production environments as it provides better
-    control over topic settings such as partition count, replication factor, and
-    retention time.
-1. **Enable automatic topic creation**: While simpler, enabling automatic topic creation
-   carries some drawbacks. It introduces the risk of inadvertently creating new topics,
-   especially in the case of typos. Additionally, it might result in topics created
-   with [default configuration values](set-kafka-parameters) defined at the service level.
+1. **Create topics in advance**: Manually
+   [create the topics](/docs/products/kafka/howto/create-topic) before use. This
+   approach is recommended for production environments as it provides better
+   control over settings such as partition count, replication factor, and retention time.
+1. **Enable automatic topic creation**: While simpler, this option carries some drawbacks.
+   It risks inadvertently creating new topics, especially due to typos, and may result
+   in topics created with [default configuration values](set-kafka-parameters) defined at
+   the service level.
 
 :::note
-When tiered storage is activated for your Aiven for Apache Kafka service, all new topics
-will have tiered storage enabled by default.
+When tiered storage is activated for your Aiven for Apache Kafka service, all
+new topics will have tiered storage enabled by default
 [Learn more about tiered storage](/docs/products/kafka/concepts/kafka-tiered-storage).
 :::
 
@@ -58,7 +56,7 @@ these steps:
 1. Log in to the [Aiven Console](https://console.aiven.io/), select your
    project, and choose your Aiven for Apache Kafka® service.
 1. Click <ConsoleLabel name="service settings"/> from the sidebar.
-1. Scroll down to the **Advanced configuration** section, and click **Configure**.
+1. Scroll to the **Advanced configuration** section, and click **Configure**.
 1. In the **Advanced configuration** dialog, click
    <ConsoleLabel name="addadvancedconfiguration"/>.
 1. Find the `auto_create_topics_enable` parameter and set it to true to
@@ -67,29 +65,28 @@ these steps:
 >>>>>>> 80470d1 (fix: editorial and styles)
 
 :::warning
-Even when you enable automatic topic creation, the user account that
-produces a message to a non-existing topic must have `admin`
-permissions. Aiven for Apache Kafka validates the access control list
-(ACL) before creating the topic. To change user permissions, go to
-the **Users** tab in your service detail page in the [Aiven Console](https://console.aiven.io/).
+Even with automatic topic creation enabled, the user account producing a message
+to a non-existent topic must have `admin` permissions. Aiven for Apache Kafka validates
+the access control list (ACL) before creating the topic. To change user permissions, go
+to the `Users` tab on your service detail page in the [Aiven Console](https://console.aiven.io/).
 :::
 
 </TabItem>
 <TabItem value="CLI" label="CLI">
 
 To enable the automatic creation of topics on an existing Aiven for Apache Kafka service,
-use the [Aiven CLI service update command](/docs/tools/cli/service-cli#avn-cli-service-update):
+use the
+[Aiven CLI service update command](/docs/tools/cli/service-cli#avn-cli-service-update).
+Run the following command, replacing `SERVICE_NAME` with your service name:
 
-1. Run the following command, replacing `SERVICE_NAME` with the name of your service:
+```bash
+avn service update SERVICE_NAME -c kafka.auto_create_topics_enable=true
+```
 
-   ```bash
-   avn service update SERVICE_NAME -c kafka.auto_create_topics_enable=true
-   ```
+Parameters:
 
-   Parameters:
-
-   - `auto_create_topics_enable=true`: Enables automatic topic creation.
-   - `SERVICE_NAME`: The name of your Aiven for Apache Kafka service.
+- `auto_create_topics_enable=true`: Enables automatic topic creation.
+- `SERVICE_NAME`: Your Aiven for Apache Kafka service name.
 
 </TabItem>
 </Tabs>

--- a/docs/products/kafka/howto/create-topics-automatically.md
+++ b/docs/products/kafka/howto/create-topics-automatically.md
@@ -29,7 +29,7 @@ In such cases, you have two options:
 
 :::note
 When tiered storage is activated for your Aiven for Apache Kafka service, all
-new topics will have tiered storage enabled by default
+new topics will have tiered storage enabled by default.
 [Learn more about tiered storage](/docs/products/kafka/concepts/kafka-tiered-storage).
 :::
 
@@ -41,18 +41,6 @@ new topics will have tiered storage enabled by default
 To enable automatic topic creation through the Aiven Console, follow
 these steps:
 
-<<<<<<< HEAD
-1.  In the [Aiven Console](https://console.aiven.io/), select your
-    project and choose your Aiven for Apache Kafka® service.
-2.  In the service page, select **Service settings** from the sidebar.
-3.  On the **Service settings** page, scroll down to the **Advanced
-    configuration** section, and click **Configure**.
-4.  In the **Advanced configuration** dialog, click **Add configuration
-    options**.
-5.  Find the `auto_create_topics_enable` parameter and set it to true to
-    enable automatic topic creation.
-6.  Select **Save configuration**.
-=======
 1. Log in to the [Aiven Console](https://console.aiven.io/), select your
    project, and choose your Aiven for Apache Kafka® service.
 1. Click <ConsoleLabel name="service settings"/> from the sidebar.
@@ -62,7 +50,6 @@ these steps:
 1. Find the `auto_create_topics_enable` parameter and set it to true to
    enable automatic topic creation.
 1. Click **Save configuration**.
->>>>>>> 80470d1 (fix: editorial and styles)
 
 :::warning
 Even with automatic topic creation enabled, the user account producing a message

--- a/docs/products/kafka/howto/create-topics-automatically.md
+++ b/docs/products/kafka/howto/create-topics-automatically.md
@@ -35,7 +35,6 @@ will have tiered storage enabled by default.
 [Learn more about tiered storage](/docs/products/kafka/concepts/kafka-tiered-storage).
 :::
 
-
 ## Enable automatic topic creation
 
 <Tabs groupId="setup">

--- a/docs/products/kafka/howto/create-topics-automatically.md
+++ b/docs/products/kafka/howto/create-topics-automatically.md
@@ -2,34 +2,49 @@
 title: Create Apache Kafka® topics automatically
 ---
 
-Apache Kafka® provides the capability to automatically create topics
-when a message is produced to a topic that does not exist. By default,
-this feature is disabled in Aiven for Apache Kafka as a precaution
-against accidental topic creation. When a message is produced to a
-non-existent topic, the common error message is as follows:
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
+import {ConsoleIcon} from "@site/src/components/ConsoleIcons"
 
-```
+Apache Kafka® provides the capability to automatically create topics when a message is produced to a topic that does not exist.
+
+By default, this feature is disabled in Aiven for Apache Kafka as a precaution against
+accidental topic creation. When a message is produced to a non-existent topic,
+the common error message is:
+
+```bash
 KafkaTimeoutError: Failed to update metadata after 60.0 secs.
 ```
 
-In such cases, you have two options available:
+In such cases, you have two options:
 
-1.  Create topics in advance: This approach involves manually
-    [creating the topics](/docs/products/kafka/howto/create-topic) before they are used. It is generally recommended for
-    production environments as it provides better control over topic
-    settings such as partition count, replication factor, and retention
-    time.
-2.  Enable topic automatic creation: While simpler, enabling automatic
-    topic creation carries some drawbacks. It introduces the risk of
-    inadvertently creating new topics, especially in the case of typos.
-    Additionally, it may result in topics created with
-    [default configuration values](set-kafka-parameters) defined at the service level.
+1. **Create topics in advance**: This approach involves manually
+    [creating the topics](/docs/products/kafka/howto/create-topic) before they are used.
+    It is generally recommended for production environments as it provides better
+    control over topic settings such as partition count, replication factor, and
+    retention time.
+1. **Enable automatic topic creation**: While simpler, enabling automatic topic creation
+   carries some drawbacks. It introduces the risk of inadvertently creating new topics,
+   especially in the case of typos. Additionally, it might result in topics created
+   with [default configuration values](set-kafka-parameters) defined at the service level.
 
-## Enable automatic topic creation using Aiven Console
+:::note
+When tiered storage is activated for your Aiven for Apache Kafka service, all new topics
+will have tiered storage enabled by default.
+[Learn more about tiered storage](/docs/products/kafka/concepts/kafka-tiered-storage).
+:::
+
+
+## Enable automatic topic creation
+
+<Tabs groupId="setup">
+<TabItem value="Console" label="Console" default>
 
 To enable automatic topic creation through the Aiven Console, follow
 these steps:
 
+<<<<<<< HEAD
 1.  In the [Aiven Console](https://console.aiven.io/), select your
     project and choose your Aiven for Apache Kafka® service.
 2.  In the service page, select **Service settings** from the sidebar.
@@ -40,36 +55,47 @@ these steps:
 5.  Find the `auto_create_topics_enable` parameter and set it to true to
     enable automatic topic creation.
 6.  Select **Save configuration**.
+=======
+1. Log in to the [Aiven Console](https://console.aiven.io/), select your
+   project, and choose your Aiven for Apache Kafka® service.
+1. Click <ConsoleLabel name="service settings"/> from the sidebar.
+1. Scroll down to the **Advanced configuration** section, and click **Configure**.
+1. In the **Advanced configuration** dialog, click
+   <ConsoleLabel name="addadvancedconfiguration"/>.
+1. Find the `auto_create_topics_enable` parameter and set it to true to
+   enable automatic topic creation.
+1. Click **Save configuration**.
+>>>>>>> 80470d1 (fix: editorial and styles)
 
 :::warning
 Even when you enable automatic topic creation, the user account that
 produces a message to a non-existing topic must have `admin`
 permissions. Aiven for Apache Kafka validates the access control list
 (ACL) before creating the topic. To change user permissions, go to
-the **Users** tab in your service detail page in the [Aiven web
-console](https://console.aiven.io/).
+the **Users** tab in your service detail page in the [Aiven Console](https://console.aiven.io/).
 :::
 
-## Enable automatic topic creation with Aiven CLI
+</TabItem>
+<TabItem value="CLI" label="CLI">
 
-The
-[Aiven CLI service update command](/docs/tools/cli/service-cli#avn-cli-service-update) enables to modify service parameters on an existing service.
-To enable the automatic creation of topics on an existing Aiven for
-Apache Kafka service set the `auto_create_topics_enable` to `true` by
-using the following command replacing the `SERVICE_NAME` with the name
-of your service:
+To enable the automatic creation of topics on an existing Aiven for Apache Kafka service,
+use the [Aiven CLI service update command](/docs/tools/cli/service-cli#avn-cli-service-update):
 
-You can enable the automatic creation of topics on an existing Aiven for
-Apache Kafka service by using the
-[Aiven CLI service update](/docs/tools/cli/service-cli#avn-cli-service-update) command:
+1. Run the following command, replacing `SERVICE_NAME` with the name of your service:
 
-1.  Use the following command:
+   ```bash
+   avn service update SERVICE_NAME -c kafka.auto_create_topics_enable=true
+   ```
 
-    ```
-    avn service update SERVICE_NAME -c kafka.auto_create_topics_enable=true
-    ```
+   Parameters:
 
-Where:
+   - `auto_create_topics_enable=true`: Enables automatic topic creation.
+   - `SERVICE_NAME`: The name of your Aiven for Apache Kafka service.
 
--   `auto_create_topics_enable` is `true`.
--   `SERVICE_NAME` matches the name of your service.
+</TabItem>
+</Tabs>
+
+## Related pages
+
+- [Manage Aiven for Apache Kafka® topics via CLI](/docs/tools/cli/service/topic#avn_cli_service_topic_create)
+- [Create an Apache Kafka® topic](/docs/products/kafka/howto/create-topic)

--- a/docs/products/kafka/howto/create-topics-automatically.md
+++ b/docs/products/kafka/howto/create-topics-automatically.md
@@ -47,7 +47,7 @@ these steps:
 1. Scroll to the **Advanced configuration** section, and click **Configure**.
 1. In the **Advanced configuration** dialog, click
    <ConsoleLabel name="addadvancedconfiguration"/>.
-1. Find the `auto_create_topics_enable` parameter and set it to true to
+1. Find the `auto_create_topics_enable` parameter and set it to `true` to
    enable automatic topic creation.
 1. Click **Save configuration**.
 

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.md
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.md
@@ -1,7 +1,6 @@
 ---
 title: Enable tiered storage for Aiven for Apache Kafka®
 sidebar_label: Enable tiered storage
-early: true
 ---
 
 Tiered storage significantly improves the storage efficiency of your Aiven for Apache Kafka® service. You can enable this feature for your service using either the [Aiven console](https://console.aiven.io/) or the [Aiven CLI](/docs/tools/cli).
@@ -16,7 +15,6 @@ Tiered storage significantly improves the storage efficiency of your Aiven for A
     page](https://aiven.io/pricing?product=kafka) for a comprehensive
     list of supported plans and regions.
 
--   [Feature preview enabled](/docs/platform/howto/feature-preview) for tiered storage
 -   Aiven CLI
 
 ## Enable tiered storage via Aiven Console

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.md
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.md
@@ -147,6 +147,10 @@ For optimal performance and reduced risk of broker interruptions when
 using tiered storage, it is recommended to update the client-side
 parameter `fetch.max.wait.ms` from its default value of 500 ms to 5000 ms.
 
+However, this consumer configuration is no longer necessary starting from Apache Kafka
+version 3.6.2. Consider upgrading to Apache Kafka version 3.6.2 or later before
+enabling tiered storage.
+
 ## Related pages
 
 - [Tiered storage in Aiven for Apache Kafka® overview](/docs/products/kafka/concepts/kafka-tiered-storage)

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.md
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.md
@@ -12,7 +12,7 @@ Tiered storage significantly improves the storage efficiency of your Aiven for A
 
 ## Prerequisites
 
-- Access to a project set up in the [Aiven console](https://console.aiven.io/).
+- Access to an Aiven organization and at least one project.
 - Aiven for Apache Kafka® service with Apache Kafka version 3.6 or later.
 
     :::note

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.md
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.md
@@ -13,7 +13,10 @@ Tiered storage significantly improves the storage efficiency of your Aiven for A
 ## Prerequisites
 
 - Access to an Aiven organization and at least one project.
-- Aiven for Apache Kafka® service with Apache Kafka version 3.6 or later.
+- Aiven for Apache Kafka® service with Apache Kafka version 3.6 or later. It is
+  recommended to upgrade to the latest default version and apply
+  [maintenance updates](/docs/platform/concepts/maintenance-window#maintenance-updates)
+  when using tiered storage for the latest fixes and improvements.
 
     :::note
     Tiered storage is not available on all plans and regions. Check the

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.md
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.md
@@ -50,7 +50,7 @@ Tiered storage significantly improves the storage efficiency of your Aiven for A
 
 :::note
 If tiered storage is not enabled in your project, you cannot access it.
-Contact [Aiven support]((mailto:support@aiven.io)).
+Contact [Aiven support](mailto:support@aiven.io).
 :::
 
 

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.md
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.md
@@ -3,26 +3,35 @@ title: Enable tiered storage for Aiven for Apache Kafka®
 sidebar_label: Enable tiered storage
 ---
 
-
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
+import {ConsoleIcon} from "@site/src/components/ConsoleIcons"
 
-Tiered storage significantly improves the storage efficiency of your Aiven for Apache Kafka® service. You can enable this feature for your service using either the [Aiven console](https://console.aiven.io/) or the [Aiven CLI](/docs/tools/cli).
+Tiered storage significantly improves the storage efficiency of your Aiven for Apache Kafka® service.
 
 ## Prerequisites
 
--   Aiven account and a project set up in the Aiven Console
--   Aiven for Apache Kafka® service with Apache Kafka version 3.6 or later
+-   Aiven account and a project set up in the [Aiven console](https://console.aiven.io/).
+-   Aiven for Apache Kafka® service with Apache Kafka version 3.6 or later.
 
+    :::note
     Tiered storage on Aiven for Apache Kafka is currently not available
     on all plans and regions. View the [plans and pricing
     page](https://aiven.io/pricing?product=kafka) for a comprehensive
     list of supported plans and regions.
+    :::
 
--   Aiven CLI
+-   [Aiven CLI](/docs/tools/cli)
 
-## Enable tiered storage via Aiven Console
+## Steps to enable tiered storage
 
+<<<<<<< HEAD
 To enable tiered storage for your service using the Aiven Console:
+=======
+<Tabs groupId="setup">
+<TabItem value="Console" label="Console" default>
+>>>>>>> 80470d1 (fix: editorial and styles)
 
 1. Log in to the [Aiven console](https://console.aiven.io/), and select
    your project.
@@ -36,12 +45,11 @@ To enable tiered storage for your service using the Aiven Console:
      1. In the **Service summary**, you can view the pricing for
         tiered storage.
    - For an existing service:
-     1. Go to the service's **Overview** page,
+     1. Go to the service's <ConsoleLabel name="overview"/> page,
         click <ConsoleLabel name="service settings"/> from the sidebar.
      1. In the Service plan section, click **Enable tiered storage**
         to activate it.
-1. Click **Activate tiered storage** to confirm your settings and turn
-   on tiered storage for your service.
+     1. In the confirmation modal, click **Activate tiered storage**.
 
 After you have activated tiered storage for your service and configured it for your
 [topics](/docs/products/kafka/howto/configure-topic-tiered-storage), you can monitor both
@@ -50,40 +58,17 @@ usage and associated costs in the
 
 :::note
 Alternatively, if tiered storage is not yet active for your service,
-you can enable it by selecting **Tiered storage**from the sidebar.
+you can enable it by selecting **Tiered storage** from the sidebar.
 :::
 
 :::warning
-If you power off a service with tiered storage active, you will
-permanently lose all remote data. However, you will not be charged for
-tiered storage while the service is off.
+Powering off your service with tiered storage active results in the permanent loss
+of all remote data. However, charges for tiered storage are not applicable while the
+service is off
 :::
 
-### Configure default retention policies at service-level
-
-1. Access [Aiven console](https://console.aiven.io/), select your
-   project, and choose your Aiven for Apache Kafka service.
-1. Click <ConsoleLabel name="service settings"/> from the sidebar.
-1. Scroll down to the **Advanced configuration** section, and click **Configure**.
-1. In the **Advanced configuration** dialog, click <ConsoleLabel name="addadvancedconfiguration" />.
-1. To define the retention policy for Aiven for Apache Kafka tiered
-   storage, choose either of these options:
-   -   Find `kafka.log_local_retention_ms` and set the value to define
-       the retention period in milliseconds for time-based retention.
-   -   Find `kafka.log_local_retention_bytes` and set the value to
-       define the retention limit in bytes for size-based retention.
-1. Click **Save configuration** to apply your changes.
-
-Additionally, you can configure the retention policies from the
-[Tiered storage overview](/docs/products/kafka/howto/tiered-storage-overview-page#modify-retention-polices) page.
-
-## (Optional) configure client-side parameter
-
-For optimal performance and reduced risk of broker interruptions when
-using tiered storage, it is recommended to update the client-side
-parameter `fetch.max.wait.ms` from its default value of 500 ms to 5000 ms.
-
-## Enable tiered storage via Aiven CLI
+</TabItem>
+<TabItem value="CLI" label="CLI">
 
 To enable tiered storage for your Aiven for Apache
 Kafka service using the [Aiven CLI](/docs/tools/cli):
@@ -131,3 +116,39 @@ In this command:
    intend to update.
 -  `-c tiered_storage.enabled=true`: Configuration flag that activates
    tiered storage for your Aiven for Apache Kafka service.
+
+</TabItem>
+</Tabs>
+
+## Configure default retention policies at service-level
+
+To efficiently manage data retention, set default policies for tiered storage at
+the service level.
+
+1. Access [Aiven console](https://console.aiven.io/), select your
+   project, and choose your Aiven for Apache Kafka service.
+1. Click <ConsoleLabel name="service settings"/> from the sidebar.
+1. Scroll down to the **Advanced configuration** section, and click **Configure**.
+1. In the **Advanced configuration** dialog, click <ConsoleLabel name="addadvancedconfiguration" />.
+1. To define the retention policy for Aiven for Apache Kafka tiered
+   storage, choose either of these options:
+   -   Find `kafka.log_local_retention_ms` and set the value to define
+       the retention period in milliseconds for time-based retention.
+   -   Find `kafka.log_local_retention_bytes` and set the value to
+       define the retention limit in bytes for size-based retention.
+1. Click **Save configuration** to apply your changes.
+
+Additionally, you can configure the retention policies from the
+[Tiered storage overview](/docs/products/kafka/howto/tiered-storage-overview-page#modify-retention-polices) page.
+
+## (Optional) configure client-side parameter
+
+For optimal performance and reduced risk of broker interruptions when
+using tiered storage, it is recommended to update the client-side
+parameter `fetch.max.wait.ms` from its default value of 500 ms to 5000 ms.
+
+## Related pages
+
+- [Tiered storage in Aiven for Apache Kafka® overview](/docs/products/kafka/concepts/kafka-tiered-storage)
+- [How tiered storage works in Aiven for Apache Kafka®](/docs/products/kafka/concepts/tiered-storage-how-it-works)
+- [Enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage)

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.md
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.md
@@ -3,6 +3,9 @@ title: Enable tiered storage for Aiven for Apache Kafka®
 sidebar_label: Enable tiered storage
 ---
 
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
+
 Tiered storage significantly improves the storage efficiency of your Aiven for Apache Kafka® service. You can enable this feature for your service using either the [Aiven console](https://console.aiven.io/) or the [Aiven CLI](/docs/tools/cli).
 
 ## Prerequisites
@@ -22,23 +25,23 @@ Tiered storage significantly improves the storage efficiency of your Aiven for A
 To enable tiered storage for your service using the Aiven Console:
 
 1. Log in to the [Aiven console](https://console.aiven.io/), and select
-    your project.
+   your project.
 1. Choose to either create an Aiven for Apache Kafka service or select an
    existing one.
-   -   For [a new service](/docs/platform/howto/create_new_service):
+   - For [a new service](/docs/platform/howto/create_new_service):
 
-       1.  On the **Create Apache Kafka® service** page, scroll down to
-           the **Tiered storage** section.
-       1.  Click **Enable tiered storage**.
-       1.  In the **Service summary**, you can view the pricing for
-           tiered storage.
-   -   For an existing service:
-       1.  Go to the service's **Overview** page, click **Service
-           settings** from the sidebar.
-       1.  In the Service plan section, click **Enable tiered storage**
-           to activate it.
-1.  Click **Activate tiered storage** to confirm your settings and turn
-    on tiered storage for your service.
+     1. On the **Create Apache Kafka® service** page, scroll down to
+        the **Tiered storage** section.
+     1. Click **Enable tiered storage**.
+     1. In the **Service summary**, you can view the pricing for
+        tiered storage.
+   - For an existing service:
+     1. Go to the service's **Overview** page,
+        click <ConsoleLabel name="service settings"/> from the sidebar.
+     1. In the Service plan section, click **Enable tiered storage**
+        to activate it.
+1. Click **Activate tiered storage** to confirm your settings and turn
+   on tiered storage for your service.
 
 After you have activated tiered storage for your service and configured it for your
 [topics](/docs/products/kafka/howto/configure-topic-tiered-storage), you can monitor both
@@ -58,20 +61,18 @@ tiered storage while the service is off.
 
 ### Configure default retention policies at service-level
 
-1.  Access [Aiven console](https://console.aiven.io/), select your
-    project, and choose your Aiven for Apache Kafka service.
-1.  In the service page, select **Service settings** from the sidebar.
-1.  On the **Service settings** page, scroll down to the **Advanced
-    configuration** section, and click **Configure**.
-1.  In the **Advanced configuration** dialog, click **Add configuration
-    option**.
-1.  To define the retention policy for Aiven for Apache Kafka tiered
-    storage, choose either of these options:
-    -   Find `kafka.log_local_retention_ms` and set the value to define
-        the retention period in milliseconds for time-based retention.
-    -   Find `kafka.log_local_retention_bytes` and set the value to
-        define the retention limit in bytes for size-based retention.
-1.  Click **Save configuration** to apply your changes.
+1. Access [Aiven console](https://console.aiven.io/), select your
+   project, and choose your Aiven for Apache Kafka service.
+1. Click <ConsoleLabel name="service settings"/> from the sidebar.
+1. Scroll down to the **Advanced configuration** section, and click **Configure**.
+1. In the **Advanced configuration** dialog, click <ConsoleLabel name="addadvancedconfiguration" />.
+1. To define the retention policy for Aiven for Apache Kafka tiered
+   storage, choose either of these options:
+   -   Find `kafka.log_local_retention_ms` and set the value to define
+       the retention period in milliseconds for time-based retention.
+   -   Find `kafka.log_local_retention_bytes` and set the value to
+       define the retention limit in bytes for size-based retention.
+1. Click **Save configuration** to apply your changes.
 
 Additionally, you can configure the retention policies from the
 [Tiered storage overview](/docs/products/kafka/howto/tiered-storage-overview-page#modify-retention-polices) page.
@@ -91,42 +92,42 @@ Kafka service using the [Aiven CLI](/docs/tools/cli):
    team](mailto:sales@aiven.io). This feature is an early availability and requires
    activation on your account.
 
-1.  Once activated, retrieve the project information using the following command:
+1. Once activated, retrieve the project information using the following command:
 
-    ```bash
-    avn project details
-    ```
+   ```bash
+   avn project details
+   ```
 
-    If you need details for a specific project, use:
+   If you need details for a specific project, use:
 
-    ```bash
-    avn project details --project <your_project_name)
-    ```
+   ```bash
+   avn project details --project <your_project_name)
+   ```
 
-1.  To find the name of the Aiven for Apache Kafka service for enabling tiered storage,
-    use this command:
+1. To find the name of the Aiven for Apache Kafka service for enabling tiered storage,
+   use this command:
 
-    ```bash
-    avn service list
-    ```
+   ```bash
+   avn service list
+   ```
 
-    Make a note of the `SERVICE_NAME` corresponding to your Aiven for
-    Apache Kafka service.
+   Make a note of the `SERVICE_NAME` corresponding to your Aiven for
+   Apache Kafka service.
 
-1.  Enable tiered storage using the command below:
+1. Enable tiered storage using the command below:
 
-    ```bash
-    avn service update \
-       --project demo-kafka-project \
-       demo-kafka-service \
-       -c tiered_storage.enabled=true
-    ```
+   ```bash
+   avn service update \
+      --project demo-kafka-project \
+      demo-kafka-service \
+      -c tiered_storage.enabled=true
+   ```
 
 In this command:
 
--   `--project demo-kafka-project`: Replace `demo-kafka-project` with
-    your project name.
--   `demo-kafka-service`: Specify the Aiven for Apache Kafka service you
-    intend to update.
--   `-c tiered_storage.enabled=true`: Configuration flag that activates
-    tiered storage for your Aiven for Apache Kafka service.
+-  `--project demo-kafka-project`: Replace `demo-kafka-project` with
+   your project name.
+-  `demo-kafka-service`: Specify the Aiven for Apache Kafka service you
+   intend to update.
+-  `-c tiered_storage.enabled=true`: Configuration flag that activates
+   tiered storage for your Aiven for Apache Kafka service.

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.md
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.md
@@ -24,7 +24,7 @@ Tiered storage significantly improves the storage efficiency of your Aiven for A
     for supported plans and regions.
     :::
 
-- [Aiven CLI](/docs/tools/cli)
+- [Aiven CLI](/docs/tools/cli).
 
 ## Steps to enable tiered storage
 

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.md
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.md
@@ -48,6 +48,12 @@ Tiered storage significantly improves the storage efficiency of your Aiven for A
         to activate it.
      1. Click **Activate tiered storage** in the confirmation window.
 
+:::note
+If tiered storage is not enabled in your project, you cannot access it.
+Contact [Aiven support]((mailto:support@aiven.io)).
+:::
+
+
 After activating tiered storage for your service and configuring it for your
 [topics](/docs/products/kafka/howto/configure-topic-tiered-storage), you can monitor
 usage and costs in the

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.md
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.md
@@ -12,85 +12,74 @@ Tiered storage significantly improves the storage efficiency of your Aiven for A
 
 ## Prerequisites
 
--   Aiven account and a project set up in the [Aiven console](https://console.aiven.io/).
--   Aiven for Apache Kafka® service with Apache Kafka version 3.6 or later.
+- Access to a project set up in the [Aiven console](https://console.aiven.io/).
+- Aiven for Apache Kafka® service with Apache Kafka version 3.6 or later.
 
     :::note
-    Tiered storage on Aiven for Apache Kafka is currently not available
-    on all plans and regions. View the [plans and pricing
-    page](https://aiven.io/pricing?product=kafka) for a comprehensive
-    list of supported plans and regions.
+    Tiered storage is not available on all plans and regions. Check the
+    [plans and pricing page](https://aiven.io/pricing?product=kafka)
+    for supported plans and regions.
     :::
 
--   [Aiven CLI](/docs/tools/cli)
+- [Aiven CLI](/docs/tools/cli)
 
 ## Steps to enable tiered storage
 
-<<<<<<< HEAD
-To enable tiered storage for your service using the Aiven Console:
-=======
 <Tabs groupId="setup">
 <TabItem value="Console" label="Console" default>
->>>>>>> 80470d1 (fix: editorial and styles)
 
 1. Log in to the [Aiven console](https://console.aiven.io/), and select
    your project.
-1. Choose to either create an Aiven for Apache Kafka service or select an
+1. Create an Aiven for Apache Kafka service or select an
    existing one.
    - For [a new service](/docs/platform/howto/create_new_service):
 
      1. On the **Create Apache Kafka® service** page, scroll down to
         the **Tiered storage** section.
      1. Click **Enable tiered storage**.
-     1. In the **Service summary**, you can view the pricing for
-        tiered storage.
+     1. View the pricing for tiered storage in the **Service summary**.
    - For an existing service:
-     1. Go to the service's <ConsoleLabel name="overview"/> page,
+     1. Go to the service's <ConsoleLabel name="overview"/> page and
         click <ConsoleLabel name="service settings"/> from the sidebar.
-     1. In the Service plan section, click **Enable tiered storage**
+     1. In the **Service plan** section, click **Enable tiered storage**
         to activate it.
-     1. In the confirmation modal, click **Activate tiered storage**.
+     1. Click **Activate tiered storage** in the confirmation window.
 
-After you have activated tiered storage for your service and configured it for your
-[topics](/docs/products/kafka/howto/configure-topic-tiered-storage), you can monitor both
-usage and associated costs in the
+After activating tiered storage for your service and configuring it for your
+[topics](/docs/products/kafka/howto/configure-topic-tiered-storage), you can monitor
+usage and costs in the
 [Tiered storage overview](/docs/products/kafka/howto/tiered-storage-overview-page) section.
 
 :::note
-Alternatively, if tiered storage is not yet active for your service,
-you can enable it by selecting **Tiered storage** from the sidebar.
+Alternatively, if tiered storage is not yet active for your service, you can enable
+it by selecting **Tiered storage** from the sidebar.
 :::
 
 :::warning
 Powering off your service with tiered storage active results in the permanent loss
-of all remote data. However, charges for tiered storage are not applicable while the
+of all remote data. Charges for tiered storage are not applicable while the
 service is off
 :::
 
 </TabItem>
 <TabItem value="CLI" label="CLI">
 
-To enable tiered storage for your Aiven for Apache
-Kafka service using the [Aiven CLI](/docs/tools/cli):
+Enable tiered storage for your Aiven for Apache Kafka service using
+the [Aiven CLI](/docs/tools/cli):
 
-1. Ensure the tiered storage feature is activated for your account by contacting [our sales
-   team](mailto:sales@aiven.io). This feature is an early availability and requires
-   activation on your account.
-
-1. Once activated, retrieve the project information using the following command:
+1. Retrieve the project information with:
 
    ```bash
    avn project details
    ```
 
-   If you need details for a specific project, use:
+   For a specific project, use:
 
    ```bash
-   avn project details --project <your_project_name)
+   avn project details --project <PROJECT_NAME>
    ```
 
-1. To find the name of the Aiven for Apache Kafka service for enabling tiered storage,
-   use this command:
+1. Find the name of the Aiven for Apache Kafka service for enabling tiered storage with:
 
    ```bash
    avn service list
@@ -99,12 +88,12 @@ Kafka service using the [Aiven CLI](/docs/tools/cli):
    Make a note of the `SERVICE_NAME` corresponding to your Aiven for
    Apache Kafka service.
 
-1. Enable tiered storage using the command below:
+1. Enable tiered storage with:
 
    ```bash
-   avn service update \
-      --project demo-kafka-project \
-      demo-kafka-service \
+   avn service update                  \
+      --project demo-kafka-project     \
+      demo-kafka-service               \
       -c tiered_storage.enabled=true
    ```
 
@@ -114,40 +103,38 @@ In this command:
    your project name.
 -  `demo-kafka-service`: Specify the Aiven for Apache Kafka service you
    intend to update.
--  `-c tiered_storage.enabled=true`: Configuration flag that activates
-   tiered storage for your Aiven for Apache Kafka service.
+-  `-c tiered_storage.enabled=true`: Activates tiered storage.
 
 </TabItem>
 </Tabs>
 
 ## Configure default retention policies at service-level
 
-To efficiently manage data retention, set default policies for tiered storage at
+To manage data retention, set default policies for tiered storage at
 the service level.
 
 1. Access [Aiven console](https://console.aiven.io/), select your
    project, and choose your Aiven for Apache Kafka service.
 1. Click <ConsoleLabel name="service settings"/> from the sidebar.
-1. Scroll down to the **Advanced configuration** section, and click **Configure**.
+1. Scroll to the **Advanced configuration** section, and click **Configure**.
 1. In the **Advanced configuration** dialog, click <ConsoleLabel name="addadvancedconfiguration" />.
-1. To define the retention policy for Aiven for Apache Kafka tiered
-   storage, choose either of these options:
+1. Define the retention policy:
    -   Find `kafka.log_local_retention_ms` and set the value to define
        the retention period in milliseconds for time-based retention.
    -   Find `kafka.log_local_retention_bytes` and set the value to
        define the retention limit in bytes for size-based retention.
 1. Click **Save configuration** to apply your changes.
 
-Additionally, you can configure the retention policies from the
+You can also configure the retention policies from the
 [Tiered storage overview](/docs/products/kafka/howto/tiered-storage-overview-page#modify-retention-polices) page.
 
-## (Optional) configure client-side parameter
+## (Optional) Configure client-side parameter
 
 For optimal performance and reduced risk of broker interruptions when
 using tiered storage, it is recommended to update the client-side
 parameter `fetch.max.wait.ms` from its default value of 500 ms to 5000 ms.
 
-However, this consumer configuration is no longer necessary starting from Apache Kafka
+This consumer configuration is no longer necessary starting from Apache Kafka
 version 3.6.2. Consider upgrading to Apache Kafka version 3.6.2 or later before
 enabling tiered storage.
 

--- a/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
+++ b/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
@@ -24,7 +24,7 @@ sets up the necessary infrastructure for using tiered storage.
 :::note
 
 - If tiered storage is not enabled in your project, you cannot access it.
-  Contact [Aiven support]((mailto:support@aiven.io)).
+  Contact [Aiven support](mailto:support@aiven.io).
 - Aiven for Apache Kafka® supports tiered storage starting from Apache Kafka® version
   3.6 or later. It is recommended to upgrade to the latest default version and apply
   [maintenance updates](/docs/platform/concepts/maintenance-window#maintenance-updates)

--- a/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
+++ b/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
@@ -6,10 +6,6 @@ import ConsoleLabel from "@site/src/components/ConsoleIcons"
 import {ConsoleIcon} from "@site/src/components/ConsoleIcons"
 
 Aiven for Apache Kafka tiered storage optimizes resources by storing recent, frequently accessed data on faster local disks.
-
-As data becomes less active, it moves to more economical, slower storage, balancing
-performance with cost efficiency.
-
 As data becomes less active, it moves to more economical, slower storage, balancing
 performance with cost efficiency.
 
@@ -26,9 +22,16 @@ sets up the necessary infrastructure for using tiered storage.
 1. Follow the instructions to [enable tiered storage](/docs/products/kafka/howto/enable-kafka-tiered-storage).
 
 :::note
-Aiven for Apache Kafka® supports tiered storage starting from Apache Kafka® version
-3.6 or later. It is not available for startup-2 plans.
+
+- Aiven for Apache Kafka® supports tiered storage starting from Apache Kafka® version
+  3.6 or later. It is recommended to upgrade to the latest default version and apply
+  [maintenance updates](/docs/platform/concepts/maintenance-window#maintenance-updates)
+  when using tiered storage for the latest fixes and improvements.
+- Tiered storage is not available on startup-2 plans.
+
 :::
+
+
 
 ## Step 2: Configure tiered storage per topic
 
@@ -49,5 +52,5 @@ Monitor your tiered storage usage to ensure optimal performance and cost efficie
 
 ## Related Pages
 
-- [Tiered storage in Aiven for Apache Kafka® overview](/docs/products/kafka/concepts/kafka-tiered-storage).
-- [Tiered storage usage overview in the Aiven Console](/docs/products/kafka/howto/tiered-storage-overview-page).
+- [Tiered storage in Aiven for Apache Kafka® overview](/docs/products/kafka/concepts/kafka-tiered-storage)
+- [Tiered storage usage overview in the Aiven Console](/docs/products/kafka/howto/tiered-storage-overview-page)

--- a/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
+++ b/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
@@ -23,6 +23,8 @@ sets up the necessary infrastructure for using tiered storage.
 
 :::note
 
+- If tiered storage is not enabled in your project, you cannot access it.
+  Contact [Aiven support]((mailto:support@aiven.io)).
 - Aiven for Apache Kafka® supports tiered storage starting from Apache Kafka® version
   3.6 or later. It is recommended to upgrade to the latest default version and apply
   [maintenance updates](/docs/platform/concepts/maintenance-window#maintenance-updates)

--- a/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
+++ b/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
@@ -5,7 +5,13 @@ title: Get started with tiered storage
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
 import {ConsoleIcon} from "@site/src/components/ConsoleIcons"
 
-Aiven for Apache Kafka tiered storage feature optimizes resources by storing recent, frequently accessed data on faster local disks. As data becomes less active, it moves to more economical, slower storage, balancing performance with cost efficiency.
+Aiven for Apache Kafka tiered storage optimizes resources by storing recent, frequently accessed data on faster local disks.
+
+As data becomes less active, it moves to more economical, slower storage, balancing
+performance with cost efficiency.
+
+As data becomes less active, it moves to more economical, slower storage, balancing
+performance with cost efficiency.
 
 For a detailed understanding of tiered storage, its workings, and benefits, see
 [Tiered storage in Aiven for Apache Kafka®](/docs/products/kafka/concepts/kafka-tiered-storage).
@@ -21,26 +27,27 @@ sets up the necessary infrastructure for using tiered storage.
 
 :::note
 Aiven for Apache Kafka® supports tiered storage starting from Apache Kafka® version
-3.6 or later. However, it is not available for startup-2 plans.
+3.6 or later. It is not available for startup-2 plans.
 :::
 
 ## Step 2: Configure tiered storage per topic
 
-After enabling tiered storage at the service level, you can configure it for
-specific topics. This gives you granular control over your data storage needs.
+After enabling tiered storage at the service level, configure it for specific
+topics to have granular control over your data storage.
 
-- For detailed instructions, see [Enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage).
-- In the <ConsoleLabel name="topics" /> page, topics using tiered storage display
-  the status **Active** in the Tiered storage column.
+- Follow the detailed instructions to [enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage).
+- On the <ConsoleLabel name="topics" /> page, topics using tiered storage display
+  **Active** in the **Tiered storage** column.
 
 ## Step 3: Monitor tiered storage usage
 
-Finally, monitor your tiered storage usage to ensure optimal performance and
-cost efficiency.
+Monitor your tiered storage usage to ensure optimal performance and cost efficiency.
 
 - Access the <ConsoleLabel name="Tiered storage" /> overviwe page in your
   Aiven for Apache Kafka service.
 - Review details on billing, settings, and specific storage aspects.
 
-For more information, see
-[Tiered Storage Overview in Aiven Console](/docs/products/kafka/howto/tiered-storage-overview-page).
+## Related Pages
+
+- [Tiered storage in Aiven for Apache Kafka® overview](/docs/products/kafka/concepts/kafka-tiered-storage).
+- [Tiered storage usage overview in the Aiven Console](/docs/products/kafka/howto/tiered-storage-overview-page).

--- a/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
+++ b/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
@@ -1,41 +1,46 @@
 ---
-title: Get started with tiered storage for Aiven for Apache Kafka®
-early: true
----
-Aiven for Apache Kafka®'s tiered storage optimizes resources by keeping recent data, typically the most
-accessed, on faster local disks. As data becomes less active, it's transferred to more economical,
-slower storage, balancing performance with cost efficiency.
+title: Get started with tiered storage
 
-For an in-depth understanding of tiered storage, how it works, and its
-benefits, see
+---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
+import {ConsoleIcon} from "@site/src/components/ConsoleIcons"
+
+Aiven for Apache Kafka tiered storage feature optimizes resources by storing recent, frequently accessed data on faster local disks. As data becomes less active, it moves to more economical, slower storage, balancing performance with cost efficiency.
+
+For a detailed understanding of tiered storage, its workings, and benefits, see
 [Tiered storage in Aiven for Apache Kafka®](/docs/products/kafka/concepts/kafka-tiered-storage).
 
-## Enable tiered storage for service
+## Step 1: Enable tiered storage for service
 
-To use tiered storage, [enable](/docs/products/kafka/howto/enable-kafka-tiered-storage)
-it for your Aiven for Apache Kafka service. This foundational step ensures that the
-necessary infrastructure is in place.
+First, enable tiered storage for your Aiven for Apache Kafka service. This
+sets up the necessary infrastructure for using tiered storage.
+
+1. Log in to the [Aiven console](https://console.aiven.io/).
+1. Select your project and the Aiven for Apache Kafka service.
+1. Follow the instructions to [enable tiered storage](/docs/products/kafka/howto/enable-kafka-tiered-storage).
 
 :::note
-Tiered storage for Aiven for Apache Kafka® is supported starting from
-Apache Kafka® version 3.6 and is not available for startup-2 plans.
+Aiven for Apache Kafka® supports tiered storage starting from Apache Kafka® version
+3.6 or later. However, it is not available for startup-2 plans.
 :::
 
-## Configure tiered storage per topic
+## Step 2: Configure tiered storage per topic
 
-Once the tiered storage is enabled at the service level, you can
-configure it for individual topics. In the Aiven for Apache Kafka Topics
-page, topics using tiered storage will display **Active** in the
-**Tiered storage** column.
+After enabling tiered storage at the service level, you can configure it for
+specific topics. This gives you granular control over your data storage needs.
 
-For detailed instructions, see
-[Configuring tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage).
+- For detailed instructions, see [Enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage).
+- In the <ConsoleLabel name="topics" /> page, topics using tiered storage display
+  the status **Active** in the Tiered storage column.
 
-## Tiered storage usage overview
+## Step 3: Monitor tiered storage usage
 
-Gain insights into tiered storage usage from the **Tiered Storage
-Overview** page in your Aiven for Apache Kafka service. This includes
-details on billing, settings, and specific storage aspects.
+Finally, monitor your tiered storage usage to ensure optimal performance and
+cost efficiency.
+
+- Access the <ConsoleLabel name="Tiered storage" /> overviwe page in your
+  Aiven for Apache Kafka service.
+- Review details on billing, settings, and specific storage aspects.
 
 For more information, see
 [Tiered Storage Overview in Aiven Console](/docs/products/kafka/howto/tiered-storage-overview-page).

--- a/docs/products/kafka/howto/tiered-storage-overview-page.md
+++ b/docs/products/kafka/howto/tiered-storage-overview-page.md
@@ -4,6 +4,9 @@ sidebar_label: Tiered storage overview page
 
 ---
 
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
+import {ConsoleIcon} from "@site/src/components/ConsoleIcons"
+
 Aiven for Apache Kafka® offers a comprehensive overview of tiered storage, allowing you to understand its usage and make informed decisions.
 
 This overview page provides insights into various aspects of tiered storage, including
@@ -11,62 +14,62 @@ hourly billing, settings, and storage details.
 
 ## Prerequisite
 
--   [Tiered storage enabled for the Aiven for Apache Kafka service](/docs/products/kafka/howto/enable-kafka-tiered-storage).
+- [Tiered storage enabled for the Aiven for Apache Kafka service](/docs/products/kafka/howto/enable-kafka-tiered-storage).
 
 ## Access tiered storage overview page
 
-1.  Log in to the [Aiven console](https://console.aiven.io/), choose
-    your project and select your Aiven for Apache Kafka service.
-1.  From the left sidebar, select **Tiered Storage**.
-    -   If tiered storage is not yet enabled for your service, you will
-        see the option to enabled it.
-    -   If tiered storage is enabled but not configured for any topics,
-        you have the option to set it up for topics directly. For more
-        details, see
-        [Enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage).
-1.  Once configured, you can view an overview of tiered storage and its
-    associated details.
+1. Log in to the [Aiven console](https://console.aiven.io/), choose
+   your project and select your Aiven for Apache Kafka service.
+1. Click <ConsoleLabel name="Tiered storage" />.
+
+   -   If tiered storage is not yet enabled for your service, you will
+       see the option to enabled it.
+   -   If tiered storage is enabled but not configured for any topics,
+       you have the option to set it up for topics directly. For more
+       details, see
+       [Enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage).
+1. Once configured, you can view an overview of tiered storage and its
+   associated details.
 
 ## Key insights of tiered storage
 
 Get a quick snapshot of the essential metrics and details related to
 tiered storage:
 
--   **Current billing expenses in USD**: Displays your tiered storage
-    costs, calculated at hourly rates.
--   **Forecasted month cost in USD**: Estimate your upcoming monthly
-    costs based on current usage.
--   **Remote tier usage in bytes**: View the volume of data that has
-    been tiered.
--   **Storage overview**: View how topics use
-    [remote storage](/docs/products/kafka/howto/tiered-storage-overview-page#remote-storage-overview).
+- **Current billing expenses in USD**: Displays your tiered storage
+  costs, calculated at hourly rates.
+- **Forecasted month cost in USD**: Estimate your upcoming monthly
+  costs based on current usage.
+- **Remote tier usage in bytes**: View the volume of data that has
+  been tiered.
+- **Storage overview**: View how topics use
+  [remote storage](/docs/products/kafka/howto/tiered-storage-overview-page#remote-storage-overview).
 
 ## Current tiered storage settings
 
 This section provides an overview of the current local cache details and
 retention policy configurations for tiered storage:
 
--   **Default local retention time (ms)**: Shows the current local data
-    retention set in milliseconds.
--   **Default local retention bytes**: Shows the configured volume of
-    data, in bytes, for local retention.
+- **Default local retention time (ms)**: Shows the current local data
+  retention set in milliseconds.
+- **Default local retention bytes**: Shows the configured volume of
+  data, in bytes, for local retention.
 
 ### Modify retention policies {#modify-retention-polices}
 
-1.  In the **Tiered storage settings** section, click **Actions(\...)**
-    and click **Update tiered storage settings**.
-1.  Within **Update tiered storage settings** page, adjust the values
-    for:
-    -   Local Cache
-    -   Default Local Retention Time (ms)
-    -   Default Local Retention Bytes
-1.  Click **Save changes**.
+1. In the **Tiered storage settings** section, click
+   <ConsoleLabel name="actions"/> > **Update tiered storage settings**.
+1. Within **Update tiered storage settings** page, adjust the values
+   for:
+   - Default Local Retention Time (ms)
+   - Default Local Retention Bytes
+1. Click **Save changes**.
 
 ## Remote storage overview
 
 Explore the specifics of your storage usage and configurations:
 
--   **Remote storage usage by topics**: Analyze how much tiered storage
-    each topic uses.
--   **Filter by topic**: Narrow down your view to specific topics for
-    focused insights.
+- **Remote storage usage by topics**: Analyze how much tiered storage
+  each topic uses.
+- **Filter by topic**: Narrow down your view to specific topics for
+  focused insights.

--- a/docs/products/kafka/howto/tiered-storage-overview-page.md
+++ b/docs/products/kafka/howto/tiered-storage-overview-page.md
@@ -1,7 +1,7 @@
 ---
 title: Tiered storage overview page in Aiven Console
 sidebar_label: Tiered storage overview page
-early: true
+
 ---
 
 Aiven for Apache Kafka® offers a comprehensive overview of tiered storage, allowing you to understand its usage and make informed decisions.

--- a/docs/products/kafka/howto/tiered-storage-overview-page.md
+++ b/docs/products/kafka/howto/tiered-storage-overview-page.md
@@ -22,14 +22,12 @@ hourly billing, settings, and storage details.
    your project and select your Aiven for Apache Kafka service.
 1. Click <ConsoleLabel name="Tiered storage" />.
 
-   -   If tiered storage is not yet enabled for your service, you will
-       see the option to enabled it.
-   -   If tiered storage is enabled but not configured for any topics,
-       you have the option to set it up for topics directly. For more
-       details, see
-       [Enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage).
-1. Once configured, you can view an overview of tiered storage and its
-   associated details.
+   - If tiered storage is not yet enabled for your service, you see the option to
+     enabled it.
+   - If tiered storage is enabled for the service but not for any topics, you see
+     the option to enable it for topics. For more
+     details, see [Enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage).
+1. Once configured, you can view an overview of tiered storage and its details
 
 ## Key insights of tiered storage
 
@@ -38,17 +36,16 @@ tiered storage:
 
 - **Current billing expenses in USD**: Displays your tiered storage
   costs, calculated at hourly rates.
-- **Forecasted month cost in USD**: Estimate your upcoming monthly
-  costs based on current usage.
-- **Remote tier usage in bytes**: View the volume of data that has
-  been tiered.
-- **Storage overview**: View how topics use
+- **Forecasted month cost in USD**: Displays your upcoming monthly costs
+  based on current usage.
+- **Remote tier usage in bytes**: Displays the volume of data that has been tiered.
+- **Storage overview**: Displays an overview of how topics use
   [remote storage](/docs/products/kafka/howto/tiered-storage-overview-page#remote-storage-overview).
 
-## Current tiered storage settings
+## Tiered storage settings
 
-This section provides an overview of the current local cache details and
-retention policy configurations for tiered storage:
+Overview of the current local cache details and retention policy configurations for
+tiered storage:
 
 - **Default local retention time (ms)**: Shows the current local data
   retention set in milliseconds.

--- a/docs/products/kafka/howto/tiered-storage-overview-page.md
+++ b/docs/products/kafka/howto/tiered-storage-overview-page.md
@@ -27,7 +27,7 @@ hourly billing, settings, and storage details.
    - If tiered storage is enabled for the service but not for any topics, you see
      the option to enable it for topics. For more
      details, see [Enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage).
-1. Once configured, you can view an overview of tiered storage and its details
+1. Once configured, you can view an overview of tiered storage and its details.
 
 ## Key insights of tiered storage
 

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.md
@@ -147,7 +147,7 @@ To create a Kafka Connect connector:
 
    - Manually create topics using the naming pattern: `database.server.name.schema_name.table_name`.
    - Enable the `Kafka topic auto-creation` feature.
-     See [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli).
+     See [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically).
    :::
 
 1. Verify the connector status under the **Connectors** screen.

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mysql.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mysql.md
@@ -208,7 +208,7 @@ To create a Kafka Connect connector:
 
    - Manually create topics using the naming pattern: `database.server.name.schema_name.table_name`.
    - Enable the `Kafka topic auto-creation` feature.
-     See [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli).
+     See [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically).
 
    :::
 

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg.md
@@ -178,7 +178,7 @@ With Aiven for Apache Kafka, topics are not created automatically. You have two 
 
 - Manually create topics using the naming pattern: `database.server.name.schema_name.table_name`.
 - Enable the `Kafka topic auto-creation` feature. See
-  [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli)
+  [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically)
 :::
 
 ## Solve the error `must be superuser to create FOR ALL TABLES publication`

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.md
@@ -268,7 +268,7 @@ To create a Kafka Connect connector:
 
    - Manually create topics using the naming pattern: `database.server.name.schema_name.table_name`.
    - Enable the `Kafka topic auto-creation` feature.
-     See [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically#enable-automatic-topic-creation-with-aiven-cli).
+     See [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically).
 
 1.  Verify the connector status under the **Connectors** screen.
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -768,7 +768,6 @@ const sidebars: SidebarsConfig = {
                     id: 'products/kafka/concepts/kafka-tiered-storage',
                   },
                   items: [
-                    'products/kafka/concepts/kafka-tiered-storage',
                     'products/kafka/concepts/tiered-storage-how-it-works',
                     'products/kafka/concepts/tiered-storage-guarantees',
                     'products/kafka/concepts/tiered-storage-limitations',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -765,7 +765,7 @@ const sidebars: SidebarsConfig = {
                   label: 'Tiered storage',
                   link: {
                     type: 'doc',
-                    id: 'products/kafka/concepts/list-kafka-tiered-storage',
+                    id: 'products/kafka/concepts/kafka-tiered-storage',
                   },
                   items: [
                     'products/kafka/concepts/kafka-tiered-storage',

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -59,6 +59,7 @@ export default function ConsoleLabel({name}): ReactElement {
         </>
       );
     case 'projectsettings':
+    case 'projectsettings':
       return (
         <>
           <ConsoleIconWrapper icon={ConsoleIcons.cog} /> <b>Settings</b>
@@ -343,18 +344,11 @@ export default function ConsoleLabel({name}): ReactElement {
           <ConsoleIconWrapper icon={ConsoleIcons.plus} /> <b>Plus</b>
         </>
       );
-    case 'governance':
+    case 'addadvancedconfiguration':
       return (
         <>
-          <ConsoleIconWrapper icon={ConsoleIcons.governance} />
-          <b>Apache Kafka governance</b>
-        </>
-      );
-    case 'grouprequests':
-      return (
-        <>
-          <ConsoleIconWrapper icon={ConsoleIcons.people} />{' '}
-          <b>Group requests</b>
+          <ConsoleIconWrapper icon={ConsoleIcons.plusCircle} />{' '}
+          <b>Add Advanced Configuration</b>
         </>
       );
     default:

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -367,7 +367,7 @@ export default function ConsoleLabel({name}): ReactElement {
     case 'tieredstorage':
       return (
         <>
-          <ConsoleIconWrapper icon={ConsoleIcons.layers} />{' '}
+          <ConsoleIconWrapper icon={ConsoleIcons.tiered} />{' '}
           <b>Tiered storage</b>
         </>
       );

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -318,6 +318,12 @@ export default function ConsoleLabel({name}): ReactElement {
           <ConsoleIconWrapper icon={ConsoleIcons.edit} /> <b>Edit ACL rules </b>
         </>
       );
+    case 'edittopic':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.edit} /> <b>Edit topic </b>
+        </>
+      );
     case 'duplicateuser':
       return (
         <>
@@ -349,6 +355,20 @@ export default function ConsoleLabel({name}): ReactElement {
         <>
           <ConsoleIconWrapper icon={ConsoleIcons.plusCircle} />{' '}
           <b>Add Advanced Configuration</b>
+        </>
+      );
+    case 'kafkaTopic':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.kafkaTopic} />{' '}
+          <b>Kafka Topic</b>
+        </>
+      );
+    case 'tieredstorage':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.layers} />{' '}
+          <b>Tiered storage</b>
         </>
       );
     default:


### PR DESCRIPTION
## Describe your changes

- Removed Early Availability tags from Kafka tiered storage content.
- Updated the Pricing section in the overview topic to include details about tiered storage charges.


## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
