### PR TITLE
fix: typo in sidebar label

### DIFF
--- a/docs/products/mysql/concepts/mysql-tuning-and-concurrency.md
+++ b/docs/products/mysql/concepts/mysql-tuning-and-concurrency.md
@@ -1,6 +1,6 @@
 ---
 title: MySQL tuning for concurrency
-sidebar_label: Tuning foor concurrency
+sidebar_label: Tuning for concurrency
 ---
 
 Determining how much memory is available for queries, and tuning concurrency accordingly, requires calculation of service memory, query analysis, and monitoring.


### PR DESCRIPTION
## Describe your changes

While scrolling through the docs, I noticed a typo in the sidebar label of `docs/products/mysql/concepts/mysql-tuning-and-concurrency.md`. The label was "Tuning foor concurrency," and I corrected it to "Tuning for concurrency". This is my first time contributing here, so if the commit or PR title is incorrect or if something is missing, I'm more than happy to make any necessary adjustments.

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
