### PR TITLE
add: InfluxDB and M3DB migration to Thanos Metrics

### DIFF
--- a/docs/products/metrics/howto/migrate-influxdb-thanos.md
+++ b/docs/products/metrics/howto/migrate-influxdb-thanos.md
@@ -6,32 +6,32 @@ import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 Migrate your Aiven for InfluxDB databases to Aiven for Thanos Metrics using the Aiven Console migration tool.
 
-## Compatibility considerations
+## Prerequisites for Migration: Compatibility Considerations
 
-Before migrating an InfluxDB database to Aiven for Metrics, carefully
-review your current InfluxDB setup.
+Before migrating an InfluxDB database to Aiven for Metrics, carefully review your
+current InfluxDB setup and ensure you meet the following prerequisites:
 
 - **Review database setup:** Examine your InfluxDB database's data structures, storage
   patterns, and configurations. Identify any unique features, custom settings, and
   specific configurations.
+
+  :::note
+  The migration doesn't include service user accounts and commands in progress.
+  :::
+
 - **API and query language compatibility:** Thanos Metrics uses PromQL, which is
-  different from InfluxDB's InfluxQL. Update your queries to be
-  compatible with PromQL. For assistance, you can use tools such as the
+  different from InfluxDB's InfluxQL. Update your queries to be compatible with PromQL.
+  For assistance, you can use tools such as the
   [InfluxQL to PromQL converter](https://github.com/logzio/influxql-to-promql-converter)
   or Aiven's own [dashboard converter](https://github.com/Aiven-Open/influxql-to-m3-dashboard-converter).
   The built-in dashboards provided by Aiven services through integrations will not
   require any manual changes.
 - **Version compatibility:** Ensure that your InfluxDB version supports migration to
   Thanos Metrics. You might need to upgrade your InfluxDB to a compatible version.
+- **Migration preparation:** Make a note of the Aiven project and Aiven for InfluxDB
+  service name for migration in the [Aiven Console](https://console.aiven.io/).
 
-## Prerequisites
-
-Before starting the migration from an Aiven for InfluxDB service:
-
-- Make a note of the Aiven project and Aiven for InfluxDB service name
-  for migration in the [Aiven Console](https://console.aiven.io/).
-
-The [Aiven Console](https://console.aiven.io/)migration tool automatically uses
+The Aiven Console migration tool automatically uses
 connection details like the hostname, port, and credentials linked to the selected
 Aiven for InfluxDB service.
 
@@ -39,7 +39,7 @@ Aiven for InfluxDB service.
 
 1. Log in to the [Aiven Console](https://console.aiven.io/) and select
    the Aiven for Metrics service for your InfluxDB database migration.
-1. Go to **Service settings** from the sidebar.
+1. Go to <ConsoleLabel name="service settings"/> from the sidebar.
 1. Scroll to the **Service management** section, and
    click <ConsoleLabel name="actions"/> > **Import database**.
    to initiate the import process.
@@ -47,8 +47,8 @@ Aiven for InfluxDB service.
 
 ### Step 1: Configure
 
-1. From the drop-down menu, select your project name.
-1. From the subsequent drop-down, select the Aiven for InfluxDB database
+1. Select your project name.
+1. Select the Aiven for InfluxDB database
    you intend to migrate.
 1. Click **Get started** to proceed with the migration.
 
@@ -56,7 +56,9 @@ Aiven for InfluxDB service.
 
 The [Aiven Console](https://console.aiven.io/) automatically
 attempts to validate the database configurations for the selected Aiven
-for InfluxDB service. Click **Run validation** to validate the connection.
+for InfluxDB service.
+
+- Click **Run validation** to validate the connection.
 
 :::warning
 If a validation error occurs during migration, follow the on-screen
@@ -67,7 +69,7 @@ user accounts and commands in progress.
 
 ### Step 3: Migration
 
-Once all the necessary checks have been completed successfully, you can
+Once all the necessary checks have been completed, you can
 proceed with the migration process.
 
 - Click **Start migration** to initiate the data migration process to
@@ -84,19 +86,15 @@ While the migration is in progress:
 - To stop the migration, click **Stop migration**. The data already transferred
   to Aiven for Metrics is preserved.
 
-  :::important
-  To prevent conflicts during replication:
+To prevent conflicts during replication:
 
-  - Avoid creating or deleting databases on the source service during migration.
-  - Avoid making network or configuration changes that can disrupt
-    the ongoing connection between the source and target databases,
-    such as modifying firewall rules or altering trusted sources.
-  :::
+- Avoid creating or deleting databases on the source service during migration.
+- Avoid making network or configuration changes that can disrupt
+  the ongoing connection between the source and target databases,
+  such as modifying firewall rules or altering trusted sources.
 
-    :::note
-    If the migration fails, investigate, resolve, and restart the
-    migration using **Start over**.
-    :::
+If the migration fails, investigate, resolve, and restart the
+migration using **Start over**.
 
 ### Step 5: Close and post-migration
 
@@ -105,13 +103,8 @@ Upon successful migration:
 - **Stop replication**: If no further synchronization is required and
   you are ready to switch to Aiven for Thanos Metrics after thoroughly
   testing the service.
-- **Keep replicating**: If ongoing data synchronization is necessary
-  to maintain active synchronization.
-
-:::warning
-Avoid system updates or configuration changes during active replication
-to prevent unintentional migrations.
-:::
+- **Keep replicating**: If ongoing data synchronization. Avoid system updates or
+  configuration changes during active replication to prevent unintentional migrations.
 
 :::note
 When replication mode is active, Aiven for Metrics ensures your data remains in sync,

--- a/docs/products/metrics/howto/migrate-influxdb-thanos.md
+++ b/docs/products/metrics/howto/migrate-influxdb-thanos.md
@@ -19,6 +19,8 @@ review your current InfluxDB setup.
   compatible with PromQL. For assistance, you can use tools such as the
   [InfluxQL to PromQL converter](https://github.com/logzio/influxql-to-promql-converter)
   or Aiven's own [dashboard converter](https://github.com/Aiven-Open/influxql-to-m3-dashboard-converter).
+  The built-in dashboards provided by Aiven services through integrations will not
+  require any manual changes.
 - **Version compatibility:** Ensure that your InfluxDB version supports migration to
   Thanos Metrics. You might need to upgrade your InfluxDB to a compatible version.
 

--- a/docs/products/metrics/howto/migrate-influxdb-thanos.md
+++ b/docs/products/metrics/howto/migrate-influxdb-thanos.md
@@ -85,11 +85,7 @@ While the migration is in progress:
   :::important
   To prevent conflicts during replication:
 
-  - The target database is in a read-only state during
-    migration. Writing to the database is only possible once the
-    migration is stopped.
-  - Do not manually change the replication settings of the source
-    database.
+  - Avoid creating or deleting databases on the source service during migration.
   - Avoid making network or configuration changes that can disrupt
     the ongoing connection between the source and target databases,
     such as modifying firewall rules or altering trusted sources.

--- a/docs/products/metrics/howto/migrate-influxdb-thanos.md
+++ b/docs/products/metrics/howto/migrate-influxdb-thanos.md
@@ -1,0 +1,125 @@
+---
+title: Migrate Aiven for InfluxDB to Aiven for Metrics
+---
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
+
+Migrate your Aiven for InfluxDB databases to Aiven for Thanos Metrics using the Aiven Console migration tool.
+
+## Compatibility considerations
+
+Before migrating an InfluxDB database to Aiven for Metrics, carefully
+review your current InfluxDB setup.
+
+- **Review database setup:** Examine your InfluxDB database's data structures, storage
+  patterns, and configurations. Identify any unique features, custom settings, and
+  specific configurations.
+- **API and query language compatibility:** Thanos Metrics uses PromQL, which is
+  different from InfluxDB's InfluxQL. Update your queries to be
+  compatible with PromQL. For assistance, you can use tools such as the
+  [InfluxQL to PromQL converter](https://github.com/logzio/influxql-to-promql-converter)
+  or Aiven's own [dashboard converter](https://github.com/Aiven-Open/influxql-to-m3-dashboard-converter).
+- **Version compatibility:** Ensure that your InfluxDB version supports migration to
+  Thanos Metrics. You might need to upgrade your InfluxDB to a compatible version.
+
+## Prerequisites
+
+Before starting the migration from an Aiven for InfluxDB service:
+
+- Make a note of the Aiven project and Aiven for InfluxDB service name
+  for migration in the [Aiven Console](https://console.aiven.io/).
+
+The [Aiven Console](https://console.aiven.io/)migration tool automatically uses
+connection details like the hostname, port, and credentials linked to the selected
+Aiven for InfluxDB service.
+
+## Database migration steps
+
+1. Log in to the [Aiven Console](https://console.aiven.io/) and select
+   the Aiven for Metrics service for your InfluxDB database migration.
+1. Go to **Service settings** from the sidebar.
+1. Scroll to the **Service management** section, and
+   click <ConsoleLabel name="actions"/> > **Import database**.
+   to initiate the import process.
+1. Follow the wizard to guide you through the database migration process.
+
+### Step 1: Configure
+
+1. From the drop-down menu, select your project name.
+1. From the subsequent drop-down, select the Aiven for InfluxDB database
+   you intend to migrate.
+1. Click **Get started** to proceed with the migration.
+
+### Step 2: Validation
+
+The [Aiven Console](https://console.aiven.io/) automatically
+attempts to validate the database configurations for the selected Aiven
+for InfluxDB service. Click **Run validation** to validate the connection.
+
+:::warning
+If a validation error occurs during migration, follow the on-screen
+instructions to fix it. Rerun validation to ensure the database meets
+migration criteria. Note that the migration doesn't include service
+user accounts and commands in progress.
+:::
+
+### Step 3: Migration
+
+Once all the necessary checks have been completed successfully, you can
+proceed with the migration process.
+
+- Click **Start migration** to initiate the data migration process to
+  Aiven for Thanos Metrics.
+
+### Step 4: Replication
+
+While the migration is in progress:
+
+- You can close the migration wizard by clicking **Close window** and
+  return later to monitor the progress. Check the service's **Overview** page to track
+  the migration progress.
+
+- To stop the migration, click **Stop migration**. The data already transferred
+  to Aiven for Metrics is preserved.
+
+  :::important
+  To prevent conflicts during replication:
+
+  - The target database is in a read-only state during
+    migration. Writing to the database is only possible once the
+    migration is stopped.
+  - Do not manually change the replication settings of the source
+    database.
+  - Avoid making network or configuration changes that can disrupt
+    the ongoing connection between the source and target databases,
+    such as modifying firewall rules or altering trusted sources.
+  :::
+
+    :::note
+    If the migration fails, investigate, resolve, and restart the
+    migration using **Start over**.
+    :::
+
+### Step 5: Close and post-migration
+
+Upon successful migration:
+
+- **Stop replication**: If no further synchronization is required and
+  you are ready to switch to Aiven for Thanos Metrics after thoroughly
+  testing the service.
+- **Keep replicating**: If ongoing data synchronization is necessary
+  to maintain active synchronization.
+
+:::warning
+Avoid system updates or configuration changes during active replication
+to prevent unintentional migrations.
+:::
+
+:::note
+When replication mode is active, Aiven for Metrics ensures your data remains in sync,
+with continuous synchronization of new writes from the source database.
+:::
+
+## Related pages
+
+- [Aiven for Thanos Metrics overview](/docs/products/metrics/concepts/metrics-overview)

--- a/docs/products/metrics/howto/migrate-influxdb-thanos.md
+++ b/docs/products/metrics/howto/migrate-influxdb-thanos.md
@@ -8,8 +8,8 @@ Migrate your Aiven for InfluxDB databases to Aiven for Thanos Metrics using the 
 
 ## Prerequisites for Migration: Compatibility Considerations
 
-Before migrating an InfluxDB database to Aiven for Metrics, carefully review your
-current InfluxDB setup and ensure you meet the following prerequisites:
+Review your current InfluxDB setup before migrating to Aiven for Metrics, and ensure it
+meets the following prerequisites:
 
 - **Review database setup:** Examine your InfluxDB database's data structures, storage
   patterns, and configurations. Identify any unique features, custom settings, and

--- a/docs/products/metrics/howto/migrate-m3db-thanos.md
+++ b/docs/products/metrics/howto/migrate-m3db-thanos.md
@@ -6,72 +6,67 @@ import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 Migrate your Aiven for M3DB databases to Aiven for Thanos Metrics using the Aiven Console migration tool.
 
-## Compatibility considerations
-
-Review your current M3DB setup before migrating to Aiven for Metrics.
-
-- **Review database setup:** Examine your M3DB database's data structures,
-  storage patterns, and configurations. Identify any unique features, custom settings,
-  and specific configurations.
-- **API and query language compatibility:** Both Thanos Metrics and M3DB use PromQL,
-  so most existing queries will work as is. However, be aware that the same metric
-  might have a slightly different name when written directly to Thanos compared to its
-  name in M3DB. For example, `prometheus_<metric-name>` in M3DB might be called
-  `<metric-name>` in Thanos. Consequently, after migration, you may encounter two names
-  for the same metric:
-
-  - `prometheus_<metric-name>{_source=m3db, labels...}` (for time series migrated from M3DB)
-  - `<metric-name>{labels...}` (for time series written to Thanos directly)
-
-  Adjust your queries accordingly. The built-in dashboards provided by Aiven
-  services through integrations do not require any manual changes.
-- **Version compatibility:** Ensure your M3DB version supports migration to
-  Thanos Metrics. You might need to upgrade your M3DB to a compatible version.
-
 ## Prerequisites
 
-Before starting the migration from an Aiven for M3DB service:
+Review your current M3DB setup before migrating to Aiven for Metrics and ensure you
+meet the following prerequisites:
 
-- Make a note of the Aiven project and Aiven for M3DB service name for migration in the
-  [Aiven Console](https://console.aiven.io/).
+- **Review database setup:** Examine your M3DB database's data structures, storage
+  patterns, and configurations. Identify any unique features, custom settings, and
+  specific configurations.
 
-The [Aiven Console](https://console.aiven.io/) migration tool automatically uses
-connection details like the hostname, port, and credentials linked to the selected
-Aiven for M3DB service.
+  :::note
+  The migration doesn't include service user accounts and commands in progress.
+  :::
+
+- **API and query language compatibility:** Both Thanos Metrics and M3DB use PromQL, so
+  most existing queries will work as is. However, be aware that the same metric might
+  have a slightly different name when written directly to Thanos compared to its name
+  in M3DB. For example, `prometheus_<metric-name>` in M3DB might be
+  called `<metric-name>` in Thanos. Consequently, after migration, you may encounter
+  two names for the same metric:
+    - `prometheus_<metric-name>{_source=m3db, labels...}` (for time series migrated from M3DB)
+    - `<metric-name>{labels...}` (for time series written to Thanos directly)
+
+  Adjust your queries accordingly. The built-in dashboards provided by Aiven services
+  through integrations do not require any manual changes.
+- **Version compatibility:** Ensure your M3DB version supports migration to Thanos
+  Metrics. You might need to upgrade your M3DB to a compatible version.
 
 ## Database migration steps
 
 1. Log in to the [Aiven Console](https://console.aiven.io/) and select the
    Aiven for Metrics service for your M3DB database migration.
-1. Go to **Service settings** from the sidebar.
+1. Go to <ConsoleLabel name="service settings"/> from the sidebar.
 1. Scroll to the **Service management** section, and click
    <ConsoleLabel name="actions"/> > **Import database** to initiate the import process.
 1. Follow the wizard to guide you through the database migration process.
 
 ### Step 1: Configure
 
-1. From the drop-down menu, select your project name.
-2. From the subsequent drop-down, select the Aiven for M3DB database you intend to migrate.
-3. Click **Get started** to proceed with the migration.
+1. Select your project name.
+1. Select the Aiven for M3DB database you intend to migrate.
+1. Click **Get started** to proceed with the migration.
 
 ### Step 2: Validation
 
 The [Aiven Console](https://console.aiven.io/) automatically attempts to validate
 the database configurations for the selected Aiven for M3DB service.
-Click **Run validation** to validate the connection.
+
+- Click **Run validation** to validate the connection.
 
 :::warning
-If a validation error occurs during migration, follow the on-screen instructions to f
-ix it. Rerun validation to ensure the database meets migration criteria. Note that the
-migration doesn't include service user accounts and commands in progress.
+If a validation error occurs during migration, follow the on-screen instructions to
+fix it. Rerun validation to ensure the database meets migration criteria.
 :::
 
 ### Step 3: Migration
 
-Once all the necessary checks have been completed successfully, you can proceed with
+Once all the necessary checks have been completed, you can proceed with
 the migration process.
 
-- Click **Start migration** to initiate the data migration process to Aiven for Metrics.
+- Click **Start migration** to initiate the data migration
+process to Aiven for Metrics.
 
 ### Step 4: Replication
 
@@ -83,7 +78,6 @@ While the migration is in progress:
 - To stop the migration, click **Stop migration**. The data already transferred to
   Aiven for Metrics is preserved.
 
-:::important
 To prevent conflicts during replication:
 
 - Avoid creating, deleting, or modifying namespaces on the source service
@@ -91,12 +85,9 @@ To prevent conflicts during replication:
 - Avoid making network or configuration changes that can disrupt the ongoing
   connection between the source and target databases, such as modifying firewall
   rules or altering trusted sources.
-:::
 
-:::note
 If the migration fails, investigate, resolve, and restart the migration
 using **Start over**.
-:::
 
 ### Step 5: Close and post-migration
 
@@ -104,13 +95,8 @@ Upon successful migration:
 
 - **Stop replication:** If no further synchronization is required and you are ready
   to switch to Aiven for Thanos Metrics after thoroughly testing the service.
-- **Keep replicating:** If ongoing data synchronization is necessary to maintain
-  active synchronization.
-
-:::warning
-Avoid system updates or configuration changes during active replication to prevent
-unintentional migrations.
-:::
+- **Keep replicating:** If ongoing data synchronization. Avoid system updates or
+  configuration changes during active replication to prevent unintentional migrations.
 
 :::note
 When replication mode is active, Aiven for Metrics ensures your data remains in sync,

--- a/docs/products/metrics/howto/migrate-m3db-thanos.md
+++ b/docs/products/metrics/howto/migrate-m3db-thanos.md
@@ -86,7 +86,8 @@ While the migration is in progress:
 :::important
 To prevent conflicts during replication:
 
-- Avoid creating or deleting databases on the source service during migration.
+- Avoid creating, deleting, or modifying namespaces on the source service
+  during migration.
 - Avoid making network or configuration changes that can disrupt the ongoing
   connection between the source and target databases, such as modifying firewall
   rules or altering trusted sources.

--- a/docs/products/metrics/howto/migrate-m3db-thanos.md
+++ b/docs/products/metrics/howto/migrate-m3db-thanos.md
@@ -8,8 +8,8 @@ Migrate your Aiven for M3DB databases to Aiven for Thanos Metrics using the Aive
 
 ## Prerequisites
 
-Review your current M3DB setup before migrating to Aiven for Metrics and ensure you
-meet the following prerequisites:
+Review your current M3DB setup before migrating to Aiven for Metrics, and ensure it
+meets the following prerequisites:
 
 - **Review database setup:** Examine your M3DB database's data structures, storage
   patterns, and configurations. Identify any unique features, custom settings, and

--- a/docs/products/metrics/howto/migrate-m3db-thanos.md
+++ b/docs/products/metrics/howto/migrate-m3db-thanos.md
@@ -17,14 +17,14 @@ Review your current M3DB setup before migrating to Aiven for Metrics.
   so most existing queries will work as is. However, be aware that the same metric
   might have a slightly different name when written directly to Thanos compared to its
   name in M3DB. For example, `prometheus_<metric-name>` in M3DB might be called
-  `<metric-name>` in Thanos. Consequently, after migration, you will have two names
+  `<metric-name>` in Thanos. Consequently, after migration, you may encounter two names
   for the same metric:
 
   - `prometheus_<metric-name>{_source=m3db, labels...}` (for time series migrated from M3DB)
   - `<metric-name>{labels...}` (for time series written to Thanos directly)
 
-  Adjust your queries accordingly. All Aiven-generated built-in dashboards will work
-  out of the box.
+  Adjust your queries accordingly. The built-in dashboards provided by Aiven
+  services through integrations do not require any manual changes.
 - **Version compatibility:** Ensure your M3DB version supports migration to
   Thanos Metrics. You might need to upgrade your M3DB to a compatible version.
 

--- a/docs/products/metrics/howto/migrate-m3db-thanos.md
+++ b/docs/products/metrics/howto/migrate-m3db-thanos.md
@@ -10,14 +10,21 @@ Migrate your Aiven for M3DB databases to Aiven for Thanos Metrics using the Aive
 
 Review your current M3DB setup before migrating to Aiven for Metrics.
 
-- **Review database setup:** Examine your M3DB database's data structures, storage
-  patterns, and configurations. Identify any unique features, custom settings, and
-  specific configurations.
-- **API and query language compatibility:** Thanos Metrics uses PromQL, which is
-  different from M3DB's native query language. Update your queries to be
-  compatible with PromQL. For assistance, you can use tools such as the
-  [M3 to PromQL converter](https://github.com/logzio/influxql-to-promql-converter) or
-  Aiven's own [dashboard converter](https://github.com/Aiven-Open/influxql-to-m3-dashboard-converter).
+- **Review database setup:** Examine your M3DB database's data structures,
+  storage patterns, and configurations. Identify any unique features, custom settings,
+  and specific configurations.
+- **API and query language compatibility:** Both Thanos Metrics and M3DB use PromQL,
+  so most existing queries will work as is. However, be aware that the same metric
+  might have a slightly different name when written directly to Thanos compared to its
+  name in M3DB. For example, `prometheus_<metric-name>` in M3DB might be called
+  `<metric-name>` in Thanos. Consequently, after migration, you will have two names
+  for the same metric:
+
+  - `prometheus_<metric-name>{_source=m3db, labels...}` (for time series migrated from M3DB)
+  - `<metric-name>{labels...}` (for time series written to Thanos directly)
+
+  Adjust your queries accordingly. All Aiven-generated built-in dashboards will work
+  out of the box.
 - **Version compatibility:** Ensure your M3DB version supports migration to
   Thanos Metrics. You might need to upgrade your M3DB to a compatible version.
 
@@ -79,9 +86,7 @@ While the migration is in progress:
 :::important
 To prevent conflicts during replication:
 
-- The target database is in a read-only state during migration. Writing to the database
-  is only possible once the migration is stopped.
-- Do not manually change the replication settings of the source database.
+- Avoid creating or deleting databases on the source service during migration.
 - Avoid making network or configuration changes that can disrupt the ongoing
   connection between the source and target databases, such as modifying firewall
   rules or altering trusted sources.

--- a/docs/products/metrics/howto/migrate-m3db-thanos.md
+++ b/docs/products/metrics/howto/migrate-m3db-thanos.md
@@ -1,0 +1,116 @@
+---
+title: Migrate Aiven for M3DB to Aiven for Metrics
+---
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
+
+Migrate your Aiven for M3DB databases to Aiven for Thanos Metrics using the Aiven Console migration tool.
+
+## Compatibility considerations
+
+Review your current M3DB setup before migrating to Aiven for Metrics.
+
+- **Review database setup:** Examine your M3DB database's data structures, storage
+  patterns, and configurations. Identify any unique features, custom settings, and
+  specific configurations.
+- **API and query language compatibility:** Thanos Metrics uses PromQL, which is
+  different from M3DB's native query language. Update your queries to be
+  compatible with PromQL. For assistance, you can use tools such as the
+  [M3 to PromQL converter](https://github.com/logzio/influxql-to-promql-converter) or
+  Aiven's own [dashboard converter](https://github.com/Aiven-Open/influxql-to-m3-dashboard-converter).
+- **Version compatibility:** Ensure your M3DB version supports migration to
+  Thanos Metrics. You might need to upgrade your M3DB to a compatible version.
+
+## Prerequisites
+
+Before starting the migration from an Aiven for M3DB service:
+
+- Make a note of the Aiven project and Aiven for M3DB service name for migration in the
+  [Aiven Console](https://console.aiven.io/).
+
+The [Aiven Console](https://console.aiven.io/) migration tool automatically uses
+connection details like the hostname, port, and credentials linked to the selected
+Aiven for M3DB service.
+
+## Database migration steps
+
+1. Log in to the [Aiven Console](https://console.aiven.io/) and select the
+   Aiven for Metrics service for your M3DB database migration.
+1. Go to **Service settings** from the sidebar.
+1. Scroll to the **Service management** section, and click
+   <ConsoleLabel name="actions"/> > **Import database** to initiate the import process.
+1. Follow the wizard to guide you through the database migration process.
+
+### Step 1: Configure
+
+1. From the drop-down menu, select your project name.
+2. From the subsequent drop-down, select the Aiven for M3DB database you intend to migrate.
+3. Click **Get started** to proceed with the migration.
+
+### Step 2: Validation
+
+The [Aiven Console](https://console.aiven.io/) automatically attempts to validate
+the database configurations for the selected Aiven for M3DB service.
+Click **Run validation** to validate the connection.
+
+:::warning
+If a validation error occurs during migration, follow the on-screen instructions to f
+ix it. Rerun validation to ensure the database meets migration criteria. Note that the
+migration doesn't include service user accounts and commands in progress.
+:::
+
+### Step 3: Migration
+
+Once all the necessary checks have been completed successfully, you can proceed with
+the migration process.
+
+- Click **Start migration** to initiate the data migration process to Aiven for Metrics.
+
+### Step 4: Replication
+
+While the migration is in progress:
+
+- You can close the migration wizard by clicking **Close window** and return later
+  to monitor the progress. Check the service's **Overview** page to track the
+  migration progress.
+- To stop the migration, click **Stop migration**. The data already transferred to
+  Aiven for Metrics is preserved.
+
+:::important
+To prevent conflicts during replication:
+
+- The target database is in a read-only state during migration. Writing to the database
+  is only possible once the migration is stopped.
+- Do not manually change the replication settings of the source database.
+- Avoid making network or configuration changes that can disrupt the ongoing
+  connection between the source and target databases, such as modifying firewall
+  rules or altering trusted sources.
+:::
+
+:::note
+If the migration fails, investigate, resolve, and restart the migration
+using **Start over**.
+:::
+
+### Step 5: Close and post-migration
+
+Upon successful migration:
+
+- **Stop replication:** If no further synchronization is required and you are ready
+  to switch to Aiven for Thanos Metrics after thoroughly testing the service.
+- **Keep replicating:** If ongoing data synchronization is necessary to maintain
+  active synchronization.
+
+:::warning
+Avoid system updates or configuration changes during active replication to prevent
+unintentional migrations.
+:::
+
+:::note
+When replication mode is active, Aiven for Metrics ensures your data remains in sync,
+with continuous synchronization of new writes from the source database.
+:::
+
+## Related Pages
+
+- [Aiven for Thanos Metrics Overview](/docs/products/metrics/concepts/metrics-overview)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1645,7 +1645,17 @@ const sidebars: SidebarsConfig = {
                 type: 'doc',
                 id: 'products/metrics/howto',
               },
-              items: ['products/metrics/howto/storage-usage'],
+              items: [
+                'products/metrics/howto/storage-usage',
+                {
+                  type: 'category',
+                  label: 'Data migration',
+                  items: [
+                    'products/metrics/howto/migrate-influxdb-thanos',
+                    'products/metrics/howto/migrate-m3db-thanos',
+                  ],
+                },
+              ],
             },
           ],
         },


### PR DESCRIPTION

## Describe your changes
Add documentation for migrating Aiven for M3DB and Aiven for InfluxDB databases to Aiven for Thanos Metrics, including compatibility considerations and step-by-step migration instructions.
## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
