### PR TITLE
fix: manage org users

### DIFF
--- a/docs/platform/howto/manage-org-users.md
+++ b/docs/platform/howto/manage-org-users.md
@@ -4,7 +4,7 @@ title: Manage users in an organization
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-Adding users to your organization lets you give them access to specific organizational units, projects, and services within that organization.
+Adding users to your organization lets you give them access to specific projects and services within that organization.
 
 ## Invite users to an organization
 


### PR DESCRIPTION
## Describe your changes
Strictly speaking, it's not currently possible to grant access the unit level. This change removes organizational units from the list of resources that access can be granted to.


## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
