### PR TITLE
update: Secrete providers configuration via Terraform

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
@@ -17,8 +17,8 @@ Configure and use [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanag
 - [AWS Secrets Manager access key and secret key](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access.html).
 
 :::note
-The integration with AWS Secrets Manager is not available through the Aiven Console.
-This feature can only be configured via the Aiven CLI, Aiven API, or Terraform.
+The integration with AWS Secrets Manager is not yet available on the Aiven Console.
+This feature can only be configured using the Aiven API, Aiven CLI, or Terraform.
 :::
 
 ## Configure secret providers

--- a/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
@@ -18,7 +18,6 @@ Configure and use [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanag
 
 :::note
 The integration with AWS Secrets Manager is not yet available on the Aiven Console.
-This feature can only be configured using the Aiven API, Aiven CLI, or Terraform.
 :::
 
 ## Configure secret providers

--- a/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
@@ -71,79 +71,89 @@ Parameters:
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
-Configure AWS Secrets Manager using Terraform:
+Configure AWS Secrets Manager using Terraform. Add this configuration to your `main.tf`
+file, or optionally create a `secrets.tf` file to manage secret providers:
 
-```hcl
-terraform {
-  required_providers {
-    aiven = {
-      source  = "aiven/aiven"
-      version = ">=4.0.0, < 5.0.0"
-    }
-  }
-}
+1. Create the `main.tf` file for your resources:
 
-provider "aiven" {
-  api_token = var.aiven_api_token
-}
-
-resource "aiven_kafka_connect" "kafka_connect" {
-  project      = var.project_name
-  cloud_name   = "your-cloud-region"
-  plan         = "startup-4"
-  service_name = "kafka-connect"
-
-  kafka_connect_user_config {
-    secret_providers {
-      name = "aws"
-      aws {
-        auth_method = "credentials"
-        region      = var.aws_region
-        access_key  = var.aws_access_key
-        secret_key  = var.aws_secret_key
+   ```hcl
+    terraform {
+    required_providers {
+      aiven = {
+        source  = "aiven/aiven"
+        version = ">=4.0.0, < 5.0.0"
       }
     }
-  }
-}
+   }
 
-variable "aiven_api_token" {
-  description = "Aiven API token"
-  type        = string
-}
+   provider "aiven" {
+   api_token = var.aiven_api_token
+   }
 
-variable "project_name" {
-  description = "Aiven project name"
-  type        = string
-}
+   resource "aiven_kafka_connect" "kafka_connect" {
+    project      = var.project_name
+    cloud_name   = "your-cloud-region"
+    plan         = "startup-4"
+    service_name = "kafka-connect"
 
-variable "aws_region" {
-  description = "AWS region"
-  type        = string
-}
+    kafka_connect_user_config {
+      secret_providers {
+        name = "aws"
+        aws {
+          auth_method = "credentials"
+          region      = var.aws_region
+          access_key  = var.aws_access_key
+          secret_key  = var.aws_secret_key
+        }
+      }
+    }
+   }
+   ```
 
-variable "aws_access_key" {
-  description = "AWS access key"
-  type        = string
-}
+1. Declare variables in a `variables.tf` file:
 
-variable "aws_secret_key" {
-  description = "AWS secret key"
-  type        = string
-  sensitive   = true
-}
+   ```hcl
+    variable "aiven_api_token" {
+      description = "Aiven API token"
+      type        = string
+     }
 
-# Provide values in a `terraform.tfvars` file or directly in the variables
-aiven_api_token = "YOUR_AIVEN_API_TOKEN"
-project_name    = "YOUR_PROJECT_NAME"
-aws_region      = "your-aws-region"
-aws_access_key  = "your-aws-access-key"
-aws_secret_key  = "your-aws-secret-key"
-```
+    variable "project_name" {
+      description = "Aiven project name"
+      type        = string
+     }
+
+    variable "aws_region" {
+      description = "AWS region"
+      type        = string
+     }
+
+    variable "aws_access_key" {
+      description = "AWS access key"
+      type        = string
+     }
+
+    variable "aws_secret_key" {
+      description = "AWS secret key"
+      type        = string
+      sensitive   = true
+     }
+   ```
+
+1. Provide variable values in a `terraform.tfvars` file:
+
+   ```hcl
+    aiven_api_token = "YOUR_AIVEN_API_TOKEN"
+    project_name    = "YOUR_PROJECT_NAME"
+    aws_region      = "your-aws-region"
+    aws_access_key  = "your-aws-access-key"
+    aws_secret_key  = "your-aws-secret-key"
+   ```
 
 Parameters:
 
 - `project_name`: Name of your Aiven project.
-- `cloud_name`**: Cloud provider and region for hosting Aiven for Apache Kafka Connect
+- `cloud_name`: Cloud provider and region for hosting Aiven for Apache Kafka Connect
   service. Replace with the appropriate region, for example `google-europe-west3`.
 - `plan`: Service plan for Aiven for Apache Kafka Connect service.
 - `service_name`: Name of your Aiven for Kafka Connect service in Aiven.
@@ -235,7 +245,8 @@ Parameters:
 <TabItem value="terraform" label="Terraform">
 
 Configure a JDBC sink connector using Terraform with secrets referenced from
-AWS Secrets Manager:
+AWS Secrets Manager. Add this configuration to your `main.tf` file, or optionally
+create a dedicated `connectors.tf` file for managing Apache Kafka connectors:
 
 ```hcl
 resource "aiven_kafka_connector" "jdbc_sink_connector" {
@@ -349,7 +360,8 @@ Parameters:
 <TabItem value="terraform" label="Terraform">
 
 Configure a JDBC source connector using Terraform with secrets referenced from
-AWS Secrets Manager:
+AWS Secrets Manager. Add this configuration to your `main.tf` file, or optionally
+create a dedicated `connectors.tf` file for managing Apache Kafka connectors:
 
 ```hcl
 resource "aiven_kafka_connector" "jdbc_source_connector" {

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -71,61 +71,69 @@ Parameters:
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
-Configure HashiCorp Vault as a secret provider for Aiven for Apache Kafka using Terraform:
+Configure HashiCorp Vault using Terraform. Add this configuration to your `main.tf` file,
+or optionally create a dedicated `vault.tf` file for managing secret providers:
 
-```hcl
-terraform {
-  required_providers {
-    aiven = {
-      source  = "aiven/aiven"
-      version = ">=4.0.0, < 5.0.0"
-    }
-  }
-}
+1. Create the `main.tf` file for your resources:
 
-provider "aiven" {
-  api_token = var.aiven_api_token
-}
+   ```hcl
+   terraform {
+     required_providers {
+       aiven = {
+         source  = "aiven/aiven"
+         version = ">=4.0.0, < 5.0.0"
+       }
+     }
+   }
 
-resource "aiven_kafka_connect" "kafka_connect" {
-  project      = var.project_name
-  cloud_name   = "your-cloud-region"
-  plan         = "startup-4"
-  service_name = "kafka-connect"
+   provider "aiven" {
+     api_token = var.aiven_api_token
+   }
 
-  kafka_connect_user_config {
-    secret_providers {
-      name = "vault"
-      vault {
-        auth_method = "token"
-        address     = "https://vault.aiven.fi:8200/"
-        token       = var.vault_token
-      }
-    }
-  }
-}
+   resource "aiven_kafka_connect" "kafka_connect" {
+     project      = var.project_name
+     cloud_name   = "your-cloud-region"
+     plan         = "startup-4"
+     service_name = "kafka-connect"
 
-variable "aiven_api_token" {
-  description = "Aiven API token"
-  type        = string
-}
+     kafka_connect_user_config {
+       secret_providers {
+         name = "vault"
+         vault {
+           auth_method = "token"
+           address     = "https://vault.aiven.fi:8200/"
+           token       = var.vault_token
+         }
+       }
+     }
+   }
 
-variable "project_name" {
-  description = "Aiven project name"
-  type        = string
-}
+1. Declare variables in a `variables.tf` file:
 
-variable "vault_token" {
-  description = "HashiCorp Vault token"
-  type        = string
-  sensitive   = true
-}
+   ```hcl
+    variable "aiven_api_token" {
+     description = "Aiven API token"
+     type        = string
+   }
 
-# Provide values in a `terraform.tfvars` file or directly in the variables
-aiven_api_token = "YOUR_AIVEN_API_TOKEN"
-project_name    = "YOUR_PROJECT_NAME"
-vault_token     = "YOUR_VAULT_TOKEN"
-```
+   variable "project_name" {
+     description = "Aiven project name"
+     type        = string
+   }
+
+   variable "vault_token" {
+     description = "HashiCorp Vault token"
+     type        = string
+     sensitive   = true
+   }
+
+1. Provide variable values in a `terraform.tfvars` file:
+
+   ```hcl
+   aiven_api_token = "YOUR_AIVEN_API_TOKEN"
+   project_name    = "YOUR_PROJECT_NAME"
+   vault_token     = "YOUR_VAULT_TOKEN"
+   ```
 
 Parameters:
 
@@ -215,7 +223,8 @@ Parameters:
 <TabItem value="terraform" label="Terraform">
 
 Configure a JDBC sink connector using Terraform with secrets referenced
-from HashiCorp Vault:
+from HashiCorp Vault. Add this configuration to your `main.tf` file, or optionally create
+a dedicated `vault.tf` file for managing secret providers:
 
 ```hcl
 resource "aiven_kafka_connector" "jdbc_sink_connector" {
@@ -252,7 +261,7 @@ Parameters:
 <TabItem value="cli" label="CLI">
 
 Configure a JDBC sink connector using the Aiven CLI with secrets referenced from
-HashiCorp Vault:
+HashiCorp Vault.
 
 ```bash
 avn service connector create SERVICE_NAME '{
@@ -286,7 +295,6 @@ Parameters:
 
 Configure a JDBC source connector using the API with secrets referenced from
 HashiCorp Vault:
-
 
 ```sh
 curl -X POST https://api.aiven.io/v1/project/{PROJECT_NAME}/service/{SERVICE_NAME}/connectors \
@@ -328,7 +336,8 @@ Parameters:
 <TabItem value="terraform" label="Terraform">
 
 Configure a JDBC source connector using Terraform with secrets referenced from
-HashiCorp Vault:
+HashiCorp Vault. Add this configuration to your `main.tf` file, or optionally
+create a dedicated `connectors.tf` file for managing Apache Kafka connectors:
 
 ```hcl
 resource "aiven_kafka_connector" "jdbc_source_connector" {

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -18,8 +18,8 @@ Configure and use [HashiCorp Vault](https://developer.hashicorp.com/vault/docs) 
 - [HashiCorp Vault address and token](https://developer.hashicorp.com/vault/docs/concepts/tokens).
 
 :::note
-The integration with HashiCorp Vault is not available through the Aiven Console.
-This feature can only be configured via the Aiven CLI, Aiven API, or Terraform.
+The integration with HashiCorp Vault is not yet available on the Aiven Console.
+This feature can only be configured using the Aiven API, Aiven CLI, or Terraform.
 :::
 
 ## Configure secret providers

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -19,7 +19,6 @@ Configure and use [HashiCorp Vault](https://developer.hashicorp.com/vault/docs) 
 
 :::note
 The integration with HashiCorp Vault is not yet available on the Aiven Console.
-This feature can only be configured using the Aiven API, Aiven CLI, or Terraform.
 :::
 
 ## Configure secret providers

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -13,7 +13,14 @@ Configure and use [HashiCorp Vault](https://developer.hashicorp.com/vault/docs) 
 - [Aiven for Apache Kafka service with Apache Kafka Connect](/docs/products/kafka/kafka-connect/get-started)
   set up and running.
 - [Aiven CLI](/docs/tools/cli).
+- [Aiven Terraform provider](https://registry.terraform.io/providers/aiven/aiven/latest/docs)
+  installed.
 - [HashiCorp Vault address and token](https://developer.hashicorp.com/vault/docs/concepts/tokens).
+
+:::note
+The integration with HashiCorp Vault is not available through the Aiven Console.
+This feature can only be configured via the Aiven CLI, Aiven API, or Terraform.
+:::
 
 ## Configure secret providers
 
@@ -60,6 +67,78 @@ Parameters:
 - `auth_method`: Authentication method used by HashiCorp Vault. In this case, it is token.
 - `address`: Address of the HashiCorp Vault server.
 - `token`: Your HashiCorp Vault token.
+
+</TabItem>
+<TabItem value="terraform" label="Terraform">
+
+Configure HashiCorp Vault as a secret provider for Aiven for Apache Kafka using Terraform:
+
+```hcl
+terraform {
+  required_providers {
+    aiven = {
+      source  = "aiven/aiven"
+      version = ">=4.0.0, < 5.0.0"
+    }
+  }
+}
+
+provider "aiven" {
+  api_token = var.aiven_api_token
+}
+
+resource "aiven_kafka_connect" "kafka_connect" {
+  project      = var.project_name
+  cloud_name   = "your-cloud-region"
+  plan         = "startup-4"
+  service_name = "kafka-connect"
+
+  kafka_connect_user_config {
+    secret_providers {
+      name = "vault"
+      vault {
+        auth_method = "token"
+        address     = "https://vault.aiven.fi:8200/"
+        token       = var.vault_token
+      }
+    }
+  }
+}
+
+variable "aiven_api_token" {
+  description = "Aiven API token"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Aiven project name"
+  type        = string
+}
+
+variable "vault_token" {
+  description = "HashiCorp Vault token"
+  type        = string
+  sensitive   = true
+}
+
+# Provide values in a `terraform.tfvars` file or directly in the variables
+aiven_api_token = "YOUR_AIVEN_API_TOKEN"
+project_name    = "YOUR_PROJECT_NAME"
+vault_token     = "YOUR_VAULT_TOKEN"
+```
+
+Parameters:
+
+- `project_name`: Name of your Aiven project.
+- `cloud_name`: Cloud provider and region for hosting the Aiven for Apache Kafka
+  service. Replace with the appropriate region. For example, `google-europe-west3`.
+- `plan`: Service plan for the Aiven for Apache Kafka Connect service.
+- `service_name`: Name of your Aiven for Apache Kafka Connect service.
+- `auth_method`: Authentication method used by HashiCorp Vault. Set to `token`.
+- `address`: URL address of the HashiCorp Vault server.
+- `token`: Token used for authenticating with HashiCorp Vault.
+- `aiven_api_token`: API token for authentication. Replace with your Aiven API token to
+  manage resources.
 
 </TabItem>
 <TabItem value="cli" label="CLI">
@@ -129,6 +208,43 @@ Parameters:
 - `connection.url`: JDBC connection URL with placeholders for `DATABASE_TYPE`, `HOST`,
   `PORT`, `DATABASE_NAME`, and the username and password retrieved from HashiCorp Vault.
 - `topics`: Apache Kafka topic where the data can be sent.
+- `auto.create`: If `true`, the connector automatically creates the table in
+  the target database if it does not exist.
+
+</TabItem>
+<TabItem value="terraform" label="Terraform">
+
+Configure a JDBC sink connector using Terraform with secrets referenced
+from HashiCorp Vault:
+
+```hcl
+resource "aiven_kafka_connector" "jdbc_sink_connector" {
+  project        = var.project_name
+  service_name   = aiven_kafka_connect.kafka_connect.service_name
+  connector_name = "jdbc-sink-connector"
+
+  config = {
+    "connector.class"      = "io.aiven.connect.jdbc.JdbcSinkConnector"
+    "connection.url"       = "jdbc:postgresql://{HOST}:{PORT}/{DATABASE_NAME}?user=${vault:PATH/TO/SECRET:USERNAME}&password=${vault:PATH/TO/SECRET:PASSWORD}&ssl=require"
+    "topics"               = "your-topic"
+    "auto.create"          = "true"
+  }
+}
+```
+
+Parameters:
+
+- `project`: Name of your Aiven project where the Kafka Connect service is located.
+- `service_name`: Name of the Aiven for Kafka Connect service where the connector is
+  to be created.
+- `connector_name`: Name for your JDBC sink connector.
+- `connector.class`: The Java class that implements the connector. For JDBC sink
+  connectors, use `"io.aiven.connect.jdbc.JdbcSinkConnector"`.
+- `connection.url`: The JDBC URL for your database. Replace `{HOST}`, `{PORT}`, and
+  `{DATABASE_NAME}` with your actual database details. The username and password are
+  retrieved from HashiCorp Vault using the `${vault:PATH/TO/SECRET:USERNAME}` and
+  `${vault:PATH/TO/SECRET:PASSWORD}` syntax.
+- `topics`: Apache Kafka topics that the connector consumes data from.
 - `auto.create`: If `true`, the connector automatically creates the table in
   the target database if it does not exist.
 
@@ -204,6 +320,57 @@ Parameters:
 - `incrementing.column.name`: Column used for incrementing mode.
 - `mode`: Mode of operation, in this case, `incrementing`.
 - `table.whitelist`: Tables to include.
+- `topic.prefix`: Prefix for Apache Kafka topics.
+- `auto.create`: If `true`, the connector automatically creates the table in
+  the target database if it does not exist.
+
+</TabItem>
+<TabItem value="terraform" label="Terraform">
+
+Configure a JDBC source connector using Terraform with secrets referenced from
+HashiCorp Vault:
+
+```hcl
+resource "aiven_kafka_connector" "jdbc_source_connector" {
+  project        = var.project_name
+  service_name   = aiven_kafka_connect.kafka_connect.service_name
+  connector_name = "jdbc-source-connector"
+
+  config = {
+    "connector.class"      = "io.aiven.connect.jdbc.JdbcSourceConnector"
+    "connection.url"       = "jdbc:postgresql://{HOST}:{PORT}/{DATABASE_NAME}?ssl=require"
+    "connection.user"      = "${vault:PATH/TO/SECRET:USERNAME}"
+    "connection.password"  = "${vault:PATH/TO/SECRET:PASSWORD}"
+    "incrementing.column.name" = "id"
+    "mode"                 = "incrementing"
+    "table.whitelist"      = "your-table"
+    "topic.prefix"         = "your-prefix_"
+    "auto.create"          = "true"
+  }
+}
+```
+
+Parameters:
+
+- `project`: Name of your Aiven project where the Kafka Connect service is located.
+- `service_name`: Name of the Kafka Connect service where the connector is to be created.
+- `connector_name`: Name for your JDBC source connector.
+- `connector.class`: The Java class that implements the connector. For JDBC source
+  connectors, use `"io.aiven.connect.jdbc.JdbcSourceConnector"`.
+- `connection.url`: The JDBC URL for your database. Replace `{HOST}`, `{PORT}`,
+  and `{DATABASE_NAME}` with your actual database details. The username and password
+  are retrieved from HashiCorp Vault using the `${vault:PATH/TO/SECRET:USERNAME}` and
+  `${vault:PATH/TO/SECRET:PASSWORD}` syntax.
+- `connection.user`: The username for connecting to the database, retrieved from
+  HashiCorp Vault.
+- `connection.password`: The password for connecting to the database, retrieved
+  from HashiCorp Vault.
+- `incrementing.column.name`: The name of the column that the connector will use
+  for incrementing mode, typically a primary key column.
+- `mode`: The mode of operation for the connector. `incrementing` mode reads data
+  incrementally based on the specified column.
+- `table.whitelist`: A list of tables that the connector includes when reading data from
+  the database.
 - `topic.prefix`: Prefix for Apache Kafka topics.
 - `auto.create`: If `true`, the connector automatically creates the table in
   the target database if it does not exist.


### PR DESCRIPTION
## Describe your changes
Updated Aiven for Apache Kafka® Connect secret providers documentation to include steps for Terraform. 

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
