### PR TITLE
fix: `avn service cli` also support Valkey

### DIFF
--- a/docs/tools/cli/service-cli.md
+++ b/docs/tools/cli/service-cli.md
@@ -56,9 +56,9 @@ avn service ca get kafka-doc --target-filepath /tmp/ca.pem
 
 ### `avn service cli`
 
-Opens the appropriate interactive shell, such as `psql` or `redis-cli`,
+Opens the appropriate interactive shell, such as `psql` or `valkey-cli`,
 to the given service. Supported only for Aiven for PostgreSQL®, Aiven
-for Caching.
+for Valkey™ and Aiven for Caching.
 
 | Parameter      | Information             |
 | -------------- | ----------------------- |


### PR DESCRIPTION
## Describe your changes

`avn service cli` also supports connecting to an Aiven for Valkey service.

It connects to Valkey or Redis using whichever of `valkey-cli` or `redis-cli` is available (validated by trying it out!), but I think it's more useful to reference `valkey-cli` (only) in the text (it does say "such as"), especially as that will make it simpler to remove mention of Aiven for Caching when that is retired.

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
