### PR TITLE
fix: metrics typo

### DIFF
--- a/docs/products/metrics/concepts.md
+++ b/docs/products/metrics/concepts.md
@@ -1,5 +1,5 @@
 ---
-title: Aiven for Mertics®
+title: Aiven for Metrics®
 ---
 
 import DocCardList from '@theme/DocCardList';


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
