### PR TITLE
add: Follower fetching in Kafka

### DIFF
--- a/docs/products/kafka/concepts/follower-fetching.md
+++ b/docs/products/kafka/concepts/follower-fetching.md
@@ -1,0 +1,49 @@
+---
+title: Follower fetching in Aiven for Apache Kafka®
+sidebar_label: Follower fetching
+---
+
+[Follower fetching](/docs/products/kafka/howto/enable-follower-fetching) in Aiven for Apache Kafka allows consumers to fetch data from the nearest replica instead of the leader. This feature optimizes data fetching by leveraging Apache Kafka's rack awareness, which treats each availability zone (AZ) as a rack.
+
+## Benefits
+
+1. **Reduced network costs:** Fetching data from the closest replica minimizes
+   inter-zone data transfers, reducing costs.
+1. **Lower latency:** Fetching from a nearby replica reduces the time it takes to
+   receive data, improving overall performance.
+
+## How it works
+
+Aiven for Apache Kafka uses rack awareness to optimize data fetching and ensure
+high availability.
+
+- **Rack awareness**: Rack awareness distributes data across different physical racks,
+  also known as availability zones (AZs), within a data center. This distribution
+  ensures data replication for fault tolerance. Each Apache Kafka broker has
+  a `broker.rack` setting corresponding to its specific AZ. For example, in AWS, AZ IDs
+  (like `use1-az1`) are used instead of AZ names (like `us-east-1a`) to ensure
+  consistency across different accounts.
+
+- **Follower fetching**: Uses rack awareness to allow consumers to fetch data from
+  the nearest replica, reducing latency and costs. Apache Kafka consumers use
+  the `client.rack` setting to specify their AZ, ensuring they fetch data from the
+  closest replica.
+
+## `broker.rack` and `client.rack` settings
+
+- `broker.rack`: This setting corresponds to the AZ where each Apache Kafka broker
+  is deployed and helps manage data replication efficiently. Apache Kafka brokers in
+  the same AZ have the same `broker.rack` value, like `use1-az1`.
+  Aiven for Apache Kafka simplifies this process by automatically managing
+  the `broker.rack` setting, eliminating the need for manual configuration.
+
+- `client.rack`:  This setting on the Apache Kafka consumer indicates the AZ where
+  the consumer is running. It allows you to fetch data from the nearest replica. For
+  example, if your `client.rack` is set to `use1-az1`, it fetches data from an
+  Apache Kafka broker with `broker.rack` set to `use1-az1`.
+  [Configure](/docs/products/kafka/howto/enable-follower-fetching#client-side-configuration)
+  this setting to retrieve from the closest replica.
+
+## Related pages
+
+- [Enable follower fetching in Aiven for Apache Kafka](/docs/products/kafka/howto/enable-follower-fetching)

--- a/docs/products/kafka/concepts/follower-fetching.md
+++ b/docs/products/kafka/concepts/follower-fetching.md
@@ -12,6 +12,10 @@ sidebar_label: Follower fetching
 1. **Lower latency:** Fetching from a nearby replica reduces the time it takes to
    receive data, improving overall performance.
 
+:::note
+Follower fetching is currently supported on AWS (Amazon Web Services).
+:::
+
 ## How it works
 
 Aiven for Apache Kafka uses rack awareness to optimize data fetching and ensure

--- a/docs/products/kafka/concepts/follower-fetching.md
+++ b/docs/products/kafka/concepts/follower-fetching.md
@@ -29,7 +29,7 @@ high availability.
   the `client.rack` setting to specify their AZ, ensuring they fetch data from the
   closest replica.
 
-## `broker.rack` and `client.rack` settings
+### `broker.rack` and `client.rack` settings
 
 - `broker.rack`: This setting corresponds to the AZ where each Apache Kafka broker
   is deployed and helps manage data replication efficiently. Apache Kafka brokers in
@@ -42,7 +42,7 @@ high availability.
   example, if your `client.rack` is set to `use1-az1`, it fetches data from an
   Apache Kafka broker with `broker.rack` set to `use1-az1`.
   [Configure](/docs/products/kafka/howto/enable-follower-fetching#client-side-configuration)
-  this setting to retrieve from the closest replica.
+  this setting to retrieve data from the closest replica.
 
 ## Related pages
 

--- a/docs/products/kafka/howto/enable-follower-fetching.md
+++ b/docs/products/kafka/howto/enable-follower-fetching.md
@@ -1,0 +1,71 @@
+---
+title: Enable follower fetching in Aiven for Apache Kafka
+sidebar_label: Enable follower fetching
+---
+
+Enable follower fetching in Aiven for Apache Kafka allows your consumers to fetch data from the nearest replica instead of the leader, optimizing data fetching and enhancing performance.
+
+## Prerequisites
+
+- Aiven for Apache Kafka service version 3.6 or later.
+- [Availability zone (AZ)](#identify-availability-zone) information for your
+  Aiven for Apache Kafka service.
+
+## Identify availability zone
+
+In AWS, availability zone (AZ) names can vary across different accounts. The same
+physical location might have different AZ names in different accounts. To ensure
+consistency when configuring `client.rack`, use the AZ ID, which remains the same
+across accounts.
+
+For mapping AZ names to AZ IDs, see [AWS Knowledge Center article](https://repost.aws/knowledge-center/vpc-map-cross-account-availability-zones) and the [AWS documentation on AZ IDs](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html).
+
+## Enable follower fetching
+
+Enable follower fetching with the [Aiven CLI](/docs/tools/cli):
+
+```bash
+avn service update <service-name> -c follower_fetching={"enabled": true}
+```
+
+Parameters:
+
+- `<service-name>`: Replace with the actual name of your Kafka service.
+- `follower_fetching={"enabled": true}`: Enables the follower fetching feature.
+
+## Client-side configuration
+
+To enable follower fetching at the client level, configure the `client.rack` setting
+in the Apache Kafka client. Set the `client.rack` value to the corresponding AZ ID
+for each client. This ensures the client fetches data from the nearest replica.
+
+Add this example configuration to your consumer properties file:
+
+```plaintext
+client.rack=use1-az1
+```
+
+### Example scenario
+
+Assume you have an Aiven for Apache Kafka cluster running in three AZs in
+the `us-east-1` region. The AZ IDs are `use1-az1`, `use1-az2`, and `use1-az3`.
+
+To configure consumers, set the `client.rack` value to the respective AZ ID for each
+consumer. For example, if your consumers are in `use1-az1` and `use1-az2`, use the
+following configuration:
+
+```plaintext
+client.rack=use1-az1
+```
+
+Consumers in `use1-az1` and `use1-az2` fetch from the nearest replica. Consumers
+in `use1-az3` fetch from the leader.
+
+## Verify follower fetching
+
+After configuring follower fetching, monitor for a decrease in cross-availability zone
+network costs to verify its effectiveness.
+
+## Related pages
+
+- [Follower fetching in Aiven for Apache Kafka®](/docs/products/kafka/concepts/follower-fetching)

--- a/docs/products/kafka/howto/enable-follower-fetching.md
+++ b/docs/products/kafka/howto/enable-follower-fetching.md
@@ -11,6 +11,10 @@ Enabling follower fetching in Aiven for Apache Kafka allows your consumers to fe
 - [Availability zone (AZ)](#identify-availability-zone) information for your
   Aiven for Apache Kafka service.
 
+:::note
+Follower fetching is currently supported on AWS (Amazon Web Services).
+:::
+
 ## Identify availability zone
 
 In AWS, availability zone (AZ) names can vary across different accounts. The same

--- a/docs/products/kafka/howto/enable-follower-fetching.md
+++ b/docs/products/kafka/howto/enable-follower-fetching.md
@@ -3,7 +3,7 @@ title: Enable follower fetching in Aiven for Apache Kafka
 sidebar_label: Enable follower fetching
 ---
 
-Enable follower fetching in Aiven for Apache Kafka allows your consumers to fetch data from the nearest replica instead of the leader, optimizing data fetching and enhancing performance.
+Enabling follower fetching in Aiven for Apache Kafka allows your consumers to fetch data from the nearest replica instead of the leader, optimizing data fetching and enhancing performance.
 
 ## Prerequisites
 
@@ -45,21 +45,49 @@ Add this example configuration to your consumer properties file:
 client.rack=use1-az1
 ```
 
-### Example scenario
+### Example scenario: follower fetching in different AZs
 
-Assume you have an Aiven for Apache Kafka cluster running in three AZs in
-the `us-east-1` region. The AZ IDs are `use1-az1`, `use1-az2`, and `use1-az3`.
+Assume you have an Aiven for Apache Kafka cluster running in two AZs in the `us-east-1`
+region. The AZ IDs are `use1-az1` and `use1-az2`. You also have consumers distributed
+across three AZs: `use1-az1`, `use1-az2`, and `use1-az3`.
 
-To configure consumers, set the `client.rack` value to the respective AZ ID for each
-consumer. For example, if your consumers are in `use1-az1` and `use1-az2`, use the
-following configuration:
+#### Cluster setup
+
+- Apache Kafka brokers are in:
+  - `use1-az1`
+  - `use1-az2`
+
+- Consumers are in:
+  - `use1-az1`
+  - `use1-az2`
+  - `use1-az3`
+
+#### Consumer configuration
+
+To configure consumers, set the `client.rack` value to the respective
+AZ ID for each consumer:
 
 ```plaintext
+# For consumers in use1-az1
 client.rack=use1-az1
+
+# For consumers in use1-az2
+client.rack=use1-az2
+
+# For consumers in use1-az3
+client.rack=use1-az3
 ```
 
-Consumers in `use1-az1` and `use1-az2` fetch from the nearest replica. Consumers
-in `use1-az3` fetch from the leader.
+#### Fetching behavior
+
+- **Consumers in `use1-az1` and `use1-az2`**:
+  - Fetch from the nearest replica in their respective AZ.
+  - Benefit from reduced latency and network costs.
+
+- **Consumers in `use1-az3`**:
+  - Fetch from the leader.
+  - No matching `broker.rack` exists, so follower fetching isn't possible.
+
 
 ## Verify follower fetching
 

--- a/docs/products/kafka/howto/enable-follower-fetching.md
+++ b/docs/products/kafka/howto/enable-follower-fetching.md
@@ -25,7 +25,7 @@ For mapping AZ names to AZ IDs, see [AWS Knowledge Center article](https://repos
 Enable follower fetching with the [Aiven CLI](/docs/tools/cli):
 
 ```bash
-avn service update <service-name> -c follower_fetching={"enabled": true}
+avn service update <service-name> -c follower_fetching.enabled=true
 ```
 
 Parameters:

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -771,6 +771,7 @@ const sidebars: SidebarsConfig = {
                 'products/kafka/concepts/monitor-consumer-group',
                 'products/kafka/concepts/consumer-lag-predictor',
                 'products/kafka/concepts/kafka-quotas',
+                'products/kafka/concepts/follower-fetching',
                 {
                   type: 'category',
                   label: 'Tiered storage',
@@ -866,6 +867,7 @@ const sidebars: SidebarsConfig = {
                     'products/kafka/howto/optimizing-resource-usage',
                     'products/kafka/howto/enabled-consumer-lag-predictor',
                     'products/kafka/howto/manage-quotas',
+                    'products/kafka/howto/enable-follower-fetching',
                   ],
                 },
                 {


### PR DESCRIPTION
## Describe your changes

Added documentation for enabling follower fetching in Aiven for Apache Kafka. [HH-4055](https://aiven.atlassian.net/browse/HH-4055)
## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.


[HH-4055]: https://aiven.atlassian.net/browse/HH-4055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ