### PR TITLE
fix: styleguide link in template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,5 @@
 - [ ] The first paragraph of the page is on one line.
 - [ ] The other lines have a line break at 90 characters.
 - [ ] I checked the output.
-- [ ] I applied the [style guide](../styleguide.md).
+- [ ] I applied the [style guide](styleguide.md).
 - [ ] My links start with `/docs/`.


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [ ] My links start with `/docs/`.
