### PR TITLE
fix: promql command

### DIFF
--- a/docs/products/kafka/howto/enabled-consumer-lag-predictor.md
+++ b/docs/products/kafka/howto/enabled-consumer-lag-predictor.md
@@ -132,7 +132,7 @@ For example, you can monitor the average estimated time lag in seconds for a
 consumer group to consume produced messages using the following PromQL query:
 
 ```promql
-`avg by(topic,group)(kafka_lag_predictor_group_lag_predicted_seconds_gauge)`
+avg by(topic,group)(kafka_lag_predictor_group_lag_predicted_seconds_gauge)
 ```
 
 Another useful metric to monitor is the consume/produce ratio. You can monitor this per


### PR DESCRIPTION
## Describe your changes
Remove extra quotes for the command.


## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [ ] I applied the [style guide](../styleguide.md).
- [x] My links start with `/docs/`.
