### PR TITLE
fix: CLI command for Elasticsearch migration to OS

### DIFF
--- a/docs/products/opensearch/howto/migrating_elasticsearch_data_to_aiven.md
+++ b/docs/products/opensearch/howto/migrating_elasticsearch_data_to_aiven.md
@@ -5,16 +5,12 @@ title: Migrate Elasticsearch data to Aiven for OpenSearch®
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
-
-We recommend migrating to Aiven for OpenSearch® by reindexing from your remote cluster.
-The same process works for migrating from Aiven for
-OpenSearch to a self-hosted Elasticsearch service.
+To migrate Elasticsearch data to Aiven for OpenSearch®, reindex from a remote Elasticsearch cluster.
+This method can also be used to migrate data from Aiven for OpenSearch to a self-hosted Elasticsearch service.
 
 <!-- vale off -->
 :::tip
-For a larger number of indexes, we recommend that you create a script to
-run these steps automatically.
+To migrate a large number of indexes, consider automating the process with a script.
 :::
 <!-- vale on -->
 
@@ -22,52 +18,46 @@ As Aiven for OpenSearch does not support joining external Elasticsearch
 servers to the same cluster, online migration is not currently possible.
 
 :::important
-Migrating from Elasticsearch to OpenSearch may affect the connectivity
-between client applications and your service. For example, some code
-included in clients or tools may check the service version, which might
-not work with OpenSearch. We recommend that you check the following
-OpenSearch resources for more information:
+Migrating from Elasticsearch to OpenSearch can impact connectivity between client
+applications and services. Some clients or tools may check the service version, which
+can lead to compatibility issues with OpenSearch. For more details, refer to the
+following OpenSearch resources:
 
--   [OpenSearch release
-    notes](https://github.com/opensearch-project/OpenSearch/blob/main/release-notes/opensearch.release-notes-1.0.0.md)
--   [OpenSearch Dashboards release
-    notes](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/release-notes/opensearch-dashboards.release-notes-1.0.0.md)
--   [Frequently asked questions about
-    OpenSearch](https://opensearch.org/faq/)
+- [OpenSearch release notes](https://github.com/opensearch-project/OpenSearch/blob/main/release-notes/opensearch.release-notes-1.0.0.md)
+- [OpenSearch Dashboards release notes](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/release-notes/opensearch-dashboards.release-notes-1.0.0.md)
+- [Frequently asked questions about OpenSearch](https://opensearch.org/faq/)
 :::
 
-To migrate or copy data:
+## Migrate data
 
-1.  Create a hosted Aiven for OpenSearch service.
+1. [Create an Aiven for OpenSearch service](/docs/products/opensearch/get-started#create-an-aiven-for-opensearch-service).
 
-1.  Use the [Aiven CLI client](https://github.com/aiven/aiven-client) to
-    set the `reindex.remote.whitelist` parameter to point to your source
-    Elasticsearch service:
+1. Set the `reindex.remote.whitelist` parameter to point to your source Elasticsearch
+   service using the following [Aiven CLI](https://github.com/aiven/aiven-client)
+   command:
 
     ```bash
-    avn service update your-service-name -c opensearch.reindex_remote_whitelist=your.non-aiven-service.example.com:9200
+    avn service update your-aiven-service \
+      -c 'opensearch.reindex_remote_whitelist=["your-non-aiven-service:port"]'
     ```
 
-    Replace the port number with the one where your source Elasticsearch
-    service is listening.
+    Replace `port` with the port number your source Elasticsearch service is using.
 
-1.  Wait for the cluster to restart. This may take several minutes, as
-    the service tries to do a rolling restart to minimize downtime. You
-    do not need to power off the service.
+1. Wait for the cluster to restart. This process might take a few minutes as the
+   service attempts a rolling restart to minimize downtime.
 
-1.  Start migrating the indexes. For each index:
+1. Start migrating the indexes. For each index:
 
-    1.  Stop writes to the index. This step is not necessary if you are
-        testing the process.
+    1. Stop writes to the index. This step is optional if testing the process.
 
-    1.  Export mapping from your source Elasticsearch index. For
-        example, using `curl`:
+    1. Export the index mapping from the source Elasticsearch instance. For example,
+       using `curl`:
 
         ```bash
         curl https://avnadmin:yourpassword@os-123-demoprj.aivencloud.com:23125/logs-2024-09-21/_mapping > mapping.json
         ```
 
-    1.  Exit `mapping.json`:
+    1. Edit `mapping.json`:
 
         <Tabs groupId="group1">
         <TabItem value="jq" label="With jq" default>
@@ -88,49 +78,48 @@ To migrate or copy data:
         </TabItem>
         </Tabs>
 
-    1.  Create the empty index on your destination OpenSearch service.
+    1. Create the empty index on your destination Aiven for OpenSearch service.
 
         ```bash
         curl -XPUT https://avnadmin:yourpassword@os-123-demoprj.aivencloud.com:23125/logs-2024-09-21
         ```
 
-    1.  Import mapping on your destination OpenSearch index.
+    1. Import the mapping to the destination Aiven for OpenSearch index.
 
-        ```bash
-        curl -XPUT https://avnadmin:yourpassword@os-123-demoprj.aivencloud.com:23125/logs-2024-09-21/_mapping \
-        -H 'Content-type: application/json' -T src_mapping.json
-        ```
+       ```bash
+       curl -XPUT https://avnadmin:yourpassword@os-123-demoprj.aivencloud.com:23125/logs-2024-09-21/_mapping \
+       -H 'Content-type: application/json' -T src_mapping.json
+       ```
 
-    1.  Submit the reindexing request.
+    1. Submit the reindexing request.
 
-        ```bash
-        curl -XPOST https://avnadmin:yourpassword@os-123-demoprj.aivencloud.com:23125/_reindex \
-          -H 'Content-type: application/json' \
-          -d '{"source":
-                  {"index": "logs-2024-09-21",
-                   "remote":
-                       {"username": "your-remote-username",
-                        "password": "your-remote-password",
-                        "host": "https://your.non-aiven-service.example.com:9200"
-                       }
-                  },
-               "dest":
-                  {"index": "logs-2024-09-21"}
-              }'
-        ```
+       ```bash
+       curl -XPOST https://avnadmin:yourpassword@os-123-demoprj.aivencloud.com:23125/_reindex \
+         -H 'Content-type: application/json' \
+         -d '{"source":
+                 {"index": "logs-2024-09-21",
+                  "remote":
+                      {"username": "your-remote-username",
+                       "password": "your-remote-password",
+                       "host": "https://your.non-aiven-service.example.com:9200"
+                      }
+                 },
+              "dest":
+                 {"index": "logs-2024-09-21"}
+             }'
+       ```
 
-    1.  Wait for the reindexing process to finish. If you see a message
-        like the following in the response, check that the host name and
-        port match the ones that you set earlier:
+    1. Wait for the reindexing process to complete. If you receive a response message
+       such as:
 
-        ```text
-        [your.non-aiven-service.example.com:9200] not whitelisted in reindex.remote.whitelist
-        ```
+       ```text
+       [your.non-aiven-service.example.com:9200] not whitelisted in reindex.remote.whitelist
+       ```
 
-        Depending on the amount of data that you have, reindexing may
-        take a significant amount of time.
+       Verify the hostname and port match those set earlier. The time required for
+       reindexing can vary depending on the amount of data.
 
-    1.  Point clients to use that index from Aiven for OpenSearch for
-        both read and write operations and resume any write activity.
+    1. Update clients to use the new index on Aiven for OpenSearch for both read and
+       write operations, then resume any paused write activity.
 
-    1.  Delete the source index if necessary.
+    1. Delete the source index if necessary.


### PR DESCRIPTION
## Describe your changes
Fixes and improvements for the Elasticsearch to Aiven for OpenSearch® migration process.
## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
