### PR TITLE
add: howto page for valkey-cli

### DIFF
--- a/docs/products/valkey/get-started.md
+++ b/docs/products/valkey/get-started.md
@@ -53,10 +53,11 @@ Begin your journey with Aiven for Valkey™, the versatile in-memory data store 
 
 ## Connect to Aiven for Valkey
 
-Learn how to connect to Aiven for Caching using different programming
-languages:
+Learn how to connect to Aiven for Valkey using different programming
+languages or through `valkey-cli`:
 
-- [Go](/docs/products/caching/howto/connect-go)
-- [Node](/docs/products/caching/howto/connect-node)
-- [PHP](/docs/products/caching/howto/connect-php)
-- [Python](/docs/products/caching/howto/connect-python)
+- [valkey-cli](/docs/products/valkey/howto/connect-valkey-cli.md)
+- [Go](/docs/products/valkey/howto/connect-go)
+- [Node](/docs/products/valkey/howto/connect-node)
+- [PHP](/docs/products/valkey/howto/connect-php)
+- [Python](/docs/products/valkey/howto/connect-python)

--- a/docs/products/valkey/howto/connect-python.md
+++ b/docs/products/valkey/howto/connect-python.md
@@ -54,4 +54,4 @@ pip install "valkey[hiredis]"
 ## Related Pages
 
 - For additional information about `valkey-py`, see
-  the [Valkey-py GitHub Repository](https://github.com/valkey-io/valkey-py).
+  the [valkey-py GitHub Repository](https://github.com/valkey-io/valkey-py).

--- a/docs/products/valkey/howto/connect-valkey-cli.md
+++ b/docs/products/valkey/howto/connect-valkey-cli.md
@@ -16,11 +16,7 @@ from your service overview page:
 
 ## Prerequisites
 
-For this example, you will need:
-
-1.  The `valkey-cli` client installed. You can install this as part of
-    [Valkey server installation](https://valkey.io/topics/installation/).
-
+Ensure that the valkey-cli client is installed. You can install it as part of the [Valkey server installation](https://valkey.io/topics/installation/).
 ## Setup and run
 
 Execute the following command from a terminal window to connect:

--- a/docs/products/valkey/howto/connect-valkey-cli.md
+++ b/docs/products/valkey/howto/connect-valkey-cli.md
@@ -21,7 +21,7 @@ For this example, you will need:
 1.  The `valkey-cli` client installed. You can install this as part of
     [Valkey server installation](https://valkey.io/topics/installation/).
 
-## Code
+## Setup and run
 
 Execute the following command from a terminal window to connect:
 

--- a/docs/products/valkey/howto/connect-valkey-cli.md
+++ b/docs/products/valkey/howto/connect-valkey-cli.md
@@ -19,7 +19,7 @@ from your service overview page:
 Ensure that the valkey-cli client is installed. You can install it as part of the [Valkey server installation](https://valkey.io/topics/installation/).
 ## Setup and run
 
-Execute the following command from a terminal window to connect:
+Run the following command from a terminal window to connect:
 
 ```shell
 valkey-cli -u SERVICE_URI

--- a/docs/products/valkey/howto/connect-valkey-cli.md
+++ b/docs/products/valkey/howto/connect-valkey-cli.md
@@ -1,0 +1,68 @@
+---
+title: Connect with valkey-cli
+---
+
+Learn how to establish a connection to an Aiven for Valkey™ service using the `valkey-cli`.
+
+
+## Variables
+
+Replace the following placeholders in the code sample with actual values
+from your service overview page:
+
+| Variable    | Description                                              |
+| ----------- | -------------------------------------------------------- |
+| `SERVICE_URI` | URI for the Aiven for Valkey service connection  |
+
+## Prerequisites
+
+For this example, you will need:
+
+1.  The `valkey-cli` client installed. You can install this as part of
+    [Valkey server installation](https://valkey.io/topics/installation/).
+
+## Code
+
+Execute the following command from a terminal window to connect:
+
+```shell
+valkey-cli -u SERVICE_URI
+```
+
+This command initiates a connection to the Aiven for Valkey service.
+
+To verify the connection, execute:
+
+```shell
+INFO
+```
+
+This command displays all server parameters, ensuring the connection is active:
+
+```text
+# Server
+redis_version:7.2.4
+server_name:valkey
+valkey_version:7.2.7
+redis_git_sha1:c0b10003
+redis_git_dirty:0
+redis_build_id:e63142036e093656
+redis_mode:standalone
+...
+```
+
+To set a key, execute the following command:
+
+```bash
+SET mykey mykeyvalue123
+```
+
+Following successful execution, a confirmation message `OK` appears.
+
+To retrieve the key value, execute the following command:
+
+```bash
+GET mykey
+```
+
+This will display the value of `mykey`, in this case,`"mykeyvalue123"`.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1880,6 +1880,7 @@ const sidebars: SidebarsConfig = {
                 id: 'products/valkey/howto/connect-services',
               },
               items: [
+                'products/valkey/howto/connect-valkey-cli',
                 'products/valkey/howto/connect-go',
                 'products/valkey/howto/connect-node',
                 'products/valkey/howto/connect-php',


### PR DESCRIPTION
## Describe your changes

Add the missing page describing how to connect to Aiven for Valkey™ using `valkey-cli`. This is very similar to the equivalent page for Aiven for Caching and `redis-cli`.

This page will be needed by the developer center articles that I am changing to mention Aiven for Valkey instead of Aiven for Caching.

1. Added the missing page
2. Linked to it from docs/products/valkey/get-started.md and also fixed the links on that page which still pointed to `/docs/products/caching` so that they now point to `/docs/products/valkey`
3. Added entry in `sidebars.ts` - it's not obvious from the comments at the top if this is necessary, but it seems consistent with current usage
4. In the "Connect with Python" page, correct the capitalisation of `valkey-python` in the link at the end

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
