### PR TITLE
fix: Kafdrop instructions for Mac users

### DIFF
--- a/docs/products/kafka/howto/kafdrop.md
+++ b/docs/products/kafka/howto/kafdrop.md
@@ -1,75 +1,104 @@
 ---
 title: Use Kafdrop Web UI with Aiven for Apache Kafka®
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-[Kafdrop](https://github.com/obsidiandynamics/kafdrop) is a popular Web UI for Apache Kafka® that allows you to monitor a cluster, view topics and consumer groups with integration into the Schema Registry, with support for Avro, JSON and Protobuf.
+[Kafdrop](https://github.com/obsidiandynamics/kafdrop) is a web UI for Apache Kafka® to monitor clusters, view topics and consumer groups, and integrate with the Schema Registry.
+It supports Avro, JSON, and Protobuf.
 
-## Retrieve Aiven for Apache Kafka® SSL certificate files
+## Prerequisites
 
-Aiven for Apache Kafka® by default enables TLS security. The
-certificates can be manually downloaded from the service overview page
-in the Aiven console, or via the
-[dedicated Aiven CLI command](/docs/tools/cli/service/user#avn_service_user_creds_download).
+- Access to the Aiven console
+- Aiven CLI
+- Docker installed. For Mac M1 chip users, ensure Docker is version 4.26.1 or lower to
+  avoid compatibility issue
 
-## Setup a Kafdrop configuration file
+## Retrieve SSL certificate files
+
+Aiven for Apache Kafka uses TLS security by default. To retrieve the necessary
+SSL certificates, do one of the following:
+
+- [Download the certificates](/docs/platform/concepts/tls-ssl-certificates#download-ca-certificates)
+  manually from the service <ConsoleLabel name="overview"/> page in the
+  [Aiven Console](https://console.aiven.io/).
+- Use the [Aiven CLI command](/docs/tools/cli/service/user#avn_service_user_creds_download).
+
+## Set up a Kafdrop configuration file
 
 Kafdrop supports both
-[SASL and SSL authentication methods](../concepts/auth-types). The following example shows the SSL version which requires
-a keystore and truststore that can be created following the
-[dedicated documentation](/docs/products/kafka/howto/keystore-truststore).
+[SASL and SSL authentication methods](/docs/products/kafka/concepts/auth-types). This
+example uses SSL, which requires a keystore and truststore.
 
-Once the keystore and truststore are created, you can define a Kafdrop
-configuration file named `kafdrop.properties` with the following
-content, replacing the `KEYSTORE_PWD` and `TRUSTSTORE_PWD` with the
-keystore and truststore passwords respectively:
+1. Follow the instructions in the
+   [keystore and truststore documentation](/docs/products/kafka/howto/keystore-truststore)
+   to create the necessary files.
+1. Create a Kafdrop configuration file named `kafdrop.properties` with the following
+   content. Replace `KEYSTORE_PWD` and `TRUSTSTORE_PWD` with your keystore and
+   truststore passwords:
 
-```
-security.protocol=SSL
-ssl.keystore.password=KEYSTORE_PWD
-ssl.keystore.type=PKCS12
-ssl.truststore.password=TRUSTSTORE_PWD
-```
+    ```plaintext
+    security.protocol=SSL
+    ssl.keystore.password=KEYSTORE_PWD
+    ssl.keystore.type=PKCS12
+    ssl.truststore.password=TRUSTSTORE_PWD
+    ```
 
 ## Run Kafdrop on Docker
 
-You can run Kafdrop in a Docker/Podman container with the following
-command, by replacing the `KAFKA_SERVICE_URI` with the Aiven for Apache
-Kafka® service URI available in the service Overview tab of the Aiven
-console, and the `client.truststore.jks` and `client.keystore.p12` with
-the keystores and truststores file names:
+To run Kafdrop in a Docker or Podman container, use the following command.
+Replace `KAFKA_SERVICE_URI` with your Aiven for Apache Kafka® service URI from
+the <ConsoleLabel name="overview"/> page in the
+[Aiven Console](https://console.aiven.io/). Replace `client.truststore.jks` and
+`client.keystore.p12` with your keystore and truststore file names:
 
-```
-docker run -p 9000:9000                                                 \
-    -e KAFKA_BROKERCONNECT=KAFKA_SERVICE_URI                            \
-    -e KAFKA_PROPERTIES="$(cat kafdrop.properties | base64)"            \
-    -e KAFKA_TRUSTSTORE="$(cat client.truststore.jks | base64)"         \
-    -e KAFKA_KEYSTORE="$(cat client.keystore.p12 | base64)"             \
-    obsidiandynamics/kafdrop
+```sh
+docker run -d --rm -p 9000:9000 \
+  -e KAFKA_BROKERCONNECT=KAFKA_SERVICE_URI \
+  -e KAFKA_PROPERTIES="$(cat kafka/kafdrop.properties | base64)" \
+  -e KAFKA_TRUSTSTORE="$(cat kafka/client.truststore.jks | base64)" \
+  -e KAFKA_KEYSTORE="$(cat kafka/client.keystore.p12 | base64)" \
+  obsidiandynamics/kafdrop
 ```
 
-If you're also interested in Kafdrop to de-serialize Avro messages
-using [Karapace](https://github.com/aiven/karapace) schema registry, add
-the following two lines to the `docker run` command:
+For users with a Mac M1 chip, add the `--platform linux/amd64` flag to the command:
 
+```sh
+docker run --platform linux/amd64 -d --rm -p 9000:9000 \
+  -e KAFKA_BROKERCONNECT=KAFKA_SERVICE_URI \
+  -e KAFKA_PROPERTIES="$(cat kafka/kafdrop.properties | base64)" \
+  -e KAFKA_TRUSTSTORE="$(cat kafka/client.truststore.jks | base64)" \
+  -e KAFKA_KEYSTORE="$(cat kafka/client.keystore.p12 | base64)" \
+  obsidiandynamics/kafdrop
 ```
+
+:::note
+Docker versions above 4.26.1 have known issues on Mac M1 chips. We recommend using
+Docker version 4.26.1 or lower.
+:::
+
+If you need Kafdrop to deserialize Avro messages using the
+[Karapace](https://github.com/aiven/karapace) schema registry, add the following
+two lines to the `docker run` command:
+
+```sh
 -e SCHEMAREGISTRY_AUTH="avnadmin:SCHEMA_REGISTRY_PWD"   \
 -e SCHEMAREGISTRY_CONNECT="https://SCHEMA_REGISTRY_URI" \
 ```
 
-Replace, in the above, the `SCHEMA_REGISTRY_PWD` with the schema
-registry password and `SCHEMA_REGISTRY_URI` with the schema registry URI
-that available in the [Aiven console](https://console.aiven.io/) service **Overview** page.
+Replace `SCHEMA_REGISTRY_PWD` with the schema registry password and
+`SCHEMA_REGISTRY_URI` with the schema registry URI available on the
+<ConsoleLabel name="overview"/> page in the [Aiven Console](https://console.aiven.io/).
 
-## Use Kafdrop
+## Access Kafdrop
 
-Once Kafdrop starts, you should be able to access it at `localhost:9000`:
+After Kafdrop starts, you can access it at `localhost:9000`:
 
 ![Kafdrop in action](/images/content/products/kafka/kafdrop.gif)
 
-You can perform the following tasks with Kafdrop over an Aiven for
-Apache Kafka® service:
+With Kafdrop, you can perform the following tasks over an Aiven for Apache Kafka®
+service:
 
--   View and search topics
--   Create and delete topics
--   View brokers
--   view messages
+- View and search topics
+- Create and delete topics
+- View brokers
+- View messages

--- a/docs/products/kafka/howto/kafdrop.md
+++ b/docs/products/kafka/howto/kafdrop.md
@@ -8,10 +8,10 @@ It supports Avro, JSON, and Protobuf.
 
 ## Prerequisites
 
-- Access to the Aiven console
+- Access to the [Aiven Console](https://console.aiven.io/)
 - Aiven CLI
 - Docker installed. For Mac M1 chip users, ensure Docker is version 4.26.1 or lower to
-  avoid compatibility issue
+  avoid compatibility issues
 
 ## Retrieve SSL certificate files
 


### PR DESCRIPTION
## Describe your changes
Fix Kafdrop Docker instructions to include Mac M1 chip compatibility and clarify setup steps.

[DOC-916](https://aiven.atlassian.net/browse/DOC-916)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.


[DOC-916]: https://aiven.atlassian.net/browse/DOC-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ