### PR TITLE
update(clickhouse): mention dictionaries_lazy_load = true setting

### DIFF
--- a/docs/products/clickhouse/howto/create-dictionary.md
+++ b/docs/products/clickhouse/howto/create-dictionary.md
@@ -66,6 +66,9 @@ Read more on dictionaries in the
   In Aiven for ClickHouse, to fill the dictionary the table users are queried with
   the permissions of the `avnadmin` user even if another user creates the dictionary.
   In upstream ClickHouse, the same is true except the `default` user is used.
+- In Aiven for ClickHouse, the setting [dictionaries_lazy_load](https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#dictionaries_lazy_load)
+  is set to `true`.  This can mean that errors with dictionary source parameters may only
+  become apparent when the dictionary is loaded, rather than when it is created.
 
 ### Supported layouts
 

--- a/docs/products/clickhouse/howto/create-dictionary.md
+++ b/docs/products/clickhouse/howto/create-dictionary.md
@@ -66,9 +66,10 @@ Read more on dictionaries in the
   In Aiven for ClickHouse, to fill the dictionary the table users are queried with
   the permissions of the `avnadmin` user even if another user creates the dictionary.
   In upstream ClickHouse, the same is true except the `default` user is used.
-- In Aiven for ClickHouse, the setting [dictionaries_lazy_load](https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#dictionaries_lazy_load)
-  is set to `true`.  This can mean that errors with dictionary source parameters may only
-  become apparent when the dictionary is loaded, rather than when it is created.
+- In Aiven for ClickHouse, setting
+  [dictionaries_lazy_load](https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#dictionaries_lazy_load)
+  is set to `true`, which means that errors with dictionary source parameters may only
+  become apparent when the dictionary is loaded on the first use, rather than when it is created.
 
 ### Supported layouts
 


### PR DESCRIPTION
Our SAs found some behaviour caused by this setting confusing.

https://aiven-io.slack.com/archives/C029BCC75K7/p1721117304789959?thread_ts=1721042188.692799&cid=C029BCC75K7

## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
