### PR TITLE
fix: free plan page should name Valkey

### DIFF
--- a/docs/platform/concepts/free-plan.md
+++ b/docs/platform/concepts/free-plan.md
@@ -2,7 +2,7 @@
 title: Free plans
 ---
 
-The free plan is available for Aiven for PostgreSQL®, Aiven for MySQL, and Aiven for Caching services. You don't need a credit card to sign up and you can create one free service for each type. This means you can create one free PostgreSQL, one free MySQL, and one free Caching service.
+The free plan is available for Aiven for PostgreSQL®, Aiven for MySQL, and Aiven for Valkey™ services. You don't need a credit card to sign up and you can create one free service for each type. This means you can create one free PostgreSQL, one free MySQL, and one free Valkey service.
 
 To try a different service, you may want to consider a
 30-day [free trial](/docs/platform/concepts/free-trial),
@@ -24,7 +24,7 @@ Free plans include:
 -   1 CPU per virtual machine
 -   1 GB RAM
 -   For PostgreSQL and MySQL: 5 GB disk storage
--   For Caching: `maxmemory` set to 50%
+-   For Valkey: `maxmemory` set to 50%
 -   Management via our web console, CLI, API, Terraform provider, or
     Kubernetes® operator
 -   Monitoring for metrics and logs


### PR DESCRIPTION
We no longer support a free plan for Aiven for Caching, we do for Aiven for Valkey, so replace the terms.

Note: I assume that the `maxmemory` limitation is retained as-is.

## Describe your changes

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
