### PR TITLE
fix: remove trademark for Aiven for Metrics

### DIFF
--- a/docs/products/metrics.md
+++ b/docs/products/metrics.md
@@ -1,9 +1,9 @@
 ---
-title: Aiven for Metrics®
+title: Aiven for Metrics
 early: true
 ---
 
-Aiven for Metrics®, powered by Thanos, simplifies managing and analyzing large volumes of metrics data for businesses of all sizes.
+Aiven for Metrics, powered by Thanos, simplifies managing and analyzing large volumes of metrics data for businesses of all sizes.
 It offers a scalable, reliable, and efficient service suitable for businesses of all sizes. This service simplifies the management of large-scale metrics systems, allowing organizations to focus on deriving insights from their data.
 
 ## Key components

--- a/docs/products/metrics/concepts.md
+++ b/docs/products/metrics/concepts.md
@@ -1,5 +1,5 @@
 ---
-title: Aiven for Metrics®
+title: Aiven for Metrics
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/products/metrics/concepts/retention-rules.md
+++ b/docs/products/metrics/concepts/retention-rules.md
@@ -2,7 +2,7 @@
 title: Retention rules in Aiven for Metrics
 sidebar_label: Retention rules
 ---
-Retention rules in Aiven for Metrics® define how long your metrics data is stored.
+Retention rules in Aiven for Metrics define how long your metrics data is stored.
 
 By default, all data is retained indefinitely, ensuring uninterrupted access to
 historical insights. Optimize storage and access to historical data by tailoring

--- a/docs/products/metrics/concepts/storage-resource-scaling.md
+++ b/docs/products/metrics/concepts/storage-resource-scaling.md
@@ -2,7 +2,7 @@
 title: Storage and resource scaling
 ---
 
-Aiven for Metrics® leverages various storage and resource types to optimize your monitoring experience for both cost and performance. Explores how Aiven uses object storage, disk storage, memory, and compute resources.
+Aiven for Metrics leverages various storage and resource types to optimize your monitoring experience for both cost and performance. Explores how Aiven uses object storage, disk storage, memory, and compute resources.
 
 ## Storage solutions
 

--- a/docs/products/metrics/howto/list-data-migration.md
+++ b/docs/products/metrics/howto/list-data-migration.md
@@ -2,7 +2,7 @@
 title: Data migration
 ---
 
-Discover how to migrate your data to Aiven for Metrics® from Aiven for InfluxDB® and Aiven for M3DB®, ensuring data integrity and minimal downtime.
+Discover how to migrate your data to Aiven for Metrics from Aiven for InfluxDB® and Aiven for M3DB®, ensuring data integrity and minimal downtime.
 
 import DocCardList from '@theme/DocCardList';
 


### PR DESCRIPTION
## Describe your changes

Remove the registered trademark symbol (®) from all mentions of "Aiven for Metrics" in our documentation. Since the 
service name is not currently registered, and there are no plans to register it in the near future. 


https://aiven.atlassian.net/browse/DOC-1139

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
