### PR TITLE
fix: Remove duplicate sentence from ECE description page

### DIFF
--- a/docs/platform/concepts/enhanced-compliance-env.md
+++ b/docs/platform/concepts/enhanced-compliance-env.md
@@ -96,4 +96,3 @@ To migrate an existing Aiven service to an ECE, the Aiven network team creates a
 tunnel between your non-compliant VPC and your ECE VPC to enable a one-click migration.
 The migration is then performed in an automated and zero-downtime fashion.
 Once the migration is complete, the VPN tunnel is removed.
-Once the migration is complete, the VPN tunnel is removed.


### PR DESCRIPTION
Migrate to ECE -chapter had a duplicated sentence.

## Describe your changes

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
