### PR TITLE
update: google cloud logging integration

### DIFF
--- a/docs/integrations/cloudlogging.md
+++ b/docs/integrations/cloudlogging.md
@@ -8,41 +8,41 @@ You can send your service logs to Google Cloud Logging to store, search, analyze
 
 ## Prerequisites
 
--   You have a Google Project ID and Log ID. More information about
-    Google Cloud projects is available in the [Google Cloud
-    documentation](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
--   You have Google Cloud service account credentials in JSON format to
-    authenticate with the Google Cloud Platform. See Google Cloud's
-    documentation for [instructions on how to create and get service
-    account
-    credentials](https://developers.google.com/workspace/guides/create-credentials).
--   The service account has permission to create log entries. See the
-    Google Cloud documentation for information on [access control with
-    IAM](https://cloud.google.com/logging/docs/access-control).
+- You have a Google Project ID and Log ID. More information about
+  Google Cloud projects is available in the [Google Cloud
+  documentation](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
+- You have Google Cloud service account credentials in JSON format created within the
+  same Google Cloud project where logs will be sent. See Google Cloud's documentation for
+  [instructions on how to create and get service account credentials](https://developers.google.com/workspace/guides/create-credentials).
+- The service account has permission to create log entries. See the
+  Google Cloud documentation for information on
+  [access control with IAM](https://cloud.google.com/logging/docs/access-control).
 
 ## Set up Cloud Logging integration in Aiven Console
 
 ### Step 1. Create the integration endpoint
 
-1.  Go to <ConsoleLabel name="integration endpoints"/>.
-2.  Select **Google Cloud Logging**.
-3.  Click **Add new endpoint**.
-4.  Enter a name.
-5.  Enter the **GCP Project ID** and **Log ID** from Google Cloud.
-6.  Enter the **Google Service Account Credentials** in JSON format.
-7.  Click **Create**.
+1. Go to <ConsoleLabel name="integration endpoints"/>.
+1. Select **Google Cloud Logging**.
+1. Click **Add new endpoint**.
+1. Enter a name.
+1. Enter the **GCP Project ID** and **Log ID** from Google Cloud.
+1. Enter the **Google Service Account Credentials** in JSON format.
+1. Click **Create**.
 
 :::warning
-Cross project service account credentials will not work in **Google Service Account Credentials**.
+Cross-project service account credentials do not work with
+**Google Service Account Credentials** for this integration. Ensure that the
+service account is created within the same Google Cloud project where logs are sent.
 :::
 
 ### Step 2. Add the integration endpoint to your service
 
-1.  Go to the service to add the logs integration to.
-2.  On the sidebar, click <ConsoleLabel name="integrations"/>.
-3.  Select **Google Cloud Logging**.
-4.  Choose the endpoint that you created.
-5.  Click **Enable**.
+1. Go to the service to add the logs integration to.
+1. On the sidebar, click <ConsoleLabel name="integrations"/>.
+1. Select **Google Cloud Logging**.
+1. Choose the endpoint that you created.
+1. Click **Enable**.
 
 ## Set up Cloud Logging integration using the CLI
 
@@ -58,16 +58,16 @@ avn service integration-endpoint-create --project your-project-name         \
 
 ### Step 2. Add the integration endpoint to your service
 
-1.  Get the endpoint identifier:
+1. Get the endpoint identifier:
 
-    ```shell
-    avn service integration-endpoint-list --project your-project-name
-    ```
+   ```shell
+   avn service integration-endpoint-list --project your-project-name
+   ```
 
-2.  Use the `endpoint_id` to attach the service to the endpoint:
+1. Use the `endpoint_id` to attach the service to the endpoint:
 
-    ```shell
-    avn service integration-create --project your-project-name  \
-    -t external_google_cloud_logging -s your-service            \
-    -D <ENDPOINT_ID>
-    ```
+   ```shell
+   avn service integration-create --project your-project-name  \
+   -t external_google_cloud_logging -s your-service            \
+   -D <ENDPOINT_ID>
+   ```

--- a/docs/integrations/cloudlogging.md
+++ b/docs/integrations/cloudlogging.md
@@ -32,6 +32,10 @@ You can send your service logs to Google Cloud Logging to store, search, analyze
 6.  Enter the **Google Service Account Credentials** in JSON format.
 7.  Click **Create**.
 
+:::warning
+Cross project service account credentials will not work in **Google Service Account Credentials**.
+:::
+
 ### Step 2. Add the integration endpoint to your service
 
 1.  Go to the service to add the logs integration to.


### PR DESCRIPTION
A customer tried to use cross project service account, but it cause auth error.

It turns out journalpump extracts project id from the credential and use it as the target project.

ZD: https://aivenhelp.zendesk.com/agent/tickets/91867

## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
