### PR TITLE
update: Kafka disk write lock triggers at 95% not 97%

### DIFF
--- a/docs/products/kafka/howto/prevent-full-disks.md
+++ b/docs/products/kafka/howto/prevent-full-disks.md
@@ -3,82 +3,136 @@ title: Prevent full disks
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-To ensure the smooth functioning of your **Aiven for Apache Kafka®** services, preventing disk space from running low is important.
-The Aiven platform actively monitors the available disk space, and if the usage
-exceeds 90%, you will be notified.
+Ensure your Aiven for Apache Kafka® services run smoothly by preventing low disk space. The Aiven platform actively monitors disk usage, triggering notifications when it exceeds 90%.
 
 If any node in the service surpasses the critical threshold of disk
 usage (more than 95%), the access control list (ACL) used to authorize
-API requests by Apache Kafka clients will be updated on all nodes. This
-update will prevent operations that can further increase disk usage,
+API requests by Apache Kafka clients is updated on all nodes. This
+update prevents operations that can further increase disk usage,
 including:
 
--   The `Write` and `IdempotentWrite` operations that clients use to
-    produce new messages.
--   The `CreateTopics` operation that creates one or more topics, each
-    carrying some overhead on disk.
+- The `Write` and `IdempotentWrite` operations are used by clients to produce
+  new messages.
+- The `CreateTopics` operation creates new topics, each of which carries some
+  overhead on disk.
 
-When the disk space is insufficient, and the ACL blocks write
-operations, you will encounter an error. For example, if you are using
-the Python client for Apache Kafka, you may receive the following error
-message:
+When the disk space is insufficient and the ACL blocks write operations, you encounter
+an error. For example, when using the Python client for Apache Kafka, you might
+receive the following error message:
 
-```
+```plaintext
 TopicAuthorizationFailedError: [Error 29] TopicAuthorizationFailedError: your-topic
 ```
 
 ## Upgrade to a larger service plan
 
-1.  In the [Aiven Console](https://console.aiven.io/), select your
-    project and choose your Aiven for Apache Kafka® service.
-1.  In the service page, select **Service settings** from the sidebar.
-1.  On the **Service settings** page, scroll to **Service plan** and
-    click <ConsoleLabel name="actions"/> > **Change plan**.
-1.  In the **Change service plan** dialog, select your new service plan
-    and select **Change**.
+<Tabs groupId="upgrade-plan">
+<TabItem value="console" label="Console" default>
 
-This will deploy new nodes with increased disk space. Once the data is
-migrated from the old nodes to the new ones, disk usage will return to
-an acceptable level, and write operations will be allowed again.
+To resolve disk space issues, you can upgrade to a larger service plan:
 
-You can also use the CLI command
-[`avn service update`](/docs/tools/cli/service-cli#avn-cli-service-update) to upgrade your
-service plan.
+1. In the [Aiven Console](https://console.aiven.io/), select your
+   project and choose your Aiven for Apache Kafka® service.
+1. On the sidebar, Click <ConsoleLabel name="service settings"/>.
+1. In to **Service plan** section, click <ConsoleLabel name="actions"/> >
+   **Manage additional storage**.
+1. In the **Upgrade service storage** screen, click **Change plan**
+   choose the new service plan and tier or use the slider to adjust disk storage.
+
+This deploys new nodes with increased disk space. After data migration from the old nodes
+to the new ones, disk usage returns to an acceptable level, and write operations are
+allowed again.
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+To upgrade your service plan using the [Aiven CLI](/docs/tools/cli):
+
+```bash
+avn service update --project <PROJECT_NAME> --service_name <SERVICE_NAME> --plan <NEW_PLAN_NAME> --disk-space-gib <DISK_SPACE_GIB>
+```
+
+Parameters:
+
+- `<PROJECT_NAME>`: The name of the project.
+- `<SERVICE_NAME>`: The name of the Aiven for Apache service to update.
+- `--plan <NEW_PLAN_NAME>`: The Aiven subscription plan name. Refer to
+  [`avn_service_plan`](/docs/tools/cli/service-cli#avn-service-plan) for available plans.
+- `--disk-space-gib <DISK_SPACE_GIB>`: The total amount of disk space for data storage
+  (in GiB).
+
+</TabItem>
+</Tabs>
 
 ## Add additional storage space
 
-See [Scale disk storage](/docs/platform/howto/add-storage-space).
+For instructions on adding storage space, see [Scale disk storage](/docs/platform/howto/add-storage-space).
 
 ## Delete one or more topics
 
-1.  In the [Aiven Console](https://console.aiven.io/), select your
-    project and choose your Aiven for Apache Kafka® service.
-1.  Select **Topics** from the sidebar.
-1.  Select the topic to remove, and in the **Topic info**
-    screen, select **Remove** and **Delete** to delete the topic.
+<Tabs groupId="delete-topics">
+<TabItem value="console" label="Console" default>
 
-Deleting a topic frees up the disk space it previously used. The log
-cleaner process may take a few minutes to remove the associated data
-files from the disk. Once completed, the access control list (ACL) is
-updated to allow write operations.
+Free up disk space by deleting topics:
 
-<!-- vale off -->
-You can also use the CLI command
-[avn cli delete-topic](/docs/tools/cli/service/topic) or make a call to [API
-endpoint](https://api.aiven.io/doc/#operation/ServiceKafkaTopicDelete)
-from any native Apache Kafka client to delete topics.
-<!-- vale on -->
+1. In the [Aiven Console](https://console.aiven.io/), select your
+   project and choose your Aiven for Apache Kafka® service.
+1. On the sidebar, click <ConsoleLabel name="topics" />.
+1. To delete an existing topic, click the topic to remove, then either:
+
+   - In the **Topic info** screen, click **Delete** and confirm the deletion.
+   - Alternatively, in the topic row, click the `<ConsoleLabel name="actions"/>` > `<ConsoleLabel name="Delete topic"/>`.
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+To delete topics using the [Aiven CLI](/docs/tools/cli):
+
+```bash
+avn service topic-delete --service_name SERVICE_NAME --topic TOPIC_NAME
+```
+
+Parameters:
+
+- `SERVICE_NAME`: The name of your Aiven for Apache Kafka service.
+- `TOPIC_NAME`: The name of the topic to delete.
+
+</TabItem>
+<TabItem value="api" label="API">
+
+To delete topics using the Aiven API:
+
+```sh
+curl -X DELETE \
+  "https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME/topic/TOPIC_NAME" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+Parameters:
+
+- `PROJECT_NAME`: The name of your project.
+- `SERVICE_NAME`: The name of your Aiven you for Apache Kafka service.
+- `TOPIC_NAME`: The name of the topic to delete.
+- `API_TOKEN`: Your [Aiven token](/docs/platform/concepts/authentication-tokens).
+
+</TabItem>
+</Tabs>
+
+Deleting topics frees up the disk space they used. The log cleaner process can take a
+few minutes to remove the associated data files from the disk. Once complete, the
+access control list (ACL) updates to allow write operations.
 
 :::note
-You must use an admin-level user account for the connection.
+[Admin](docs/platform/reference/project-member-privileges) access is required to
+perform this action.
 :::
 
 ## Decrease retention time/size
 
-Another way to make more space available without deleting an entire
-topic is to reduce the retention time or size for one or more topics. If
-you know how old the oldest messages are in a topic, you can lower the
-retention time for the topic to make more space available. Follow the
-instructions
-[to change retention period](/docs/products/kafka/howto/change-retention-period).
+To free up space without deleting a topic, consider reducing the retention time or size
+for one or more topics. If you know the age of the oldest messages in a topic, you can
+lower the retention time to make more space available. For more details,
+see [how to change the retention period](/docs/products/kafka/howto/change-retention-period).

--- a/docs/products/kafka/howto/prevent-full-disks.md
+++ b/docs/products/kafka/howto/prevent-full-disks.md
@@ -126,7 +126,7 @@ few minutes to remove the associated data files from the disk. Once complete, th
 access control list (ACL) updates to allow write operations.
 
 :::note
-[Admin](docs/platform/reference/project-member-privileges) access is required to
+[Admin](/docs/platform/reference/project-member-privileges) access is required to
 perform this action.
 :::
 

--- a/docs/products/kafka/howto/prevent-full-disks.md
+++ b/docs/products/kafka/howto/prevent-full-disks.md
@@ -9,7 +9,7 @@ The Aiven platform actively monitors the available disk space, and if the usage
 exceeds 90%, you will be notified.
 
 If any node in the service surpasses the critical threshold of disk
-usage (more than 97%), the access control list (ACL) used to authorize
+usage (more than 95%), the access control list (ACL) used to authorize
 API requests by Apache Kafka clients will be updated on all nodes. This
 update will prevent operations that can further increase disk usage,
 including:

--- a/docs/products/kafka/howto/prevent-full-disks.md
+++ b/docs/products/kafka/howto/prevent-full-disks.md
@@ -81,10 +81,10 @@ Free up disk space by deleting topics:
 1. In the [Aiven Console](https://console.aiven.io/), select your
    project and choose your Aiven for Apache Kafka® service.
 1. On the sidebar, click <ConsoleLabel name="topics" />.
-1. To delete an existing topic, click the topic to remove, then either:
+1. To delete an existing topic, click the topic to remove.
 
    - In the **Topic info** screen, click **Delete** and confirm the deletion.
-   - Alternatively, in the topic row, click the `<ConsoleLabel name="actions"/>` > `<ConsoleLabel name="Delete topic"/>`.
+   - Alternatively, in the topic row, click the <ConsoleLabel name="actions"/> > <ConsoleLabel name="Delete topic"/>.
 
 </TabItem>
 <TabItem value="cli" label="CLI">

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -330,6 +330,12 @@ export default function ConsoleLabel({name}): ReactElement {
           <ConsoleIconWrapper icon={ConsoleIcons.edit} /> <b>Edit topic </b>
         </>
       );
+    case 'deletetopic':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.trash} /> <b>Delete topic</b>
+        </>
+      );
     case 'edit':
       return (
         <>


### PR DESCRIPTION
Critical threshold for denying writes to Apache Kafka broker is currently defined at 95% not 97% disk usage.
https://aiven.io/docs/products/kafka/howto/prevent-full-disks

[PM-4272]

[PM-4272]: https://aiven.atlassian.net/browse/PM-4272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ