### PR TITLE
fix: replace BigQuery reference in snowflake-sink-prereq.md

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/snowflake-sink-prereq.md
+++ b/docs/products/kafka/kafka-connect/howto/snowflake-sink-prereq.md
@@ -12,7 +12,7 @@ To sink data from Apache Kafka® to Snowflake via the dedicated connector:
 
 ## Configure a Snowflake key pair authentication
 
-The Apache Kafka BigQuery sink connector requires a key pair
+The Snowflake sink connector requires a key pair
 authentication with a minimum 2048-bit RSA. Generate the key
 pair locally and [upload the public key to Snowflake](https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-authentication):
 


### PR DESCRIPTION
I assume mentioning BigQuery in the Snowflake sink connector (Apache Kafka Connect) is a copy & paste mistake.

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
