### PR TITLE
fix: cross-links

### DIFF
--- a/docs/products/kafka/concepts/topic-catalog-overview.md
+++ b/docs/products/kafka/concepts/topic-catalog-overview.md
@@ -19,7 +19,8 @@ the management of your Aiven for Apache Kafka infrastructure.
 
 ## Governance on topic catalog
 
-With governance enabled for your organization, you can efficiently manage topic ownership
+With [governance enabled](/docs/products/kafka/howto/enable-governance) for your
+organization, you can efficiently manage topic ownership
 and creation requests. You can also access and govern topics across your organization,
 even if you aren't a member of all projects.
 
@@ -32,3 +33,4 @@ even if you aren't a member of all projects.
 ## Related page
 
 - [Manage Apache Kafka topics with topic catalog](/docs/products/kafka/howto/view-kafka-topic-catalog)
+- [Aiven for Apache Kafka governance](/docs/products/kafka/concepts/governance-overview)

--- a/docs/products/kafka/howto/view-kafka-topic-catalog.md
+++ b/docs/products/kafka/howto/view-kafka-topic-catalog.md
@@ -4,7 +4,7 @@ sidebar_label: Manage topic catalog
 early: true
 ---
 
-The Aiven for Apache Kafka® topic catalog offers a user-friendly interface to manage your Apache Kafka topics within your Aiven for Apache Kafka services.
+The [Aiven for Apache Kafka® topic catalog](/docs/products/kafka/concepts/topic-catalog-overview) offers a user-friendly interface to manage your Apache Kafka topics within your Aiven for Apache Kafka services.
 
 ## Access the topic catalog
 
@@ -78,6 +78,6 @@ topic overview page, see [Manage Apache Kafka topics in detail](/docs/products/k
 
 ## Related pages
 
-- [Aiven for Apache Kafka® topic catalog overview](/docs/products/kafka/concepts/topic-catalog-overview)
+- [Aiven for Apache Kafka® topic catalog](/docs/products/kafka/concepts/topic-catalog-overview)
 - [Manage Apache Kafka topics in detail](/docs/products/kafka/howto/manage-topics-details).
 - [Aiven for Apache Kafka® governance](/docs/products/kafka/concepts/governance-overview)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -901,19 +901,6 @@ const sidebars: SidebarsConfig = {
                 },
                 {
                   type: 'category',
-                  label: 'Tiered storage',
-                  link: {
-                    type: 'doc',
-                    id: 'products/kafka/howto/kafka-tiered-storage-get-started',
-                  },
-                  items: [
-                    'products/kafka/howto/enable-kafka-tiered-storage',
-                    'products/kafka/howto/configure-topic-tiered-storage',
-                    'products/kafka/howto/tiered-storage-overview-page',
-                  ],
-                },
-                {
-                  type: 'category',
                   label: 'Governance',
                   link: {
                     type: 'doc',
@@ -934,6 +921,19 @@ const sidebars: SidebarsConfig = {
                         'products/kafka/howto/group-requests',
                       ],
                     },
+                  ],
+                },
+                {
+                  type: 'category',
+                  label: 'Tiered storage',
+                  link: {
+                    type: 'doc',
+                    id: 'products/kafka/howto/kafka-tiered-storage-get-started',
+                  },
+                  items: [
+                    'products/kafka/howto/enable-kafka-tiered-storage',
+                    'products/kafka/howto/configure-topic-tiered-storage',
+                    'products/kafka/howto/tiered-storage-overview-page',
                   ],
                 },
               ],


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
