### PR TITLE
update: Google Pub/Sub connector details and IAM roles

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-source.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-source.md
@@ -1,81 +1,82 @@
 ---
 title: Create a Google Pub/Sub source connector to Apache Kafka®
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 The [Google Pub/Sub source connector](https://github.com/googleapis/java-pubsub-group-kafka-connector) enables you to push from a Google Pub/Sub subscription to an Aiven for Apache Kafka® topic.
 
 :::note
-See the full set of available parameters and configuration
+See the complete set of available parameters and configuration
 options in the [connector's
 documentation](https://github.com/googleapis/java-pubsub-group-kafka-connector).
 :::
 
 ## Prerequisites {#connect_pubsub_source_prereq}
 
-To setup an Google Pub/Sub source connector, you need an Aiven for
-Apache Kafka service
-[with Kafka Connect enabled](enable-connect) or a
-[dedicated Aiven for Apache Kafka Connect cluster](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
+To set up a Google Pub/Sub source connector, ensure you have the following:
 
-Also collect the following information about the
-target Google Pub/Sub upfront:
-
--   `GCP_PROJECT_NAME`: The GCP project name where the target Google
-    Pub/Sub is located
-
--   `GCP_SUBSCRIPTION`: the name of the [Google Pub/Sub
-    subscription](https://cloud.google.com/pubsub/docs/create-subscription)
-
--   `GCP_SERVICE_KEY`: A valid GCP service account key for the
-    `GCP_PROJECT_NAME`. To create the project key review the
-    [dedicated document](/docs/products/kafka/kafka-connect/howto/gcp-bigquery-sink-prereq#gcp-bigquery-sink-connector-google-account)
+- An Aiven for Apache Kafka service with [Kafka Connect enabled](enable-connect) or a
+  [dedicated Aiven for Apache Kafka Connect service](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster)
+- Google Cloud Pub/Sub details:
+  - `GCP_PROJECT_NAME`: The name of the Google Cloud project where the Pub/Sub
+    subscription is located
+  - `GCP_SUBSCRIPTION`: The name of the [Google Pub/Sub subscription](https://cloud.google.com/pubsub/docs/create-subscription)
+  - `GCP_SERVICE_KEY`: A valid Google Cloud service account key for the
+    `GCP_PROJECT_NAME`. To create this key, see [Configure GCP for a Google BigQuery sink connector](/docs/products/kafka/kafka-connect/howto/gcp-bigquery-sink-prereq#gcp-bigquery-sink-connector-google-account)
 
     :::warning
-    The GCP Pub/Sub source connector accepts the `GCP_SERVICE_KEY` JSON
-    service key as a string, therefore all `"` symbols within it must be
-    escaped `\"`.
+    The GCP Pub/Sub source connector accepts the `GCP_SERVICE_KEY` as a JSON string.
+    Escape all `"` symbols as `\"`, and replace any `\n` symbols in the `private_key` field with `\\n`.
 
-    The `GCP_SERVICE_KEY` parameter should be in the format
+    Format the `GCP_SERVICE_KEY` like this:
+
     `{\"type\": \"service_account\",\"project_id\": \"XXXXXX\", ...}`
 
-    Additionally, any `\n` symbols contained in the `private_key` field
-    need to be escaped (by substituting with `\\n`)
     :::
 
--   `KAFKA_TOPIC`: The name of the target topic in Aiven for Apache
-    Kafka
+- IAM Roles: The service account used by the Google Pub/Sub source connector must have
+  the following IAM roles:
+  - `roles/pubsub.subscriber`: Allows the connector to subscribe to the Pub/Sub topic
+  - `roles/pubsub.viewer`: Required to verify the subscription and perform
+    `pubsub.subscriptions.get` operations
+  - Alternatively, use `roles/pubsub.editor`, which includes both the `subscriber` and
+    `viewer` permissions
 
--   `APACHE_KAFKA_HOST`: The hostname of the Apache Kafka service, only
-    needed when using Avro as data format
+  :::note
+  Without these roles, the connector will fail with a `PERMISSION_DENIED` error during
+  the verification process.
+  :::
 
--   `SCHEMA_REGISTRY_PORT`: The Apache Kafka's schema registry port,
-    only needed when using Avro as data format
+- Apache Kafka details: The target topic in Aiven for Apache Kafka, `KAFKA_TOPIC`,
+  where data from the Pub/Sub subscription is written
+- Schema registry details (if using Avro as the data format):
+  - `APACHE_KAFKA_HOST`: The hostname of your Apache Kafka service
+  - `SCHEMA_REGISTRY_PORT`: The schema registry port for your Apache Kafka service
+  - `SCHEMA_REGISTRY_USER`: The schema registry username for your Apache Kafka service
+  - `SCHEMA_REGISTRY_PASSWORD`: The schema registry password for your Apache Kafka service
 
--   `SCHEMA_REGISTRY_USER`: The Apache Kafka's schema registry
-    username, only needed when using Avro as data format
+ :::note
 
--   `SCHEMA_REGISTRY_PASSWORD`: The Apache Kafka's schema registry user
-    password, only needed when using Avro as data format
+ To find the `SCHEMA_REGISTRY` details, go to the Aiven for Apache Kafka®
+ <ConsoleLabel name="overview"/> page, click <ConsoleLabel name="service settings"/>, and
+ scroll to the **Service management** section.
 
-:::note
-The `SCHEMA_REGISTRY` related parameters are available in the Aiven for
-Apache Kafka® service page, *Overview* tab, and *Schema Registry* subtab
+ Since Apache Kafka version 3.0, Aiven for Apache Kafka® uses Karapace instead of
+ Confluent Schema Registry. For more information, see
+ [Karapace](/docs/products/kafka/karapace).
 
-As of version 3.0, Aiven for Apache Kafka no longer supports Confluent
-Schema Registry. For more information, read [the article describing the
-replacement, Karapace](https://help.aiven.io/en/articles/5651983)
-:::
+ :::
 
-## Setup a Google Pub/Sub source connector with Aiven Console
+## Setup a Google Pub/Sub source connector
 
-The following example demonstrates how to setup a Google Pub/Sub source
-connector for Apache Kafka using the [Aiven
-Console](https://console.aiven.io/).
+This example shows how to set up a Google Pub/Sub source connector for Aiven for Apache
+Kafka using the [Aiven Console](https://console.aiven.io/).
 
 ### Define a Kafka Connect configuration file
 
-Define the connector configurations in a file (we'll refer to it with
-the name `pubsub_source.json`) with the following content:
+Create a configuration file, `pubsub_source.json`, with the following content:
 
 ```json
 {
@@ -96,110 +97,104 @@ the name `pubsub_source.json`) with the following content:
 }
 ```
 
-The configuration file contains the following entries:
+This configuration file includes:
 
--   `name`: the connector name
-
--   `kafka-topic`: the target Apache Kafka topic name
-
--   `cps.project`: the GCP project name where the target Google Pub/Sub
+- `name`: Connector name
+- `kafka.topic`: Target Apache Kafka topic name
+- `cps.project`: GCP project name where the target Google Pub/Sub
     is located
+- `cps.subscription`: Name of the [Google Pub/Sub subscription](https://cloud.google.com/pubsub/docs/create-subscription)
+- `gcp.credentials.json`: GCP service account key, correctly escaped as defined in the
+  [prerequisite](/docs/products/kafka/kafka-connect/howto/gcp-pubsub-source#connect_pubsub_source_prereq)
+- `key.converter` and `value.converter`: Define the message format in the Apache Kafka
+  topic. The `io.confluent.connect.avro.AvroConverter` translates messages from the
+  Avro format. To retrieve the message schema, use Aiven's
+  [Karapace schema registry](https://github.com/aiven/karapace), as specified
+  by the `schema.registry.url` parameter and related credentials
 
--   `cps.subscription`: the name of the [Google Pub/Sub
-    subscription](https://cloud.google.com/pubsub/docs/create-subscription)
+  :::note
+  Use the `key.converter` and `value.converter` sections only if the source data is in
+  Avro format. If omitted, messages are read as binary.
 
--   `gcp.credentials.json`: contains the GCP service account key,
-    correctly escaped as defined in the
-    [prerequisite phase](/docs/products/kafka/kafka-connect/howto/gcp-pubsub-source#connect_pubsub_source_prereq)
+  When using Avro as the source data format, set the following parameters:
 
--   `key.converter` and `value.converter`: define the message data
-    format in the Apache Kafka topic. The
-    `io.confluent.connect.avro.AvroConverter` converter translates
-    messages from the Avro format. To retrieve the message schema we use
-    Aiven's [Karapace schema
-    registry](https://github.com/aiven/karapace), as specified by the
-    `schema.registry.url` parameter and related credentials.
+  - `value.converter.schema.registry.url`: Points to the Aiven for Apache Kafka schema
+    registry URL (`https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT`)
+  - `value.converter.basic.auth.credentials.source`: Set to `USER_INFO` to log in to the
+    schema registry using a username and password
+  - `value.converter.schema.registry.basic.auth.user.info`: Pass the schema registry
+    credentials in the form `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`
 
-    :::note
-    The `key.converter` and `value.converter` sections are only needed
-    when the source data is in Avro format. If omitted the messages will
-    be read as binary format.
+   :::
 
-    When using Avro as source data format, set following
-    parameters:
+For a full list of parameters, see the
+[java-pubsub-group-kafka-connector GitHub repository](https://github.com/googleapis/java-pubsub-group-kafka-connector/).
 
-    -   `value.converter.schema.registry.url`: pointing to the Aiven for
-        Apache Kafka schema registry URL in the form of
-        `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT` with the
-        `APACHE_KAFKA_HOST` and `SCHEMA_REGISTRY_PORT` parameters
-        [retrieved in the previous step](/docs/products/kafka/kafka-connect/howto/gcp-pubsub-source#connect_pubsub_source_prereq).
-    -   `value.converter.basic.auth.credentials.source`: to the value
-        `USER_INFO`, since you're going to login to the schema registry
-        using username and password.
-    -   `value.converter.schema.registry.basic.auth.user.info`: passing
-        the required schema registry credentials in the form of
-        `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD` with the
-        `SCHEMA_REGISTRY_USER` and `SCHEMA_REGISTRY_PASSWORD` parameters
-        [retrieved in the previous step](/docs/products/kafka/kafka-connect/howto/gcp-pubsub-source#connect_pubsub_source_prereq).
-    :::
+### Create a Google Pub/Sub source connector
 
-The full list of parameters is available in the [dedicated GitHub
-page](https://github.com/googleapis/java-pubsub-group-kafka-connector/).
+<Tabs groupId="setup-method"> <TabItem value="console" label="Aiven Console" default>
 
-### Create a Kafka Connect connector with the Aiven Console
+1. Log in to the [Aiven Console](https://console.aiven.io/) and select the Aiven for
+   Apache Kafka® or Aiven for Apache Kafka Connect® service.
+1. Click  <ConsoleLabel name="connectors"/> from the left sidebar.
+1. Click **Create New Connector**. If connectors are not enabled,
+   click **Enable connector on this service**.
+1. Click **See all connectors** to view all available options.
+1. Select **Google Pub/Sub source** and click **Get started**.
+1. In the **Common** tab, find the **Connector configuration** text box and
+   click <ConsoleLabel name="edit"/>.
+1. Paste the `pubsub_source.json` connector configuration into the form.
+1. Click **Apply**.
 
-To create a Kafka Connect connector:
+   :::note
+   The Aiven Console parses the configuration file and fills in the relevant UI fields.
+   Review and modify fields as needed. Changes are reflected in
+   the **Connector configuration** text box in JSON format.
+   :::
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/) and select
-    the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
-    service where the connector needs to be defined.
+1. After verifying the settings, click **Create connector**.
+1. Check the connector status on the **Connectors** screen.
+1. Verify that data appears in the target Pub/Sub dataset. By default, the table name is
+   derived from the Apache Kafka topic name. To change the table name, use the Kafka
+   Connect `RegexRouter` transformation. This transformation allows you to rename
+   topics using regular expressions, ensuring that the data is routed to the desired
+   table.
 
-2.  Select **Connectors** from the left sidebar.
-
-3.  Select **Create New Connector**.
-
-    :::note
-    It is enabled only for services [with Kafka Connect enabled](enable-connect).
-    :::
-
-4.  Select **Google Pub/Sub source**.
-
-5.  In the **Common** tab, locate the **Connector configuration** text
-    box and select on **Edit**.
-
-6.  Paste the connector configuration (stored in the
-    `pubsub_source.json` file) in the form.
-
-7.  Select **Apply**.
-
-    :::note
-    The Aiven Console parses the configuration file and fills the
-    relevant UI fields. You can review the UI fields across the various
-    tabs and change them if necessary. The changes will be reflected in
-    JSON format in the **Connector configuration** text box.
-    :::
-
-8.  After all the settings are correctly configured, select **Create
-    connector**.
-
-9.  Verify the connector status under the **Connectors** screen.
-
-10. Verify the presence of the data in the target Pub/Sub dataset, the
-    table name is equal to the Apache Kafka topic name. To
-    change the target table name, you can do so using the Kafka Connect
-    `RegexRouter` transformation.
 
     :::note
     You can also create connectors using the
     [Aiven CLI command](/docs/tools/cli/service/connector#avn_service_connector_create).
     :::
 
+</TabItem> <TabItem value="cli" label="Aiven CLI">
+
+To create a Google Pub/Sub source connector using the
+[Aiven CLI](/docs/tools/cli/service-cli), run:
+
+```bash
+avn service connector create SERVICE_NAME @pubsub_source.json
+```
+
+Parameters:
+
+- `SERVICE_NAME`: Your Aiven for Apache Kafka service name.
+- `@pubsub_source.json`: The path to your JSON configuration file.
+
+To check the connector status, run:
+
+```bash
+avn service connector status SERVICE_NAME CONNECTOR_NAME
+```
+
+Verify that topic and data are present in the Apache Kafka target instance.
+
+</TabItem> </Tabs>
+
 ## Example: Create a Google Pub/Sub source connector
 
-You have a Google Pub/Sub subscription `GCP_SUBSCRIPTION` that you want
-to push to a Aiven for Apache Kafka topic named `measurements` you can
-create a source connector with the following configuration, after
-replacing the placeholders for `GCP_PROJECT_NAME` and `GCP_SERVICE_KEY`:
+Use the following configuration to push data from a Google Pub/Sub subscription
+(`GCP_SUBSCRIPTION`) to an Aiven for Apache Kafka topic named `measurements`. Replace the
+placeholders `GCP_PROJECT_NAME` and `GCP_SERVICE_KEY` with the appropriate values:
 
 ```json
 {
@@ -212,6 +207,5 @@ replacing the placeholders for `GCP_PROJECT_NAME` and `GCP_SERVICE_KEY`:
 }
 ```
 
-The Apache Kafka topic format will be the default bytes by default, you
-can use the AVRO schema by including the `value.converter` and
-`key.converter` properties defined previously.
+The default Apache Kafka topic format is bytes. To use the AVRO schema, include
+the `value.converter` and `key.converter` properties defined earlier.

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-source.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-source.md
@@ -24,7 +24,7 @@ To set up a Google Pub/Sub source connector, ensure you have the following:
     subscription is located
   - `GCP_SUBSCRIPTION`: The name of the [Google Pub/Sub subscription](https://cloud.google.com/pubsub/docs/create-subscription)
   - `GCP_SERVICE_KEY`: A valid Google Cloud service account key for the
-    `GCP_PROJECT_NAME`. To create this key, see [Configure GCP for a Google BigQuery sink connector](/docs/products/kafka/kafka-connect/howto/gcp-bigquery-sink-prereq#gcp-bigquery-sink-connector-google-account)
+    `GCP_PROJECT_NAME`: To create this key, see [Configure GCP for a Google BigQuery sink connector](/docs/products/kafka/kafka-connect/howto/gcp-bigquery-sink-prereq#gcp-bigquery-sink-connector-google-account)
 
     :::warning
     The GCP Pub/Sub source connector accepts the `GCP_SERVICE_KEY` as a JSON string.
@@ -207,5 +207,5 @@ placeholders `GCP_PROJECT_NAME` and `GCP_SERVICE_KEY` with the appropriate value
 }
 ```
 
-The default Apache Kafka topic format is bytes. To use the AVRO schema, include
+The default Apache Kafka topic format is bytes. To use the Avro schema, include
 the `value.converter` and `key.converter` properties defined earlier.


### PR DESCRIPTION
## Describe your changes
Updated Google Pub/Sub connector documentation to clarify required IAM roles and added error handling information for PERMISSION_DENIED during subscription verification.

[EC-524](https://aiven.atlassian.net/browse/EC-524)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.


[EC-524]: https://aiven.atlassian.net/browse/EC-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ