### PR TITLE
update: remove cloud providers from free plan

### DIFF
--- a/docs/platform/concepts/free-plan.md
+++ b/docs/platform/concepts/free-plan.md
@@ -40,7 +40,7 @@ There are some limitations of the free plan services:
 -   For PostgreSQL: no connection pooling
 -   Support only through the [Aiven Community
     Forum](https://aiven.io/community/forum/)
--   A limited number of hosting regions on AWS and DigitalOcean
+-   Hosting only on AWS
 -   Only one service per service type per user and
     [organization](/docs/platform/concepts/orgs-units-projects)
 -   Not covered under Aiven's 99.99% SLA


### PR DESCRIPTION
## Describe your changes
Removes DO from the free plan doc as it will no longer be offered on new free plans. 

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
