### PR TITLE
fix: broken link for K8s docs

### DIFF
--- a/docs/tools/kubernetes.md
+++ b/docs/tools/kubernetes.md
@@ -20,7 +20,8 @@ database.
 ### Requirements
 
 - You have access to a Kubernetes cluster where you can run the operator.
-- You have an Aiven account. If you don't have one yet, [sign up for free](https://console.aiven.io/signup).
+- You have an Aiven account. If you don't have one yet,
+  [sign up for free](https://console.aiven.io/signup).
 - To use the operator locally, we recommend using [**kind**](https://kind.sigs.k8s.io/).
   See [the installation guide](https://kind.sigs.k8s.io/docs/user/quick-start/#installation).
 - To install the operator, we recommend [**Helm**](https://helm.sh/).
@@ -28,7 +29,8 @@ database.
 
 ### Install the Kubernetes® operator
 
-1. Optional: To manage the webhook TLS certificates used by our operator, install the `cert-manager`:
+1. Optional: To manage the webhook TLS certificates used by our operator,
+   install the `cert-manager`:
 
    ```bash
    kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
@@ -41,7 +43,8 @@ database.
 
    :::note
    - For GKE version >= 1.21 VPC users, add a firewall rule to explicitly allow
-     ingress to port 9443 for admission webhook. See [the Google Cloud docs](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules).
+     ingress to port 9443 for admission webhook. See
+     [the Google Cloud docs](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules).
 
    - If you are running a GKE _Autopilot_ cluster in Google Cloud Platform,
      use GKE version >=1.21 and install `cert-manager`
@@ -94,8 +97,8 @@ Your pod's status should be `Running`.
 Before creating a service, authenticate the operator with Aiven's API:
 
 1. [Create a token](/docs/platform/howto/create_authentication_token).
-1. Create the Kubernetes secret in the namespace which is going to be used to create your Aiven
-   services:
+1. Create the Kubernetes secret in the namespace which is going to be used
+   to create your Aiven services:
 
    ```bash
    kubectl create secret generic aiven-token --from-literal=token="<your-token>"

--- a/docs/tools/kubernetes.md
+++ b/docs/tools/kubernetes.md
@@ -2,9 +2,8 @@
 title: Aiven Operator for Kubernetes®
 ---
 
-Aiven Operator for [Kubernetes®](https://kubernetes.io/) allows users to manage Aiven services through the Kubernetes® API by using [Custom Resource Definitions (CRD)](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/).
+Manage Aiven services with [Aiven Operator for Kubernetes®](https://aiven.github.io/aiven-operator/) by using [Custom Resource Definitions (CRD)](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/).
 
-:::note[Supported services]
 Aiven Operator for Kubernetes® supports:
 
 - Aiven for Apache Kafka®
@@ -12,7 +11,6 @@ Aiven Operator for Kubernetes® supports:
 - Aiven for ClickHouse®
 - Aiven for OpenSearch®
 - Aiven for PostgreSQL®
-:::
 
 ## Get started
 
@@ -95,7 +93,7 @@ Your pod's status should be `Running`.
 
 Before creating a service, authenticate the operator with Aiven's API:
 
-1. [Create an Aiven token](/docs/platform/howto/create_authentication_token).
+1. [Create a token](/docs/platform/howto/create_authentication_token).
 1. Create the Kubernetes secret in the namespace which is going to be used to create your Aiven
    services:
 
@@ -219,5 +217,6 @@ kubectl delete -f https://github.com/jetstack/cert-manager/releases/latest/downl
 
 ## Related links
 
-- [Aiven Operator for Kubernetes repository](https://github.io/aiven-operator)
+- [Aiven Operator for Kubernetes repository](https://github.com/aiven/aiven-operator/)
+- [Aiven Operator examples](https://aiven.github.io/aiven-operator/resources/project.html)
 - [Kubernetes Basics](https://kubernetes.io/docs/tutorials/kubernetes-basics/)


### PR DESCRIPTION
## Describe your changes

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](styleguide.md).
- [X] My links start with `/docs/`.
