### PR TITLE
fix(cassandra): broken link to ZDM migration intro

### DIFF
--- a/docs/products/cassandra/howto/zdm-proxy.md
+++ b/docs/products/cassandra/howto/zdm-proxy.md
@@ -16,7 +16,7 @@ while write requests are forwarded to both clusters.
 
 For details on how ZDM Proxy works, see [Introduction to Zero
 Downtime
-Migration](https://docs.datastax.com/en/astra-serverless/docs/migrate/introduction).
+Migration](https://docs.datastax.com/en/data-migration/introduction.html).
 
 ## Prerequisites
 


### PR DESCRIPTION
Fixing a broken link

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
