### PR TITLE
fix(platform): move byoc networking and security doc to the byoc section

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -201,7 +201,6 @@ const sidebars: SidebarsConfig = {
             id: 'platform/howto/list-service',
           },
           items: [
-            'platform/howto/byoc/networking-security',
             {
               type: 'category',
               label: 'Concepts',
@@ -276,6 +275,7 @@ const sidebars: SidebarsConfig = {
                 id: 'platform/concepts/byoc',
               },
               items: [
+                'platform/howto/byoc/networking-security',
                 'platform/howto/byoc/enable-byoc',
                 'platform/howto/byoc/create-custom-cloud',
                 'platform/howto/byoc/assign-project-custom-cloud',


### PR DESCRIPTION
Somehow the byoc networking & sec doc landed in a weird place. Fixing that...

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
