### PR TITLE
update(platform): promote the EoL for services and tools versions article

### DIFF
--- a/docs/platform/reference/eol-for-major-versions.md
+++ b/docs/platform/reference/eol-for-major-versions.md
@@ -1,6 +1,6 @@
 ---
 title: End of life for major versions of Aiven services and tools
-sidebar_label: End of life for services and tools versions
+sidebar_label: End of life for services and tools
 ---
 
 End of life (EOL) is the date after which Aiven services and tools are no longer supported or maintained.

--- a/docs/platform/reference/eol-for-major-versions.md
+++ b/docs/platform/reference/eol-for-major-versions.md
@@ -1,5 +1,6 @@
 ---
 title: End of life for major versions of Aiven services and tools
+sidebar_label: End of life for services and tools versions
 ---
 
 End of life (EOL) is the date after which Aiven services and tools are no longer supported or maintained.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -211,7 +211,6 @@ const sidebars: SidebarsConfig = {
                 'platform/concepts/service-memory-limits',
                 'platform/concepts/out-of-memory-conditions',
                 'platform/concepts/maintenance-window',
-                'platform/reference/eol-for-major-versions',
               ],
             },
             {
@@ -419,6 +418,7 @@ const sidebars: SidebarsConfig = {
             },
           ],
         },
+        'platform/reference/eol-for-major-versions',
       ],
     },
     {


### PR DESCRIPTION
https://aiven.atlassian.net/browse/DOC-1111

- Promoting the EoL article in the doc architecture to improve its accessibility.
- Removing it from the "Service management" section coz it includes not only services EoL dates but also dev tools EoL info.
- Moving the article upwards in the hierarchy under the "Platform" area due to its cross-domain character.

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
