### PR TITLE
add: OpenSearch to BTAR list

### DIFF
--- a/docs/platform/concepts/backup-to-another-region.md
+++ b/docs/platform/concepts/backup-to-another-region.md
@@ -23,6 +23,7 @@ BTAR is supported for the following services:
 
 - Aiven for PostgreSQL®
 - Aiven for MySQL®
+- Aiven for OpenSearch®
 
 ## How BTAR works
 
@@ -73,7 +74,7 @@ flowchart LR
 
 ## Limitations
 
-- BTAR is supported for Aiven for MySQL® and Aiven for PostgreSQL®.
+- BTAR is supported for Aiven for MySQL®, Aiven for PostgreSQL®, and Aiven for OpenSearch®.
 - The cloud provider for your additional backup region must match the cloud provider for
   your service and the primary backup.
 <!-- - To

--- a/docs/platform/howto/btar/enable-backup-to-another-region.md
+++ b/docs/platform/howto/btar/enable-backup-to-another-region.md
@@ -4,10 +4,12 @@ sidebar_label: Add cross-region backup
 limited: true
 ---
 
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
+
 Enable [the backup to another region (BTAR) feature](/docs/platform/concepts/backup-to-another-region) and create an additional cross-region service backup on top of a regular backup stored in the region where your service is hosted.
 
 :::important
-BTAR is supported for Aiven for MySQL® and Aiven for PostgreSQL®.
+BTAR is supported for Aiven for MySQL®, Aiven for PostgreSQL®, and Aiven for OpenSearch®.
 :::
 
 To add an additional service backup for your service, you can use the Aiven
@@ -27,13 +29,14 @@ To add an additional service backup for your service, you can use the Aiven
 ## Back up to another region via console {#enable-btar-console}
 
 1. Log in to the [Aiven Console](https://console.aiven.io/).
-1. From the **Services** view, select an Aiven service on which you'd like to enable BTAR.
-1. On your service's page, select **Backups** from the sidebar.
-1. On the **Backups** page, select the actions (**...**) menu > **Secondary backup
-   location**.
+1. From the <ConsoleLabel name="serviceusers"/> view, select an Aiven service on
+   which you'd like to enable BTAR.
+1. On your service's page, click <ConsoleLabel name="backups"/> from the sidebar.
+1. On the **Backups** page, click <ConsoleLabel name="actions"/> >
+   **Secondary backup location**.
 1. In the **Secondary backup location** window, use the **Secondary location** menu to
-   select a region for your additional backup. Confirm your choice by selecting
-   **Enable**.
+   choose a region for your additional backup.
+1. Click **Enable** to confirm your selection.
 
    :::tip
    For names of the cloud regions supported in Aiven, see column *Cloud* in


### PR DESCRIPTION
## Describe your changes

Added OpenSearch to the list of supported services for Backup to Another Region (BTAR).

NOTE: due to the merge freeze, the prod update is pending. 

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
