### PR TITLE
fix: impact of govenanace topic creation

### DIFF
--- a/docs/products/kafka/howto/enable-governance.md
+++ b/docs/products/kafka/howto/enable-governance.md
@@ -18,9 +18,10 @@ Enable governance in Aiven for Apache Kafka® to establish a secure and complian
 
 - **Topic creation workflow**:
   - There is no impact on existing topics.
-  - You can continue to create topics in your Aiven for Apache Kafka service. Governance
-    introduces an additional request-and-approval process for claiming ownership of
-    topics in the Apache Kafka topic catalog.
+  - You can continue to [create topics](/docs/products/kafka/howto/create-topic) in your
+    Aiven for Apache Kafka service. Governance in Aiven for Apache Kafka introduces an
+    additional request-and-approval process to claim ownership of topics from the
+    Apache Kafka topic catalog.
   - All topics align with your organization's data management policies.
 
 ## Prerequisites

--- a/docs/products/kafka/howto/enable-governance.md
+++ b/docs/products/kafka/howto/enable-governance.md
@@ -17,7 +17,10 @@ Enable governance in Aiven for Apache Kafka® to establish a secure and complian
   - Users from different groups can still claim ownership of individual resources.
 
 - **Topic creation workflow**:
-  - Direct topic creation is replaced by a structured request-and-approval process.
+  - There is no impact on existing topics.
+  - You can continue to create topics in your Aiven for Apache Kafka service. Governance
+    introduces an additional request-and-approval process for claiming ownership of
+    topics in the Apache Kafka topic catalog.
   - All topics align with your organization's data management policies.
 
 ## Prerequisites


### PR DESCRIPTION
## Describe your changes
Users can continue to create new topics within their Aiven for Apache Kafka service even with Governance enabled. However, when claiming ownership of a topic, Governance introduces a request-and-approval flow.

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
