### PR TITLE
update: added method to get document count for migrated data

### DIFF
--- a/docs/products/opensearch/howto/migrate-snapshot-data-opensearch.md
+++ b/docs/products/opensearch/howto/migrate-snapshot-data-opensearch.md
@@ -304,6 +304,7 @@ curl $SERVICE_URL/_cat/indices?v&expand_wildcards=all
 This command returns detailed information about all indices, including the number of
 documents, shards, and index size. For example:
 
+```text
 | Status | Index Name                           | UUID                                | Shards | Replicas | Documents | Deleted Docs | Size   | Primary Size |
 |--------|--------------------------------------|-------------------------------------|--------|----------|-----------|--------------|--------|--------------|
 | Green  | clustermember_correlation_v1-002573  | OLj34vDHTX-rIXCz3s8W7A              | 4      | 1        | 57        | 4            | 5.7mb  | 2.8mb        |

--- a/docs/products/opensearch/howto/migrate-snapshot-data-opensearch.md
+++ b/docs/products/opensearch/howto/migrate-snapshot-data-opensearch.md
@@ -301,7 +301,7 @@ replacing `SERVICE_URL` with your service's URL:
 curl $SERVICE_URL/_cat/indices?v&expand_wildcards=all
 ```
 
-This command retrieves detailed information about all indices, including the number of
+This command returns detailed information about all indices, including the number of
 documents, shards, and index size. For example:
 
 | Status | Index Name                           | UUID                                | Shards | Replicas | Documents | Deleted Docs | Size   | Primary Size |

--- a/docs/products/opensearch/howto/migrate-snapshot-data-opensearch.md
+++ b/docs/products/opensearch/howto/migrate-snapshot-data-opensearch.md
@@ -295,7 +295,7 @@ Ensure that your data has been restored successfully by listing the indices and 
 the document count for your migrated data.
 
 To view all indices in your Aiven for OpenSearch service, use the following API call,
-replacing `SERVICE_URL` with your actual service URL:
+replacing `SERVICE_URL` with your service's URL:
 
 ```bash
 curl $SERVICE_URL/_cat/indices?v&expand_wildcards=all
@@ -317,8 +317,7 @@ curl $SERVICE_URL/_cat/aliases?v&expand_wildcards=all
 ```
 
 Compare the outputs from both the source and target services to ensure that document
-counts and aliases match after the migration. This comparison ensures that all data has
-been successfully migrated.
+counts and aliases match after the migration.
 
 ## Complete the migration
 

--- a/docs/products/opensearch/howto/migrate-snapshot-data-opensearch.md
+++ b/docs/products/opensearch/howto/migrate-snapshot-data-opensearch.md
@@ -294,8 +294,8 @@ Parameters:
 Ensure that your data has been restored successfully by listing the indices and checking
 the document count for your migrated data.
 
-To list all indices in your Aiven for OpenSearch service, use the following API call,
-where `SERVICE_URL` is your Aiven for OpenSearch service URL:
+To view all indices in your Aiven for OpenSearch service, use the following API call,
+replacing `SERVICE_URL` with your actual service URL:
 
 ```bash
 curl $SERVICE_URL/_cat/indices?v&expand_wildcards=all

--- a/docs/products/opensearch/howto/migrate-snapshot-data-opensearch.md
+++ b/docs/products/opensearch/howto/migrate-snapshot-data-opensearch.md
@@ -291,27 +291,34 @@ Parameters:
 
 ## Verify the migration
 
-Ensure that your data has been restored successfully by listing the indices.
+Ensure that your data has been restored successfully by listing the indices and checking
+the document count for your migrated data.
 
-<Tabs groupId="verify-restoration">
-<TabItem value="api" label="API" default>
-
-```bash
-curl -X GET "https://SERVICE_NAME.aivencloud.com/_cat/indices?v" \
-  -H "Authorization: Bearer API_TOKEN"
-```
-
-</TabItem>
-<TabItem value="cli" label="CLI">
+To list all indices in your Aiven for OpenSearch service, use the following API call,
+where `SERVICE_URL` is your Aiven for OpenSearch service URL:
 
 ```bash
-avn service index-list \
-  --project PROJECT_NAME \
-  --service SERVICE_NAME
+curl $SERVICE_URL/_cat/indices?v&expand_wildcards=all
 ```
 
-</TabItem>
-</Tabs>
+This command retrieves detailed information about all indices, including the number of
+documents, shards, and index size. For example:
+
+| Status | Index Name                           | UUID                                | Shards | Replicas | Documents | Deleted Docs | Size   | Primary Size |
+|--------|--------------------------------------|-------------------------------------|--------|----------|-----------|--------------|--------|--------------|
+| Green  | clustermember_correlation_v1-002573  | OLj34vDHTX-rIXCz3s8W7A              | 4      | 1        | 57        | 4            | 5.7mb  | 2.8mb        |
+| Green  | clustermember_correlation_v1-002574  | j7obT9rXS-C0LJOuyulCfA              | 4      | 1        | 1         | 0            | 240.7kb| 120.3kb      |
+| Green  | clustermember_correlation_v1-002575  | KG7lWPK2SrOMgMuJYUscyg              | 4      | 1        | 447       | 56           | 24.7mb | 12.3mb       |
+
+To list all aliases for your indices, use the following command:
+
+```bash
+curl $SERVICE_URL/_cat/aliases?v&expand_wildcards=all
+```
+
+Compare the outputs from both the source and target services to ensure that document
+counts and aliases match after the migration. This comparison ensures that all data has
+been successfully migrated.
 
 ## Complete the migration
 

--- a/docs/products/opensearch/howto/migrate-snapshot-data-opensearch.md
+++ b/docs/products/opensearch/howto/migrate-snapshot-data-opensearch.md
@@ -294,7 +294,7 @@ Parameters:
 Ensure that your data has been restored successfully by listing the indices and checking
 the document count for your migrated data.
 
-To view all indices in your Aiven for OpenSearch service, use the following API call,
+To view all indices in your Aiven for OpenSearch service, run the following command,
 replacing `SERVICE_URL` with your service's URL:
 
 ```bash
@@ -310,7 +310,7 @@ documents, shards, and index size. For example:
 | Green  | clustermember_correlation_v1-002574  | j7obT9rXS-C0LJOuyulCfA              | 4      | 1        | 1         | 0            | 240.7kb| 120.3kb      |
 | Green  | clustermember_correlation_v1-002575  | KG7lWPK2SrOMgMuJYUscyg              | 4      | 1        | 447       | 56           | 24.7mb | 12.3mb       |
 
-To list all aliases for your indices, use the following command:
+To list all aliases for your indices, run the following command:
 
 ```bash
 curl $SERVICE_URL/_cat/aliases?v&expand_wildcards=all


### PR DESCRIPTION
## Describe your changes

Updated the documentation to provide a method for verifying document counts after migration.



## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
