### PR TITLE
update: use permission resource in teams migration

### DIFF
--- a/docs/tools/terraform/howto/migrate-from-teams-to-groups.md
+++ b/docs/tools/terraform/howto/migrate-from-teams-to-groups.md
@@ -57,7 +57,7 @@ Account Owners team.
     this team after the migration.
     :::
 
-3.  To add the users to the groups, use the
+1.  To add the users to the groups, use the
     [`aiven_organization_user_group_member` resource](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/organization_user_group_member):
 
     ```hcl
@@ -68,7 +68,7 @@ Account Owners team.
     }
     ```
 
-4.  To add each new group to the same projects that the teams are assigned to, use the
+1.  To add each new group to the same projects that the teams are assigned to, use the
     [`aiven_organization_permission` resource](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/organization_permission):
 
     ```hcl
@@ -86,19 +86,19 @@ Account Owners team.
     }
     ```
 
-5.  Preview your changes by running:
+1.  Preview your changes by running:
 
     ```bash
     terraform plan
     ```
 
-6.  To apply the new configuration, run:
+1.  To apply the new configuration, run:
 
     ```bash
     terraform apply --auto-approve
     ```
 
-7.  After confirming all users have the correct access, delete the team resources and
+1.  After confirming all users have the correct access, delete the team resources and
     apply the changes.
 
 ## Related pages

--- a/docs/tools/terraform/howto/migrate-from-teams-to-groups.md
+++ b/docs/tools/terraform/howto/migrate-from-teams-to-groups.md
@@ -3,7 +3,7 @@ title: Migrate from teams to groups with Terraform
 sidebar_label: Migrate from teams to groups
 ---
 
-Teams in Aiven are becoming groups. [Groups](/docs/platform/howto/manage-groups) are an easier way to control access to your organization's projects and services for a group of users.
+Teams in Aiven are becoming groups. Groups are an easier way to control access to your organization's projects and services for a group of users.
 
 :::important
 **Teams have been deprecated and are being migrated to groups.**
@@ -45,9 +45,9 @@ Account Owners team.
 
     ```hcl
     resource "aiven_organization_user_group" "admin" {
-      organization_id = data.aiven_organization.ORGANIZATION_RESOURCE_NAME.id
-      name       = "Admin user group"
-      description = "Administrators"
+      organization_id = data.aiven_organization.main.id
+      name            = "Admin user group"
+      description     = "Administrators"
     }
     ```
 
@@ -57,29 +57,49 @@ Account Owners team.
     this team after the migration.
     :::
 
-1.  To add the users to the groups, use the
+3.  To add the users to the groups, use the
     [`aiven_organization_user_group_member` resource](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/organization_user_group_member):
 
     ```hcl
     resource "aiven_organization_user_group_member" "admin_members" {
-      group_id      = aiven_organization_user_group.admin.group_id
-      organization_id = data.aiven_organization.ORGANIZATION_RESOURCE_NAME.id
-      user_id = "USER_ID"
+      group_id        = aiven_organization_user_group.admin.group_id
+      organization_id = data.aiven_organization.main.id
+      user_id         = "u123a456b7890c"
     }
     ```
 
-1.  To add each new group to the same projects that the teams are assigned to, use the
-    [`aiven_organization_group_project` resource](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/organization_group_project):
+4.  To add each new group to the same projects that the teams are assigned to, use the
+    [`aiven_organization_permission` resource](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/organization_permission):
 
     ```hcl
-    resource "aiven_organization_group_project" "admin_project1" {
-      group_id      = aiven_organization_user_group.admin.group_id
-      project = aiven_project.PROJECT_RESOURCE_NAME.project
-      role    = "admin"
+    resource "aiven_organization_permission" "project_admin" {
+      organization_id = data.aiven_organization.main.id
+      resource_id     = data.aiven_project.example_project.id
+      resource_type   = "project"
+      permissions {
+        permissions = [
+          "admin"
+        ]
+        principal_id   = aiven_organization_user_group.admin.group_id
+        principal_type = "user_group"
+      }
     }
     ```
 
-1.  After confirming all users have the correct access, delete the team resources.
+5.  Preview your changes by running:
+
+    ```bash
+    terraform plan
+    ```
+
+6.  To apply the new configuration, run:
+
+    ```bash
+    terraform apply --auto-approve
+    ```
+
+7.  After confirming all users have the correct access, delete the team resources and
+    apply the changes.
 
 ## Related pages
 


### PR DESCRIPTION
## Describe your changes

Updates teams to groups migration instructions to use the new `aiven_organization_permission` resource.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](styleguide.md).
- [X] My links start with `/docs/`.
