### PR TITLE
fix: match variable names with variable placeholder

### DIFF
--- a/docs/products/cassandra/howto/connect-python.md
+++ b/docs/products/cassandra/howto/connect-python.md
@@ -27,7 +27,7 @@ These are the placeholders you will need to replace in the code sample:
 | `PORT`         | Port number used for connecting to your Cassandra service                      |
 | `USER`         | Username used for connecting to your Cassandra service. Defaults to `avnadmin` |
 | `PASSWORD`     | Password of the `avnadmin` user                                                |
-| `SSL-CERTFILE` | Path to the `CA Certificate` file of your Cassandra service                    |
+| `SSL_CERTFILE` | Path to the `CA Certificate` file of your Cassandra service                    |
 
 :::tip
 The Aiven for Cassandra CA certificate can be downloaded from [Aiven
@@ -38,6 +38,6 @@ Console](https://console.aiven.io/) on the service detail page.
 
 The following example establishes a SSL connection with your database
 cluster; replace the placeholders for `HOST`, `PORT`, `USER`,
-`PASSWORD`, `SSL-CERTFILE`:
+`PASSWORD`, `SSL_CERTFILE`:
 
 <CodeBlock language='python'>{MyComponentSource1}</CodeBlock>


### PR DESCRIPTION
## Describe your changes
Just a minor change to align the documented variable name `SSL_CERTFILE` with the placeholder in the code. Noticed when I did a Ctrl^C on the web page - with no hits.

Could as well be done the other way around of course, by rather changing the variable name in the code example.

## Checklist

- [ X] The first paragraph of the page is on one line.
- [ X] The other lines have a line break at 90 characters.
- [ -] I checked the output.
- [ X] I applied the [style guide](../styleguide.md).
- [ X] My links start with `/docs/`.
