### PR TITLE
fix typo

### DIFF
--- a/src/components/Badges/EarlyBadge/index.tsx
+++ b/src/components/Badges/EarlyBadge/index.tsx
@@ -6,7 +6,7 @@ import stylesGeneric from '../styles.module.css';
 export default function EarlyBadge(): JSX.Element {
   return (
     <span className={clsx(stylesGeneric.badge, styles.badge)}>
-      Early availabilty
+      Early availability
     </span>
   );
 }

--- a/src/components/Badges/LimitedBadge/index.tsx
+++ b/src/components/Badges/LimitedBadge/index.tsx
@@ -6,7 +6,7 @@ import stylesGeneric from '../styles.module.css';
 export default function LimitedBadge(): JSX.Element {
   return (
     <span className={clsx(stylesGeneric.badge, styles.badge)}>
-      Limited availabilty
+      Limited availability
     </span>
   );
 }


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
