### PR TITLE
add: Configure secret providers for Apache Kafka Connect

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
@@ -98,8 +98,9 @@ Parameters:
 
 ## Reference secrets in connector configurations
 
-After configuring the secret providers, you can reference secrets in your
-connector configurations.
+You can use secrets stored in AWS Secrets Manager with any connector. The examples below
+show how to configure secrets for JDBC connectors, but you can follow the same steps
+for other connectors.
 
 ### JDBC sink connector
 

--- a/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
@@ -53,7 +53,7 @@ Parameters:
 
 - `url`: API endpoint for updating the service configuration. Replace
   `PROJECT_NAME` and `SERVICE_NAME` with your project and service names.
-- `Authorization`: Used for authentication. Replace `YOUR_BEARER_TOKEN` with your
+- `Authorization`: Token used for authentication. Replace `YOUR_BEARER_TOKEN` with your
   [Aiven API token](/docs/platform/howto/create_authentication_token).
 - `Content-Type`: Specifies that the request body is in JSON format.
 - `auth_method`: Authentication method used by AWS Secrets Manager. In this case,

--- a/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
@@ -10,8 +10,8 @@ Configure and use AWS Secrets Manager as a secret provider in Aiven for Apache K
 ## Prerequisites
 
 - Access to the [Aiven Console](https://console.aiven.io/).
-- Aiven for Apache Kafka service with Apache Kafka Connect set up and running. For setup
-  instructions, see [Aiven for Apache Kafka with Kafka Connect documentation](/docs/products/kafka/kafka-connect/get-started).
+- [Aiven for Apache Kafka service with Apache Kafka Connect](/docs/products/kafka/kafka-connect/get-started)
+  set up and running.
 - [Aiven CLI](/docs/tools/cli).
 - [AWS Secrets Manager access key and secret key](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access.html).
 
@@ -52,9 +52,9 @@ curl --request PUT \
 Parameters:
 
 - `url`: API endpoint for updating the service configuration. Replace
-  `PROJECT_NAME` and `SERVICE_NAME` with your actual project and service names.
+  `PROJECT_NAME` and `SERVICE_NAME` with your project and service names.
 - `Authorization`: Header for authentication. Replace `YOUR_BEARER_TOKEN` with your
-  actual [Aiven API token](/docs/platform/howto/create_authentication_token).
+  [Aiven API token](/docs/platform/howto/create_authentication_token).
 - `Content-Type`: Specifies that the request body is in JSON format.
 - `auth_method`: Authentication method used by AWS Secrets Manager. In this case,
   it is `credentials`.

--- a/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
@@ -1,0 +1,239 @@
+---
+title: Configure AWS Secrets Manager
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Configure and use AWS Secrets Manager as a secret provider in Apache Kafka® Connect services on Aiven for Apache Kafka®.
+
+## Prerequisites
+
+- Access to the [Aiven Console](https://console.aiven.io/).
+- Aiven for Apache Kafka service with Apache Kafka Connect set up and running. For setup
+  instructions, see [Aiven for Apache Kafka with Kafka Connect documentation](https://aiven.io/docs/products/kafka/kafka-connect/get-started).
+- [Aiven CLI](/docs/tools/cli)
+- [AWS Secrets Manager access key and secret key](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access.html)
+
+## Configure secret providers
+
+Set up AWS Secrets Manager in your Aiven for Apache Kafka Connect service to securely
+manage and access sensitive information.
+
+<Tabs groupId="config-methods">
+<TabItem value="api" label="API" default>
+
+Add the AWS Secrets Manager configuration to the `user_config`:
+
+```sh
+curl --request PUT \
+  --url https://api.aiven.io/v1/project/{project_name}/service/{service_name} \
+  --header 'Authorization: Bearer YOUR_BEARER_TOKEN' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "user_config": {
+      "secret_providers": [
+        {
+          "name": "aws",
+          "aws": {
+            "auth_method": "credentials",
+            "region": "your-aws-region",
+            "access_key": "your-aws-access-key",
+            "secret_key": "your-aws-secret-key"
+          }
+        }
+      ]
+    }
+  }'
+```
+
+Parameters:
+
+- `url`: API endpoint for updating the service configuration. Replace
+  `{project_name}` and `{service_name}` with your actual project and service names.
+- `Authorization`: Header for authentication. Replace `YOUR_BEARER_TOKEN` with your
+  actual [Aiven API token](/docs/platform/howto/create_authentication_token).
+- `Content-Type`: Specifies that the request body is in JSON format.
+- `auth_method`: Authentication method used by AWS Secrets Manager. In this case,
+  it is `credentials`.
+- `region`: AWS region where your secrets are stored.
+- `access_key`: Your AWS access key.
+- `secret_key`: Your AWS secret key.
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+Add AWS Secrets Manager using the Aiven CLI:
+
+```bash
+avn service update kafka-connect \
+-c secret_providers='[
+    {
+        "aws": {
+            "access_key": "<replace_with_your_access_key>",
+            "auth_method": "credentials",
+            "region": "your-aws-region",
+            "secret_key": "<replace_with_your_secret_key>"
+        },
+        "name": "aws"
+    }
+]'
+```
+
+Parameters:
+
+- `auth_method`: Authentication method used by AWS Secrets Manager. In this case,
+  it is `credentials`.
+- `region`: AWS region where your secrets are stored.
+- `access_key`: Your AWS access key.
+- `secret_key`: Your AWS secret key.
+
+</TabItem>
+</Tabs>
+
+## Reference secrets in connector configurations
+
+After configuring the secret providers, you can reference secrets in your
+connector configurations.
+
+### JDBC sink connector
+
+<Tabs groupId="reference-secrets-sink">
+<TabItem value="api" label="API" default>
+
+Reference secrets in the JDBC sink connector configuration using the following
+API request:
+
+```sh
+curl -X POST https://api.aiven.io/v1/project/<project_name>/service/<service_name>/connectors \
+  -H "Authorization: Bearer <your_auth_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "your-sink-connector-name",
+        "connector.class": "io.aiven.connect.jdbc.JdbcSinkConnector",
+        "connection.url": "jdbc:postgresql://host:port/dbname?user=${aws:path/to/secret:username}&password=${aws:path/to/secret:password}&ssl=require",
+        "topics": "your-topic",
+        "auto.create": "true"
+      }'
+```
+
+Parameters:
+
+- `name`: Name of the connector.
+- `connector.class`: Specifies the connector class to use, in this case,
+  `io.aiven.connect.jdbc.JdbcSinkConnector`.
+- `connection.url`: JDBC connection URL, with placeholders for the username and password
+  retrieved from AWS Secrets Manager.
+- `topics`: Apache Kafka topic where the data can be sent.
+- `auto.create`: If `true`, the connector automatically creates the table in the
+  target database if it does not exist.
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+Reference secrets in the JDBC sink connector configuration using the following
+CLI command:
+
+```sh
+avn service user-config set kafka-connect -c name=your-sink-connector-name \
+-c connector.class=io.aiven.connect.jdbc.JdbcSinkConnector \
+-c connection.url="jdbc:postgresql://host:port/dbname?user=${aws:path/to/secret:username}&password=${aws:path/to/secret:password}&ssl=require" \
+-c topics=your-topic \
+-c auto.create=true
+```
+
+Parameters:
+
+- `name`: Name of the connector.
+- `connector.class`: Specifies the connector class to use, in this case,
+  `io.aiven.connect.jdbc.JdbcSinkConnector`.
+- `connection.url`: JDBC connection URL, with placeholders for the username and password
+  retrieved from AWS Secrets Manager.
+- `topics`: Apache Kafka topic where the data can be sent.
+- `auto.create`: If `true`, the connector automatically creates the table in the
+  target database if it does not exist.
+
+</TabItem>
+</Tabs>
+
+### JDBC source connector
+
+<Tabs groupId="reference-secrets-source">
+<TabItem value="api" label="API" default>
+
+Reference secrets in the JDBC source connector configuration using the following
+API request:
+
+```sh
+curl -X POST https://api.aiven.io/v1/project/<project_name>/service/<service_name>/connectors \
+  -H "Authorization: Bearer <your_auth_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "your-source-connector-name",
+        "connector.class": "io.aiven.connect.jdbc.JdbcSourceConnector",
+        "connection.url": "jdbc:postgresql://your-postgresql-host:your-port/defaultdb?ssl=require",
+        "connection.user": "${aws:path/to/secret:username}",
+        "connection.password": "${aws:path/to/secret:password}",
+        "incrementing.column.name": "id",
+        "mode": "incrementing",
+        "table.whitelist": "your-table",
+        "topic.prefix": "your-prefix_",
+        "auto.create": "true"
+      }'
+
+```
+
+Parameters:
+
+- `name`: Name of the connector.
+- `connector.class`: Specifies the connector class to use, in this case,
+  `io.aiven.connect.jdbc.JdbcSinkConnector`.
+- `connection.url`: JDBC connection URL, with placeholders for the username and
+  password retrieved from AWS Secrets Manager.
+- `connection.user`: Database username retrieved from AWS Secrets Manager
+- `connection.password`: Database password retrieved from AWS Secrets Manager.
+- `incrementing.column.name`: Column used for incrementing mode.
+- `mode`: Mode of operation, in this case, `incrementing`.
+- `table.whitelist`: Tables to include.
+- `topic.prefix`: Prefix to use for Apache Kafka topics.
+- `auto.create`: If `true`, the connector automatically creates the table in
+  the target database if it does not exist.
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+Reference secrets in the JDBC source connector configuration using the following
+CLI command:
+
+```sh
+avn service user-config set kafka-connect -c name=your-source-connector-name \
+-c connector.class=io.aiven.connect.jdbc.JdbcSourceConnector \
+-c connection.url="jdbc:postgresql://your-postgresql-host:your-port/defaultdb?ssl=require" \
+-c connection.user="${aws:path/to/secret:username}" \
+-c connection.password="${aws:path/to/secret:password}" \
+-c incrementing.column.name=id \
+-c mode=incrementing \
+-c table.whitelist=your-table \
+-c topic.prefix=your-prefix_ \
+-c auto.create=true
+
+```
+
+Parameters:
+
+- `name`: Name of the connector.
+- `connector.class`: Specifies the connector class to use, in this case,
+  `io.aiven.connect.jdbc.JdbcSinkConnector`.
+- `connection.url`: JDBC connection URL, with placeholders for the username and
+  password retrieved from AWS Secrets Manager.
+- `connection.user`: Database username retrieved from AWS Secrets Manager
+- `connection.password`: Database password retrieved from AWS Secrets Manager.
+- `incrementing.column.name`: Column used for incrementing mode.
+- `mode`: Mode of operation, in this case, `incrementing`.
+- `table.whitelist`: Tables to include.
+- `topic.prefix`: Prefix to use for Apache Kafka topics.
+- `auto.create`: If `true`, the connector automatically creates the table in
+  the target database if it does not exist.
+
+</TabItem>
+</Tabs>

--- a/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
@@ -53,7 +53,7 @@ Parameters:
 
 - `url`: API endpoint for updating the service configuration. Replace
   `PROJECT_NAME` and `SERVICE_NAME` with your project and service names.
-- `Authorization`: Header for authentication. Replace `YOUR_BEARER_TOKEN` with your
+- `Authorization`: Used for authentication. Replace `YOUR_BEARER_TOKEN` with your
   [Aiven API token](/docs/platform/howto/create_authentication_token).
 - `Content-Type`: Specifies that the request body is in JSON format.
 - `auth_method`: Authentication method used by AWS Secrets Manager. In this case,

--- a/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
@@ -5,7 +5,7 @@ title: Configure AWS Secrets Manager
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Configure and use AWS Secrets Manager as a secret provider in Aiven for Apache Kafka® Connect services.
+Configure and use [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html) as a secret provider in Aiven for Apache Kafka® Connect services.
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@ Configure and use AWS Secrets Manager as a secret provider in Aiven for Apache K
 Set up AWS Secrets Manager in your Aiven for Apache Kafka Connect service to manage and
 access sensitive information.
 
-<Tabs groupId="config-methods">
+<Tabs groupId="secret-config">
 <TabItem value="api" label="API" default>
 
 Use the [ServiceUpdate](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
@@ -104,7 +104,7 @@ for other connectors.
 
 ### JDBC sink connector
 
-<Tabs groupId="reference-secrets-sink">
+<Tabs groupId="secret-config">
 <TabItem value="api" label="API" default>
 
 Configure a JDBC sink connector using the API with secrets referenced from
@@ -173,7 +173,7 @@ Parameters:
 
 ### JDBC source connector
 
-<Tabs groupId="reference-secrets-source">
+<Tabs groupId="secret-config">
 <TabItem value="api" label="API" default>
 
 Configure a JDBC source connector using the API with secrets referenced from

--- a/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
@@ -11,7 +11,7 @@ Configure and use AWS Secrets Manager as a secret provider in Aiven for Apache K
 
 - Access to the [Aiven Console](https://console.aiven.io/).
 - Aiven for Apache Kafka service with Apache Kafka Connect set up and running. For setup
-  instructions, see [Aiven for Apache Kafka with Kafka Connect documentation](https://aiven.io/docs/products/kafka/kafka-connect/get-started).
+  instructions, see [Aiven for Apache Kafka with Kafka Connect documentation](/docs/products/kafka/kafka-connect/get-started).
 - [Aiven CLI](/docs/tools/cli).
 - [AWS Secrets Manager access key and secret key](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access.html).
 

--- a/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
@@ -29,7 +29,7 @@ to the `user_config` using the following API request:
 
 ```sh
 curl --request PUT \
-  --url https://api.aiven.io/v1/project/{project_name}/service/{service_name} \
+  --url https://api.aiven.io/v1/project/{PROJECT_NAME}/service/{SERVICE_NAME} \
   --header 'Authorization: Bearer YOUR_BEARER_TOKEN' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -52,7 +52,7 @@ curl --request PUT \
 Parameters:
 
 - `url`: API endpoint for updating the service configuration. Replace
-  `{project_name}` and `{service_name}` with your actual project and service names.
+  `PROJECT_NAME` and `SERVICE_NAME` with your actual project and service names.
 - `Authorization`: Header for authentication. Replace `YOUR_BEARER_TOKEN` with your
   actual [Aiven API token](/docs/platform/howto/create_authentication_token).
 - `Content-Type`: Specifies that the request body is in JSON format.
@@ -68,7 +68,7 @@ Parameters:
 Add AWS Secrets Manager using the [Aiven CLI](/docs/tools/cli):
 
 ```bash
-avn service update demo-kafka-service \
+avn service update SERVICE_NAME \
   -c secret_providers='[
     {
       "name": "aws",
@@ -85,8 +85,8 @@ avn service update demo-kafka-service \
 
 Parameters:
 
-- `project`: Name of your Aiven project.
-- `service`: Name of your Aiven Kafka service.
+- `PROJECT_NAME`: Name of your Aiven project.
+- `SERVICE_NAME`: Name of your Aiven Kafka service.
 - `name`: Name of the secret provider. In this case, `aws`.
 - `auth_method`: Authentication method used by AWS Secrets Manager. In this case, it is credentials.
 - `region`: AWS region where your secrets are stored.
@@ -106,29 +106,34 @@ connector configurations.
 <Tabs groupId="reference-secrets-sink">
 <TabItem value="api" label="API" default>
 
-Reference secrets in the JDBC sink connector configuration using the following
-API request:
+Configure a JDBC sink connector using the API with secrets referenced from
+AWS Secrets Manager.
 
 ```sh
-curl -X POST https://api.aiven.io/v1/project/<project_name>/service/<service_name>/connectors \
-  -H "Authorization: Bearer <your_auth_token>" \
-  -H "Content-Type: application/json" \
-  -d '{
-        "name": "your-sink-connector-name",
-        "connector.class": "io.aiven.connect.jdbc.JdbcSinkConnector",
-        "connection.url": "jdbc:postgresql://host:port/dbname?user=${aws:path/to/secret:username}&password=${aws:path/to/secret:password}&ssl=require",
-        "topics": "your-topic",
-        "auto.create": "true"
-      }'
+curl --request POST \
+  --url https://api.aiven.io/v1/project/{PROJECT_NAME}/service/{SERVICE_NAME}/connectors \
+  --header 'Authorization: Bearer YOUR_BEARER_TOKEN' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "name": "YOUR_CONNECTOR_NAME",
+    "connector.class": "io.aiven.connect.jdbc.JdbcSinkConnector",
+    "connection.url": "jdbc:{DATABASE_TYPE}://{HOST}:{PORT}/{DATABASE_NAME}?user=${aws:PATH/TO/SECRET:USERNAME}&password=${aws:PATH/TO/SECRET:PASSWORD}&ssl=require",
+    "topics": "YOUR_TOPIC",
+    "auto.create": true
+  }'
+
 ```
 
 Parameters:
 
+- `PROJECT_NAME`: Name of your Aiven project.
+- `SERVICE_NAME`: Name of your Aiven Kafka service.
 - `name`: Name of the connector.
 - `connector.class`: Specifies the connector class to use, in this case,
   `io.aiven.connect.jdbc.JdbcSinkConnector`.
-- `connection.url`: JDBC connection URL, with placeholders for the username and password
-  retrieved from AWS Secrets Manager.
+- `connection.url`: JDBC connection URL with placeholders for `DATABASE_TYPE`, `HOST`,
+  `PORT`, `DATABASE_NAME`, and the username and password retrieved from AWS Secrets
+  Manager.
 - `topics`: Apache Kafka topic where the data can be sent.
 - `auto.create`: If `true`, the connector automatically creates the table in the
   target database if it does not exist.
@@ -136,31 +141,28 @@ Parameters:
 </TabItem>
 <TabItem value="cli" label="CLI">
 
-Reference secrets in the JDBC sink connector configuration using the following
-CLI command:
+Configure a JDBC sink connector using the Aiven CLI with secrets referenced
+from AWS Secrets Manager.
 
 ```bash
-avn service connector create                                    \
-  --project demo-project                                        \
-  --service demo-kafka-service                                  \
-  --connector-name jdbc-sink-connector                          \
-  --connector-class io.aiven.connect.jdbc.JdbcSinkConnector     \
-  --config '{
-    "connection.url": "jdbc:postgresql://localhost:5432/mydb?user=${aws:path/to/secret:username}&password=${aws:path/to/secret:password}&ssl=require",
-    "topics": "your-topic",
-    "auto.create": "true"
-  }'
+avn service connector create SERVICE_NAME '{
+  "name": "jdbc-sink-connector",
+  "connector.class": "io.aiven.connect.jdbc.JdbcSinkConnector",
+  "connection.url": "jdbc:{DATABASE_TYPE}://{HOST}:{PORT}/{DATABASE_NAME}?user=${aws:PATH/TO/SECRET:USERNAME}&password=${aws:PATH/TO/SECRET:PASSWORD}&ssl=require",
+  "topics": "your-topic",
+  "auto.create": true
+}'
 ```
 
 Parameters:
 
-- `project`: Name of your Aiven project.
-- `service`: Name of your Aiven for Apache Kafka service.
-- `connector-name`: Name of the connector.
+- `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
+- `name`: Name of the connector.
 - `connector.class`: Specifies the connector class to use, in this case,
   `io.aiven.connect.jdbc.JdbcSinkConnector`.
-- `connection.url`: JDBC connection URL, with placeholders for the username and password
-  retrieved from AWS Secrets Manager.
+- `connection.url`: JDBC connection URL with placeholders for `DATABASE_TYPE`, `HOST`,
+  `PORT`, `DATABASE_NAME`, and the username and password retrieved from AWS Secrets
+  Manager.
 - `topics`: Apache Kafka topic where the data can be sent.
 - `auto.create`: If `true`, the connector automatically creates the table in the
   target database if it does not exist.
@@ -173,19 +175,19 @@ Parameters:
 <Tabs groupId="reference-secrets-source">
 <TabItem value="api" label="API" default>
 
-Reference secrets in the JDBC source connector configuration using the following
-API request:
+Configure a JDBC source connector using the API with secrets referenced from
+AWS Secrets Manager.
 
 ```sh
-curl -X POST https://api.aiven.io/v1/project/<project_name>/service/<service_name>/connectors \
-  -H "Authorization: Bearer <your_auth_token>" \
+curl -X POST https://api.aiven.io/v1/project/{PROJECT_NAME}/service/{SERVICE_NAME}/connectors \
+  -H "Authorization: Bearer YOUR_BEARER_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
         "name": "your-source-connector-name",
         "connector.class": "io.aiven.connect.jdbc.JdbcSourceConnector",
-        "connection.url": "jdbc:postgresql://your-postgresql-host:your-port/defaultdb?ssl=require",
-        "connection.user": "${aws:path/to/secret:username}",
-        "connection.password": "${aws:path/to/secret:password}",
+        "connection.url": "jdbc:{DATABASE_TYPE}://{HOST}:{PORT}/{DATABASE_NAME}?ssl=require",
+        "connection.user": "${aws:PATH/TO/SECRET:USERNAME}",
+        "connection.password": "${aws:PATH/TO/SECRET:PASSWORD}",
         "incrementing.column.name": "id",
         "mode": "incrementing",
         "table.whitelist": "your-table",
@@ -196,59 +198,59 @@ curl -X POST https://api.aiven.io/v1/project/<project_name>/service/<service_nam
 
 Parameters:
 
+- `PROJECT_NAME`: Name of your Aiven project.
+- `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
 - `name`: Name of the connector.
 - `connector.class`: Specifies the connector class to use, in this case,
   `io.aiven.connect.jdbc.JdbcSinkConnector`.
-- `connection.url`: JDBC connection URL, with placeholders for the username and
-  password retrieved from AWS Secrets Manager.
+- `connection.url`: JDBC connection URL with placeholders for `DATABASE_TYPE`, `HOST`,
+  `PORT`, `DATABASE_NAME`, and the username and password retrieved from AWS Secrets
+  Manager.
 - `connection.user`: Database username retrieved from AWS Secrets Manager
 - `connection.password`: Database password retrieved from AWS Secrets Manager.
 - `incrementing.column.name`: Column used for incrementing mode.
 - `mode`: Mode of operation, in this case, `incrementing`.
 - `table.whitelist`: Tables to include.
-- `topic.prefix`: Prefix to use for Apache Kafka topics.
+- `topic.prefix`: Prefix for Apache Kafka topics.
 - `auto.create`: If `true`, the connector automatically creates the table in
   the target database if it does not exist.
 
 </TabItem>
 <TabItem value="cli" label="CLI">
 
-Reference secrets in the JDBC source connector configuration using the following
-CLI command:
+Configure a JDBC source connector using the Aiven CLI with secrets referenced from
+AWS Secrets Manager.
 
 ```bash
-avn service connector create                                   \
-  --project demo-project                                       \
-  --service demo-kafka-service                                 \
-  --connector-name jdbc-source-connector                       \
-  --connector-class io.aiven.connect.jdbc.JdbcSourceConnector  \
-  --config '{
-    "connection.url": "jdbc:postgresql://your-postgresql-host:your-port/defaultdb?ssl=require",
-    "connection.user": "${aws:path/to/secret:username}",
-    "connection.password": "${aws:path/to/secret:password}",
-    "incrementing.column.name": "id",
-    "mode": "incrementing",
-    "table.whitelist": "your-table",
-    "topic.prefix": "your-prefix_",
-    "auto.create": "true"
-  }'
+avn service connector create SERVICE_NAME '{
+  "name": "jdbc-source-connector",
+  "connector.class": "io.aiven.connect.jdbc.JdbcSourceConnector",
+  "connection.url": "jdbc:{DATABASE_TYPE}://{HOST}:{PORT}/{DATABASE_NAME}?ssl=require",
+  "connection.user": "${aws:PATH/TO/SECRET:USERNAME}",
+  "connection.password": "${aws:PATH/TO/SECRET:PASSWORD}",
+  "incrementing.column.name": "id",
+  "mode": "incrementing",
+  "table.whitelist": "your-table",
+  "topic.prefix": "your-prefix_",
+  "auto.create": true
+}'
 ```
 
 Parameters:
 
-- `project`: Name of your Aiven project.
-- `service`: Name of your Aiven for Apache Kafka service.
-- `connector-name`: Name of the connector.
+- `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
+- `name`: Name of the connector.
 - `connector.class`: Specifies the connector class to use, in this case,
   `io.aiven.connect.jdbc.JdbcSinkConnector`.
-- `connection.url`: JDBC connection URL, with placeholders for the username and
-  password retrieved from AWS Secrets Manager.
+- `connection.url`:JDBC connection URL with placeholders for `DATABASE_TYPE`, `HOST`,
+  `PORT`, `DATABASE_NAME`, and the username and password retrieved from AWS Secrets
+  Manager.
 - `connection.user`: Database username retrieved from AWS Secrets Manager
 - `connection.password`: Database password retrieved from AWS Secrets Manager.
 - `incrementing.column.name`: Column used for incrementing mode.
 - `mode`: Mode of operation, in this case, `incrementing`.
 - `table.whitelist`: Tables to include.
-- `topic.prefix`: Prefix to use for Apache Kafka topics.
+- `topic.prefix`: Prefix for Apache Kafka topics.
 - `auto.create`: If `true`, the connector automatically creates the table in
   the target database if it does not exist.
 

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -94,8 +94,9 @@ Parameters:
 
 ## Reference secrets in connector configurations
 
-After configuring the secret providers, you can reference secrets in your
-connector configurations.
+You can use secrets stored in HashiCorp Vault with any connector. The examples below
+show how to configure secrets for JDBC connectors, but you can follow the same steps
+for other connectors.
 
 ### JDBC sink connector
 

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -5,7 +5,7 @@ title: Configure HashiCorp Vault
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Configure and use HashiCorp Vault as a secret provider in Apache Kafka® Connect services on Aiven for Apache Kafka®.
+Configure and use HashiCorp Vault as a secret provider in Aiven for Apache Kafka® Connect services.
 
 ## Prerequisites
 
@@ -13,18 +13,20 @@ Configure and use HashiCorp Vault as a secret provider in Apache Kafka® Connect
 - Aiven for Apache Kafka service with Apache Kafka Connect set up and running.
   For setup instructions, see
   [Aiven for Apache Kafka with Kafka Connect documentation](https://aiven.io/docs/products/kafka/kafka-connect/get-started).
-- [Aiven CLI](/docs/tools/cli)
-- [HashiCorp Vault address and token](https://developer.hashicorp.com/vault/docs/concepts/tokens)
+- [Aiven CLI](/docs/tools/cli).
+- [HashiCorp Vault address and token](https://developer.hashicorp.com/vault/docs/concepts/tokens).
 
 ## Configure secret providers
 
-Set up HashiCorp Vault in your Aiven for Apache Kafka Connect service to securely
-manage and access sensitive information.
+Set up HashiCorp Vault in your Aiven for Apache Kafka Connect service to manage and
+access sensitive information.
 
 <Tabs groupId="config-methods">
 <TabItem value="api" label="API" default>
 
-Add HashiCorp Vault configuration to `user_config`:
+Use the [ServiceUpdate](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
+API to update your service configuration. Add the AWS Secrets Manager configuration
+to the `user_config` using the following API request:
 
 ```sh
 curl --request PUT \
@@ -61,7 +63,7 @@ Parameters:
 </TabItem>
 <TabItem value="cli" label="CLI">
 
-Add HashiCorp Vault using the Aiven CLI:
+Add HashiCorp Vault using the [Aiven CLI](/docs/tools/cli):
 
 ```sh
 avn service update kafka-connect \
@@ -79,6 +81,9 @@ avn service update kafka-connect \
 
 Parameters:
 
+- `project`: Name of your Aiven project.
+- `service`: Name of your Aiven Kafka service.
+- `name`: Name of the secret provider. In this case, `vault`.
 - `auth_method`: Authentication method used by HashiCorp Vault. In this case, it is
   `token`.
 - `address`: Address of the HashiCorp Vault server.
@@ -131,17 +136,24 @@ Reference secrets in the JDBC sink connector configuration using the following
 CLI command:
 
 ```bash
-avn service user-config set kafka-connect -c name=your-sink-connector-name \
--c connector.class=io.aiven.connect.jdbc.JdbcSinkConnector \
--c connection.url="jdbc:postgresql://host:port/dbname?user=${vault:path/to/secret:username}&password=${vault:path/to/secret:password}&ssl=require" \
--c topics=your-topic \
--c auto.create=true
+avn service connector create \
+  --project demo-project \
+  --service demo-kafka-service \
+  --connector-name jdbc-sink-connector \
+  --connector-class io.aiven.connect.jdbc.JdbcSinkConnector \
+  --config '{
+    "connection.url": "jdbc:postgresql://localhost:5432/mydb?user=${vault:path/to/secret:username}&password=${vault:path/to/secret:password}&ssl=require",
+    "topics": "your-topic",
+    "auto.create": "true"
+  }'
 
 ```
 
 Parameters:
 
-- `name`: Name of the connector.
+- `project`: Name of your Aiven project.
+- `service`: Name of your Aiven Kafka service.
+- `connector-name`: Name of the connector.
 - `connector.class`: Specifies the connector class to use, in this case,
   `io.aiven.connect.jdbc.JdbcSinkConnector`.
 - `connection.url`: JDBC connection URL, with placeholders for the username and password
@@ -201,22 +213,30 @@ Parameters:
 Reference secrets in the JDBC source connector configuration using the following
 CLI command:
 
-```sh
-avn service user-config set kafka-connect -c name=your-source-connector-name \
--c connector.class=io.aiven.connect.jdbc.JdbcSourceConnector \
--c connection.url="jdbc:postgresql://your-postgresql-host:your-port/defaultdb?ssl=require" \
--c connection.user="${vault:path/to/secret:username}" \
--c connection.password="${vault:path/to/secret:password}" \
--c incrementing.column.name=id \
--c mode=incrementing \
--c table.whitelist=your-table \
--c topic.prefix=your-prefix_ \
--c auto.create=true
+```bash
+avn service connector create \
+  --project demo-project \
+  --service demo-kafka-service \
+  --connector-name jdbc-source-connector \
+  --connector-class io.aiven.connect.jdbc.JdbcSourceConnector \
+  --config '{
+    "connection.url": "jdbc:postgresql://your-postgresql-host:your-port/defaultdb?ssl=require",
+    "connection.user": "${vault:path/to/secret:username}",
+    "connection.password": "${vault:path/to/secret:password}",
+    "incrementing.column.name": "id",
+    "mode": "incrementing",
+    "table.whitelist": "your-table",
+    "topic.prefix": "your-prefix_",
+    "auto.create": "true"
+  }'
+
 ```
 
 Parameters:
 
-- `name`: Name of the connector.
+- `project`: Name of your Aiven project.
+- `service`: Name of your Aiven Kafka service.
+- `connector-name`: Name of the connector.
 - `connector.class`: Specifies the connector class to use, in this case,
   `io.aiven.connect.jdbc.JdbcSinkConnector`.
 - `connection.url`: JDBC connection URL, with placeholders for the username and password

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -54,7 +54,7 @@ Parameters:
 - `SERVICE_NAME`: Name of your Aiven Kafka service.
 - `url`: API endpoint for updating service configuration. Replace `{project_name}` and
   `{service_name}` with your project and service names.
-- `Authorization`: Header for authentication. Replace `YOUR_BEARER_TOKEN` with your
+- `Authorization`: User for authentication. Replace `YOUR_BEARER_TOKEN` with your
   [Aiven API token](/docs/platform/howto/create_authentication_token).
 - `Content-Type`: Specifies that the request body is in JSON format.
 - `auth_method`: Authentication method used by HashiCorp Vault. In this case, it is token.

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -54,7 +54,7 @@ Parameters:
 - `SERVICE_NAME`: Name of your Aiven Kafka service.
 - `url`: API endpoint for updating service configuration. Replace `{project_name}` and
   `{service_name}` with your project and service names.
-- `Authorization`: User for authentication. Replace `YOUR_BEARER_TOKEN` with your
+- `Authorization`: Token used for authentication. Replace `YOUR_BEARER_TOKEN` with your
   [Aiven API token](/docs/platform/howto/create_authentication_token).
 - `Content-Type`: Specifies that the request body is in JSON format.
 - `auth_method`: Authentication method used by HashiCorp Vault. In this case, it is token.

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -10,9 +10,8 @@ Configure and use HashiCorp Vault as a secret provider in Aiven for Apache Kafka
 ## Prerequisites
 
 - Access to the [Aiven Console](https://console.aiven.io/).
-- Aiven for Apache Kafka service with Apache Kafka Connect set up and running.
-  For setup instructions, see
-  [Aiven for Apache Kafka with Kafka Connect documentation](/docs/products/kafka/kafka-connect/get-started).
+- [Aiven for Apache Kafka service with Apache Kafka Connect](/docs/products/kafka/kafka-connect/get-started)
+  set up and running.
 - [Aiven CLI](/docs/tools/cli).
 - [HashiCorp Vault address and token](https://developer.hashicorp.com/vault/docs/concepts/tokens).
 
@@ -54,9 +53,9 @@ Parameters:
 - `PROJECT_NAME`: Name of your Aiven project.
 - `SERVICE_NAME`: Name of your Aiven Kafka service.
 - `url`: API endpoint for updating service configuration. Replace `{project_name}` and
-  `{service_name}` with your actual project and service names.
+  `{service_name}` with your project and service names.
 - `Authorization`: Header for authentication. Replace `YOUR_BEARER_TOKEN` with your
-  actual  [Aiven API token](/docs/platform/howto/create_authentication_token).
+  [Aiven API token](/docs/platform/howto/create_authentication_token).
 - `Content-Type`: Specifies that the request body is in JSON format.
 - `auth_method`: Authentication method used by HashiCorp Vault. In this case, it is token.
 - `address`: Address of the HashiCorp Vault server.

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -1,0 +1,234 @@
+---
+title: Configure HashiCorp Vault
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Configure and use HashiCorp Vault as a secret provider in Apache Kafka® Connect services on Aiven for Apache Kafka®.
+
+## Prerequisites
+
+- Access to the [Aiven Console](https://console.aiven.io/).
+- Aiven for Apache Kafka service with Apache Kafka Connect set up and running.
+  For setup instructions, see
+  [Aiven for Apache Kafka with Kafka Connect documentation](https://aiven.io/docs/products/kafka/kafka-connect/get-started).
+- [Aiven CLI](/docs/tools/cli)
+- [HashiCorp Vault address and token](https://developer.hashicorp.com/vault/docs/concepts/tokens)
+
+## Configure secret providers
+
+Set up HashiCorp Vault in your Aiven for Apache Kafka Connect service to securely
+manage and access sensitive information.
+
+<Tabs groupId="config-methods">
+<TabItem value="api" label="API" default>
+
+Add HashiCorp Vault configuration to `user_config`:
+
+```sh
+curl --request PUT \
+  --url https://api.aiven.io/v1/project/{project_name}/service/{service_name} \
+  --header 'Authorization: Bearer YOUR_BEARER_TOKEN' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "user_config": {
+      "secret_providers": [
+       {
+        "name": "vault",
+        "vault": {
+          "auth_method": "token",
+          "address": "https://vault.aiven.fi:8200/",
+          "token": "YOUR_VAULT_TOKEN"
+        }
+      }
+    ]
+  }
+}'
+```
+
+Parameters:
+
+- `url`: API endpoint for updating service configuration. Replace `{project_name}` and
+  `{service_name}` with your actual project and service names.
+- `Authorization`: Header for authentication. Replace `YOUR_BEARER_TOKEN` with your
+  actual  [Aiven API token](/docs/platform/howto/create_authentication_token).
+- `Content-Type`: Specifies that the request body is in JSON format.
+- `auth_method`: Authentication method used by HashiCorp Vault. In this case, it is token.
+- `address`: Address of the HashiCorp Vault server.
+- `token`: Your HashiCorp Vault token.
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+Add HashiCorp Vault using the Aiven CLI:
+
+```sh
+avn service update kafka-connect \
+-c secret_providers='[
+    {
+        "vault": {
+            "auth_method": "token",
+            "address": "https://vault.aiven.fi:8200/",
+            "token": "<replace_with_your_vault_token>"
+        },
+        "name": "vault"
+    }
+]'
+```
+
+Parameters:
+
+- `auth_method`: Authentication method used by HashiCorp Vault. In this case, it is
+  `token`.
+- `address`: Address of the HashiCorp Vault server.
+- `token`: Your HashiCorp Vault token.
+
+</TabItem>
+</Tabs>
+
+## Reference secrets in connector configurations
+
+After configuring the secret providers, you can reference secrets in your
+connector configurations.
+
+### JDBC sink connector
+
+<Tabs groupId="reference-secrets-sink">
+<TabItem value="api" label="API" default>
+
+Reference secrets in the JDBC sink connector configuration using the
+following API request:
+
+```sh
+curl -X POST https://api.aiven.io/v1/project/<project_name>/service/<service_name>/connectors \
+  -H "Authorization: Bearer <your_auth_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "your-connector-name",
+        "connector.class": "io.aiven.connect.jdbc.JdbcSinkConnector",
+        "connection.url": "jdbc:postgresql://host:port/dbname?user=${vault:path/to/secret:username}&password=${vault:path/to/secret:password}&ssl=require",
+        "topics": "your-topic",
+        "auto.create": "true"
+      }'
+```
+
+Parameters:
+
+- `name`: Name of the connector.
+- `connector.class`: Specifies the connector class to use, in this case,
+  `io.aiven.connect.jdbc.JdbcSinkConnector`.
+- `connection.url`: JDBC connection URL, with placeholders for the username and password
+  retrieved from HashiCorp Vault.
+- `topics`: Apache Kafka topic where the data can be sent.
+- `auto.create`: If `true`, the connector automatically creates the table in
+  the target database if it does not exist.
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+Reference secrets in the JDBC sink connector configuration using the following
+CLI command:
+
+```bash
+avn service user-config set kafka-connect -c name=your-sink-connector-name \
+-c connector.class=io.aiven.connect.jdbc.JdbcSinkConnector \
+-c connection.url="jdbc:postgresql://host:port/dbname?user=${vault:path/to/secret:username}&password=${vault:path/to/secret:password}&ssl=require" \
+-c topics=your-topic \
+-c auto.create=true
+
+```
+
+Parameters:
+
+- `name`: Name of the connector.
+- `connector.class`: Specifies the connector class to use, in this case,
+  `io.aiven.connect.jdbc.JdbcSinkConnector`.
+- `connection.url`: JDBC connection URL, with placeholders for the username and password
+  retrieved from HashiCorp Vault.
+- `topics`: Apache Kafka topic where the data can be sent.
+- `auto.create`: If `true`, the connector automatically creates the table in
+  the target database if it does not exist.
+
+</TabItem>
+</Tabs>
+
+### JDBC source connector
+
+<Tabs groupId="reference-secrets-source">
+<TabItem value="api" label="API" default>
+
+Reference secrets in the JDBC source connector configuration using the following
+API request:
+
+```sh
+curl -X POST https://api.aiven.io/v1/project/<project_name>/service/<service_name>/connectors \
+  -H "Authorization: Bearer <your_auth_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "your-connector-name",
+        "connector.class": "io.aiven.connect.jdbc.JdbcSourceConnector",
+        "connection.url": "jdbc:postgresql://your-postgresql-host:your-port/defaultdb?ssl=require",
+        "connection.user": "${vault:path/to/secret:username}",
+        "connection.password": "${vault:path/to/secret:password}",
+        "incrementing.column.name": "id",
+        "mode": "incrementing",
+        "table.whitelist": "your-table",
+        "topic.prefix": "your-prefix_",
+        "auto.create": "true"
+      }'
+```
+
+Parameters:
+
+- `name`: Name of the connector.
+- `connector.class`: Specifies the connector class to use, in this case,
+  `io.aiven.connect.jdbc.JdbcSinkConnector`.
+- `connection.url`: JDBC connection URL, with placeholders for the username and password
+  retrieved from HashiCorp Vault.
+- `connection.user`: Database username retrieved from HashiCorp Vault.
+- `connection.password`: Database password retrieved from HashiCorp Vault.
+- `incrementing.column.name`: Column used for incrementing mode.
+- `mode`: Mode of operation, in this case, `incrementing`.
+- `table.whitelist`: Tables to include.
+- `topic.prefix`: Prefix to use for Apache Kafka topics.
+- `auto.create`: If `true`, the connector automatically creates the table in
+  the target database if it does not exist.
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+Reference secrets in the JDBC source connector configuration using the following
+CLI command:
+
+```sh
+avn service user-config set kafka-connect -c name=your-source-connector-name \
+-c connector.class=io.aiven.connect.jdbc.JdbcSourceConnector \
+-c connection.url="jdbc:postgresql://your-postgresql-host:your-port/defaultdb?ssl=require" \
+-c connection.user="${vault:path/to/secret:username}" \
+-c connection.password="${vault:path/to/secret:password}" \
+-c incrementing.column.name=id \
+-c mode=incrementing \
+-c table.whitelist=your-table \
+-c topic.prefix=your-prefix_ \
+-c auto.create=true
+```
+
+Parameters:
+
+- `name`: Name of the connector.
+- `connector.class`: Specifies the connector class to use, in this case,
+  `io.aiven.connect.jdbc.JdbcSinkConnector`.
+- `connection.url`: JDBC connection URL, with placeholders for the username and password
+  retrieved from HashiCorp Vault.
+- `connection.user`: Database username retrieved from HashiCorp Vault.
+- `connection.password`: Database password retrieved from HashiCorp Vault.
+- `incrementing.column.name`: Column used for incrementing mode.
+- `mode`: Mode of operation, in this case, `incrementing`.
+- `table.whitelist`: Tables to include.
+- `topic.prefix`: Prefix to use for Apache Kafka topics.
+- `auto.create`: If `true`, the connector automatically creates the table in
+  the target database if it does not exist.
+
+</TabItem>
+</Tabs>

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -5,7 +5,7 @@ title: Configure HashiCorp Vault
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Configure and use HashiCorp Vault as a secret provider in Aiven for Apache Kafka® Connect services.
+Configure and use [HashiCorp Vault](https://developer.hashicorp.com/vault/docs) as a secret provider in Aiven for Apache Kafka® Connect services.
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@ Configure and use HashiCorp Vault as a secret provider in Aiven for Apache Kafka
 Set up HashiCorp Vault in your Aiven for Apache Kafka Connect service to manage and
 access sensitive information.
 
-<Tabs groupId="config-methods">
+<Tabs groupId="secret-config">
 <TabItem value="api" label="API" default>
 
 Use the [ServiceUpdate](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
@@ -100,7 +100,7 @@ for other connectors.
 
 ### JDBC sink connector
 
-<Tabs groupId="reference-secrets-sink">
+<Tabs groupId="secret-config">
 <TabItem value="api" label="API" default>
 
 Configure a JDBC sink connector using the API with secrets referenced from
@@ -165,7 +165,7 @@ Parameters:
 
 ### JDBC source connector
 
-<Tabs groupId="reference-secrets-source">
+<Tabs groupId="secret-config">
 <TabItem value="api" label="API" default>
 
 Configure a JDBC source connector using the API with secrets referenced from

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -12,7 +12,7 @@ Configure and use HashiCorp Vault as a secret provider in Aiven for Apache Kafka
 - Access to the [Aiven Console](https://console.aiven.io/).
 - Aiven for Apache Kafka service with Apache Kafka Connect set up and running.
   For setup instructions, see
-  [Aiven for Apache Kafka with Kafka Connect documentation](https://aiven.io/docs/products/kafka/kafka-connect/get-started).
+  [Aiven for Apache Kafka with Kafka Connect documentation](/docs/products/kafka/kafka-connect/get-started).
 - [Aiven CLI](/docs/tools/cli).
 - [HashiCorp Vault address and token](https://developer.hashicorp.com/vault/docs/concepts/tokens).
 

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -41,7 +41,6 @@ curl --request PUT \
           "vault": {
             "auth_method": "token",
             "address": "https://vault.aiven.fi:8200/
-            ",
             "token": "YOUR_VAULT_TOKEN"
           }
         }

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -25,32 +25,35 @@ access sensitive information.
 <TabItem value="api" label="API" default>
 
 Use the [ServiceUpdate](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
-API to update your service configuration. Add the AWS Secrets Manager configuration
-to the `user_config` using the following API request:
+API to update your service configuration. Add the HashiCorp Vault configuration to
+the `user_config` using the following API request:
 
 ```sh
 curl --request PUT \
-  --url https://api.aiven.io/v1/project/{project_name}/service/{service_name} \
+  --url https://api.aiven.io/v1/project/{PROJECT_NAME}/service/{SERVICE_NAME} \
   --header 'Authorization: Bearer YOUR_BEARER_TOKEN' \
   --header 'Content-Type: application/json' \
   --data '{
     "user_config": {
       "secret_providers": [
-       {
-        "name": "vault",
-        "vault": {
-          "auth_method": "token",
-          "address": "https://vault.aiven.fi:8200/",
-          "token": "YOUR_VAULT_TOKEN"
+        {
+          "name": "vault",
+          "vault": {
+            "auth_method": "token",
+            "address": "https://vault.aiven.fi:8200/
+            ",
+            "token": "YOUR_VAULT_TOKEN"
+          }
         }
-      }
-    ]
-  }
-}'
+      ]
+    }
+  }'
 ```
 
 Parameters:
 
+- `PROJECT_NAME`: Name of your Aiven project.
+- `SERVICE_NAME`: Name of your Aiven Kafka service.
 - `url`: API endpoint for updating service configuration. Replace `{project_name}` and
   `{service_name}` with your actual project and service names.
 - `Authorization`: Header for authentication. Replace `YOUR_BEARER_TOKEN` with your
@@ -63,26 +66,25 @@ Parameters:
 </TabItem>
 <TabItem value="cli" label="CLI">
 
-Add HashiCorp Vault using the [Aiven CLI](/docs/tools/cli):
+Configure HashiCorp Vault as a secret provider using [Aiven CLI](/docs/tools/cli):
 
 ```sh
-avn service update kafka-connect \
--c secret_providers='[
+avn service update SERVICE_NAME \
+  -c secret_providers='[
     {
         "vault": {
             "auth_method": "token",
             "address": "https://vault.aiven.fi:8200/",
-            "token": "<replace_with_your_vault_token>"
+            "token": "YOUR_VAULT_TOKEN"
         },
         "name": "vault"
     }
-]'
+  ]'
 ```
 
 Parameters:
 
-- `project`: Name of your Aiven project.
-- `service`: Name of your Aiven Kafka service.
+- `SERVICE_NAME`: Name of your Aiven Kafka service..
 - `name`: Name of the secret provider. In this case, `vault`.
 - `auth_method`: Authentication method used by HashiCorp Vault. In this case, it is
   `token`.
@@ -102,29 +104,31 @@ connector configurations.
 <Tabs groupId="reference-secrets-sink">
 <TabItem value="api" label="API" default>
 
-Reference secrets in the JDBC sink connector configuration using the
-following API request:
+Configure a JDBC sink connector using the API with secrets referenced from
+HashiCorp Vault:
 
 ```sh
-curl -X POST https://api.aiven.io/v1/project/<project_name>/service/<service_name>/connectors \
-  -H "Authorization: Bearer <your_auth_token>" \
+curl -X POST https://api.aiven.io/v1/project/{PROJECT_NAME}/service/{SERVICE_NAME}/connectors \
+  -H "Authorization: Bearer YOUR_BEARER_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
         "name": "your-connector-name",
         "connector.class": "io.aiven.connect.jdbc.JdbcSinkConnector",
-        "connection.url": "jdbc:postgresql://host:port/dbname?user=${vault:path/to/secret:username}&password=${vault:path/to/secret:password}&ssl=require",
+        "connection.url": "jdbc:{DATABASE_TYPE}://{HOST}:{PORT}/{DATABASE_NAME}?user=${vault:PATH/TO/SECRET:USERNAME}&password=${vault:PATH/TO/SECRET:PASSWORD}&ssl=require",
         "topics": "your-topic",
-        "auto.create": "true"
+        "auto.create": true
       }'
 ```
 
 Parameters:
 
+- `PROJECT_NAME`: Name of your Aiven project.
+- `SERVICE_NAME`: Name of your Aiven Kafka service.
 - `name`: Name of the connector.
 - `connector.class`: Specifies the connector class to use, in this case,
   `io.aiven.connect.jdbc.JdbcSinkConnector`.
-- `connection.url`: JDBC connection URL, with placeholders for the username and password
-  retrieved from HashiCorp Vault.
+- `connection.url`: JDBC connection URL with placeholders for `DATABASE_TYPE`, `HOST`,
+  `PORT`, `DATABASE_NAME`, and the username and password retrieved from HashiCorp Vault.
 - `topics`: Apache Kafka topic where the data can be sent.
 - `auto.create`: If `true`, the connector automatically creates the table in
   the target database if it does not exist.
@@ -132,32 +136,27 @@ Parameters:
 </TabItem>
 <TabItem value="cli" label="CLI">
 
-Reference secrets in the JDBC sink connector configuration using the following
-CLI command:
+Configure a JDBC sink connector using the Aiven CLI with secrets referenced from
+HashiCorp Vault:
 
 ```bash
-avn service connector create \
-  --project demo-project \
-  --service demo-kafka-service \
-  --connector-name jdbc-sink-connector \
-  --connector-class io.aiven.connect.jdbc.JdbcSinkConnector \
-  --config '{
-    "connection.url": "jdbc:postgresql://localhost:5432/mydb?user=${vault:path/to/secret:username}&password=${vault:path/to/secret:password}&ssl=require",
-    "topics": "your-topic",
-    "auto.create": "true"
-  }'
+avn service connector create SERVICE_NAME '{
+  "name": "jdbc-sink-connector",
+  "connector.class": "io.aiven.connect.jdbc.JdbcSinkConnector",
+  "connection.url": "jdbc:{DATABASE_TYPE}://{HOST}:{PORT}/{DATABASE_NAME}?user=${vault:PATH/TO/SECRET:USERNAME}&password=${vault:PATH/TO/SECRET:PASSWORD}&ssl=require",
+  "topics": "your-topic",
+  "auto.create": true
 
 ```
 
 Parameters:
 
-- `project`: Name of your Aiven project.
-- `service`: Name of your Aiven Kafka service.
-- `connector-name`: Name of the connector.
+- `SERVICE_NAME`: Name of your Aiven Kafka service.
+- `name`: Name of the connector.
 - `connector.class`: Specifies the connector class to use, in this case,
   `io.aiven.connect.jdbc.JdbcSinkConnector`.
-- `connection.url`: JDBC connection URL, with placeholders for the username and password
-  retrieved from HashiCorp Vault.
+- `connection.url`: JDBC connection URL with placeholders for `DATABASE_TYPE`, `HOST`,
+  `PORT`, `DATABASE_NAME`, and the username and password retrieved from HashiCorp Vault.
 - `topics`: Apache Kafka topic where the data can be sent.
 - `auto.create`: If `true`, the connector automatically creates the table in
   the target database if it does not exist.
@@ -170,83 +169,82 @@ Parameters:
 <Tabs groupId="reference-secrets-source">
 <TabItem value="api" label="API" default>
 
-Reference secrets in the JDBC source connector configuration using the following
-API request:
+Configure a JDBC source connector using the API with secrets referenced from
+HashiCorp Vault:
+
 
 ```sh
-curl -X POST https://api.aiven.io/v1/project/<project_name>/service/<service_name>/connectors \
-  -H "Authorization: Bearer <your_auth_token>" \
+curl -X POST https://api.aiven.io/v1/project/{PROJECT_NAME}/service/{SERVICE_NAME}/connectors \
+  -H "Authorization: Bearer YOUR_BEARER_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
         "name": "your-connector-name",
         "connector.class": "io.aiven.connect.jdbc.JdbcSourceConnector",
-        "connection.url": "jdbc:postgresql://your-postgresql-host:your-port/defaultdb?ssl=require",
-        "connection.user": "${vault:path/to/secret:username}",
-        "connection.password": "${vault:path/to/secret:password}",
+        "connection.url": "jdbc:{DATABASE_TYPE}://{HOST}:{PORT}/{DATABASE_NAME}?ssl=require",
+        "connection.user": "${vault:PATH/TO/SECRET:USERNAME}",
+        "connection.password": "${vault:PATH/TO/SECRET:PASSWORD}",
         "incrementing.column.name": "id",
         "mode": "incrementing",
         "table.whitelist": "your-table",
         "topic.prefix": "your-prefix_",
-        "auto.create": "true"
+        "auto.create": true
       }'
 ```
 
 Parameters:
 
+- `PROJECT_NAME`: Name of your Aiven project.
+- `SERVICE_NAME`: Name of your Aiven Kafka service.
 - `name`: Name of the connector.
 - `connector.class`: Specifies the connector class to use, in this case,
   `io.aiven.connect.jdbc.JdbcSinkConnector`.
-- `connection.url`: JDBC connection URL, with placeholders for the username and password
-  retrieved from HashiCorp Vault.
+- `connection.url`: JDBC connection URL with placeholders for `DATABASE_TYPE`, `HOST`,
+  `PORT`, `DATABASE_NAME`, and the username and password retrieved from HashiCorp Vault.
 - `connection.user`: Database username retrieved from HashiCorp Vault.
 - `connection.password`: Database password retrieved from HashiCorp Vault.
 - `incrementing.column.name`: Column used for incrementing mode.
 - `mode`: Mode of operation, in this case, `incrementing`.
 - `table.whitelist`: Tables to include.
-- `topic.prefix`: Prefix to use for Apache Kafka topics.
+- `topic.prefix`: Prefix for Apache Kafka topics.
 - `auto.create`: If `true`, the connector automatically creates the table in
   the target database if it does not exist.
 
 </TabItem>
 <TabItem value="cli" label="CLI">
 
-Reference secrets in the JDBC source connector configuration using the following
-CLI command:
+Configure a JDBC source connector using the Aiven CLI with secrets referenced
+from HashiCorp Vault:
 
 ```bash
-avn service connector create \
-  --project demo-project \
-  --service demo-kafka-service \
-  --connector-name jdbc-source-connector \
-  --connector-class io.aiven.connect.jdbc.JdbcSourceConnector \
-  --config '{
-    "connection.url": "jdbc:postgresql://your-postgresql-host:your-port/defaultdb?ssl=require",
-    "connection.user": "${vault:path/to/secret:username}",
-    "connection.password": "${vault:path/to/secret:password}",
-    "incrementing.column.name": "id",
-    "mode": "incrementing",
-    "table.whitelist": "your-table",
-    "topic.prefix": "your-prefix_",
-    "auto.create": "true"
-  }'
+avn service connector create SERVICE_NAME '{
+  "name": "jdbc-source-connector",
+  "connector.class": "io.aiven.connect.jdbc.JdbcSourceConnector",
+  "connection.url": "jdbc:{DATABASE_TYPE}://{HOST}:{PORT}/{DATABASE_NAME}?ssl=require",
+  "connection.user": "${vault:PATH/TO/SECRET:USERNAME}",
+  "connection.password": "${vault:PATH/TO/SECRET:PASSWORD}",
+  "incrementing.column.name": "id",
+  "mode": "incrementing",
+  "table.whitelist": "your-table",
+  "topic.prefix": "your-prefix_",
+  "auto.create": true
+}'
 
 ```
 
 Parameters:
 
-- `project`: Name of your Aiven project.
-- `service`: Name of your Aiven Kafka service.
-- `connector-name`: Name of the connector.
+- `SERVICE_NAME`: Name of your Aiven Kafka service.
+- `name`: Name of the connector.
 - `connector.class`: Specifies the connector class to use, in this case,
   `io.aiven.connect.jdbc.JdbcSinkConnector`.
-- `connection.url`: JDBC connection URL, with placeholders for the username and password
-  retrieved from HashiCorp Vault.
+- `connection.url`: JDBC connection URL with placeholders for `DATABASE_TYPE`, `HOST`,
+  `PORT`, `DATABASE_NAME`, and the username and password retrieved from HashiCorp Vault.
 - `connection.user`: Database username retrieved from HashiCorp Vault.
 - `connection.password`: Database password retrieved from HashiCorp Vault.
 - `incrementing.column.name`: Column used for incrementing mode.
 - `mode`: Mode of operation, in this case, `incrementing`.
 - `table.whitelist`: Tables to include.
-- `topic.prefix`: Prefix to use for Apache Kafka topics.
+- `topic.prefix`: Prefix for Apache Kafka topics.
 - `auto.create`: If `true`, the connector automatically creates the table in
   the target database if it does not exist.
 

--- a/docs/products/kafka/kafka-connect/howto/configure-secret-providers.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-secret-providers.md
@@ -11,9 +11,8 @@ Secret providers are tools that manage sensitive information, such as passwords
 and API keys, in a secure manner. Instead of directly including these secrets in your
 configuration files, secret providers allow you to store them securely in external
 secret managers like AWS Secrets Manager and HashiCorp Vault.
-Aiven for Apache Kafka Connect can then dynamically retrieve these secrets when needed,
-enhancing the security of your setup.
-
+Aiven for Apache Kafka Connect dynamically retrieves these secrets when needed, enhancing
+the security of your setup.
 
 ## Supported secret managers
 

--- a/docs/products/kafka/kafka-connect/howto/configure-secret-providers.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-secret-providers.md
@@ -1,0 +1,25 @@
+---
+title: Aiven for Apache Kafka® Connect secret providers
+---
+
+Configure and use secret providers in Apache Kafka Connect services on Aiven for Apache Kafka.
+Securely reference secrets stored in external secret managers within your connector configurations, ensuring that sensitive information is not stored in plain text.
+
+## What are secret providers?
+
+Secret providers are tools that manage sensitive information, such as passwords
+and API keys, in a secure manner. Instead of directly including these secrets in your
+configuration files, secret providers allow you to store them securely in external
+secret managers like AWS Secrets Manager and HashiCorp Vault.
+Aiven for Apache Kafka Connect can then dynamically retrieve these secrets when needed,
+enhancing the security of your setup.
+
+
+## Supported secret managers
+
+- [AWS Secrets Manager](/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager)
+  - **Auth method**:` credentials`
+  - **Required parameters**: `access key`, `secret key`
+- [HashiCorp Vault](/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault)
+  - **Auth method**: `token`
+  - **Required parameters**: `token`, `address`

--- a/docs/products/kafka/kafka-connect/howto/configure-secret-providers.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-secret-providers.md
@@ -18,7 +18,7 @@ enhancing the security of your setup.
 ## Supported secret managers
 
 - [AWS Secrets Manager](/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager)
-  - **Auth method**:` credentials`
+  - **Auth method**: `credentials`
   - **Required parameters**: `access key`, `secret key`
 - [HashiCorp Vault](/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault)
   - **Auth method**: `token`

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1005,6 +1005,18 @@ const sidebars: SidebarsConfig = {
                         'products/kafka/kafka-connect/howto/enable-automatic-restart',
                         'products/kafka/kafka-connect/howto/manage-logging-level',
                         'products/kafka/kafka-connect/howto/request-new-connector',
+                        {
+                          type: 'category',
+                          label: 'Configure secret providers',
+                          link: {
+                            type: 'doc',
+                            id: 'products/kafka/kafka-connect/howto/configure-secret-providers',
+                          },
+                          items: [
+                            'products/kafka/kafka-connect/howto/configure-aws-secrets-manager',
+                            'products/kafka/kafka-connect/howto/configure-hashicorp-vault',
+                          ],
+                        },
                       ],
                     },
                     {


### PR DESCRIPTION
## Describe your changes
Added content for configuring AWS Secrets Manager and HashiCorp Vault as secret providers in Apache Kafka Connect on Aiven, including examples for JDBC connectors.

Ref: [EC-343](https://aiven.atlassian.net/browse/EC-343)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.


[EC-343]: https://aiven.atlassian.net/browse/EC-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ