### PR TITLE
add: enable Karapace to shut down

### DIFF
--- a/docs/products/kafka/karapace/howto/enable-schema-reader-strict-mode.md
+++ b/docs/products/kafka/karapace/howto/enable-schema-reader-strict-mode.md
@@ -1,0 +1,88 @@
+---
+title: Enable automatic shutdown for invalid schema records
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
+import ConsoleIcon from "@site/src/components/ConsoleIcons"
+
+You can configure the Karapace schema registry to automatically shut down when corrupt schema records are detected in the `_schemas` topic.
+
+## Why enable automatic shutdown
+
+By default, Karapace skips invalid schema records to prevent interruptions. To ensure
+data consistency, you can enable `schema_reader_strict_mode` to shut down Karapace when
+it detects faulty records. This ensures that only valid schemas are processed,
+preventing data integrity issues.
+
+## What to do if Karapace shuts down
+
+- **Contact Aiven support**: If Karapace shuts down due to corrupt schema records,
+  [create a support ticket](/docs/platform/howto/support) or email
+  [Aiven support](mailto:support@aiven.io).
+
+- **Disable strict mode**: You can also disable `schema_reader_strict_mode` to allow
+  Karapace to continue running while skipping faulty records.
+
+## How to enable automatic shutdown
+
+<Tabs groupId="enable-shutdown">
+<TabItem value="Console" label="Console" default>
+
+1. Log in to the [Aiven Console](https://console.aiven.io/), select your project, and
+   choose your **Aiven for Apache Kafka®** service.
+
+1. On the <ConsoleLabel name="overview"/> page, click
+   <ConsoleLabel name="service settings"/> from the sidebar.
+
+1. Scroll to **Advanced configuration** and click **Configure**.
+
+1. Click <ConsoleIcon name="Add config options"/>.
+
+1. Find `schema_registry_config.schema_reader_strict_mode` and set it to **Enabled**.
+
+1. Click **Save configuration**.
+
+</TabItem>
+<TabItem value="CLI" label="CLI">
+
+To enable automatic shutdown using the [Aiven CLI](/docs/tools/cli):
+
+```bash
+aiven service update \
+  --project PROJECT_NAME \
+  --service SERVICE_NAME \
+  --user-config schema_reader_strict_mode=true
+```
+
+Parameters:
+
+- `PROJECT_NAME`: Name of your project in Aiven.
+- `SERVICE_NAME`: Name of your Aiven for Apache Kafka® service.
+- `--user-config schema_reader_strict_mode=true`: Enables the automatic shutdown of
+  Karapace when it detects corrupt schema records.
+
+</TabItem>
+<TabItem value="API" label="API">
+
+To enable automatic shutdown using the [Aiven API](/docs/tools/api):
+
+```bash
+curl -X PUT \
+-H "Authorization: Bearer <token>" \
+-d '{"user_config": {"schema_reader_strict_mode": true}}' \
+https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME
+```
+
+Parameters:
+
+- `PROJECT_NAME`: Name of your project in Aiven.
+- `SERVICE_NAME`: Name of your Aiven for Apache Kafka® service.
+- `Authorization: Bearer <token>`: Your API authentication
+  [token](/docs/platform/concepts/authentication-tokens).
+- `"user_config": {"schema_reader_strict_mode": true}`: Enables the automatic
+  shutdown of Karapace when it detects corrupt schema records.
+
+</TabItem>
+</Tabs>

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1056,6 +1056,7 @@ const sidebars: SidebarsConfig = {
                     'products/kafka/karapace/howto/enable-kafka-rest-proxy-authorization',
                     'products/kafka/karapace/howto/enable-oauth-oidc-kafka-rest-proxy',
                     'products/kafka/karapace/howto/manage-schema-registry-authorization',
+                    'products/kafka/karapace/howto/enable-schema-reader-strict-mode',
                   ],
                 },
               ],


### PR DESCRIPTION
## Describe your changes



Added information on how to configure the Karapace schema registry to shut down when invalid schema records are detected in the `_schemas` topic.
## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
