### PR TITLE
fix(integrations): typo in ACL permission

### DIFF
--- a/docs/integrations/cloudwatch/cloudwatch-logs-cli.md
+++ b/docs/integrations/cloudwatch/cloudwatch-logs-cli.md
@@ -22,7 +22,7 @@ Your AWS credentials should have appropriate access rights. According to
 the official AWS documentation, the access rights required for the
 credentials are:
 
--   `inlogs:DescribeLogStreams` which lists the log streams for the
+-   `logs:DescribeLogStreams` which lists the log streams for the
     specified log group endpoint.
 -   `logs:CreateLogGroup` which creates a log group with the specified
     name endpoint.


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
