### PR TITLE
update: default behavior of automatic topic creation

### DIFF
--- a/docs/products/kafka/howto/create-topics-automatically.md
+++ b/docs/products/kafka/howto/create-topics-automatically.md
@@ -6,11 +6,14 @@ import TabItem from '@theme/TabItem';
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
 import {ConsoleIcon} from "@site/src/components/ConsoleIcons"
 
-Apache Kafka® provides the capability to automatically create topics when a message is produced to a topic that does not exist.
+Apache Kafka® can automatically create a topic if a message is sent to a topic that doesn’t already exist.
 
-By default, Aiven for Apache Kafka enables automatic topic creation to maintain
-compatibility with standard Apache Kafka configurations. If a message is produced to a
-non-existent topic, you see the following error message:
+By default, Aiven for Apache Kafka enables automatic topic creation to remain compatible
+with standard Apache Kafka configurations, making it useful for testing and development.
+In production environments, disable automatic topic creation to avoid accidental topics
+created by typos, which can lead to disorganized topics.
+
+If a message is produced to a non-existent topic, you see the following error message:
 
 ```bash
 KafkaTimeoutError: Failed to update metadata after 60.0 secs.

--- a/docs/products/kafka/howto/create-topics-automatically.md
+++ b/docs/products/kafka/howto/create-topics-automatically.md
@@ -8,9 +8,9 @@ import {ConsoleIcon} from "@site/src/components/ConsoleIcons"
 
 Apache Kafka® provides the capability to automatically create topics when a message is produced to a topic that does not exist.
 
-By default, Aiven for Apache Kafka disables this feature to prevent accidental
-topic creation. If a message is produced to a non-existent topic, you'll see the
-following error message:
+By default, Aiven for Apache Kafka enables automatic topic creation to maintain
+compatibility with standard Apache Kafka configurations. If a message is produced to a
+non-existent topic, you see the following error message:
 
 ```bash
 KafkaTimeoutError: Failed to update metadata after 60.0 secs.
@@ -22,15 +22,14 @@ In such cases, you have two options:
    [create the topics](/docs/products/kafka/howto/create-topic) before use. This
    approach is recommended for production environments as it provides better
    control over settings such as partition count, replication factor, and retention time.
-1. **Enable automatic topic creation**: While simpler, this option carries some drawbacks.
-   It risks inadvertently creating new topics, especially due to typos, and may result
-   in topics created with [default configuration values](set-kafka-parameters) defined at
-   the service level.
+1. **Enable automatic topic creation**: This option is simpler but has some drawbacks. It
+   can lead to inadvertent topic creation due to typos and may create topics with
+   [default configuration values](set-kafka-parameters) set at the service level.
 
 :::note
-When tiered storage is activated for your Aiven for Apache Kafka service, all
-new topics will have tiered storage enabled by default.
-[Learn more about tiered storage](/docs/products/kafka/concepts/kafka-tiered-storage).
+If [tiered storage is enabled](/docs/products/kafka/howto/enable-kafka-tiered-storage)
+for your Aiven for Apache Kafka service, all new topics have tiered storage enabled
+by default.
 :::
 
 ## Enable automatic topic creation

--- a/docs/products/kafka/howto/create-topics-automatically.md
+++ b/docs/products/kafka/howto/create-topics-automatically.md
@@ -11,7 +11,7 @@ Apache Kafka® can automatically create a topic if a message is produced to a to
 By default, Aiven for Apache Kafka enables automatic topic creation to remain compatible
 with standard Apache Kafka configurations, making it useful for testing and development.
 In production environments, **disable** automatic topic creation to avoid accidental topics
-created by typos, which can lead to disorganized topics.
+created by typos, which can lead to a disorganized topic catalog.
 
 If a message is produced to a non-existent topic, you see the following error message:
 

--- a/docs/products/kafka/howto/create-topics-automatically.md
+++ b/docs/products/kafka/howto/create-topics-automatically.md
@@ -6,11 +6,11 @@ import TabItem from '@theme/TabItem';
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
 import {ConsoleIcon} from "@site/src/components/ConsoleIcons"
 
-Apache Kafka® can automatically create a topic if a message is sent to a topic that doesn’t already exist.
+Apache Kafka® can automatically create a topic if a message is produced to a topic that doesn’t already exist.
 
 By default, Aiven for Apache Kafka enables automatic topic creation to remain compatible
 with standard Apache Kafka configurations, making it useful for testing and development.
-In production environments, disable automatic topic creation to avoid accidental topics
+In production environments, **disable** automatic topic creation to avoid accidental topics
 created by typos, which can lead to disorganized topics.
 
 If a message is produced to a non-existent topic, you see the following error message:


### PR DESCRIPTION
## Describe your changes
Clarify default behavior of automatic topic creation in Aiven for Apache Kafka. 

[DOC-1206](https://aiven.atlassian.net/browse/DOC-1206)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.


[DOC-1206]: https://aiven.atlassian.net/browse/DOC-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ