### PR TITLE
update: add Valkey to Dragonfly migration documentation

### DIFF
--- a/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
+++ b/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
@@ -1,10 +1,11 @@
 ---
-title: Migrate Aiven for Caching to Aiven for Dragonfly®
+title: Migrate Aiven for Caching or Aiven for Valkey™ to Aiven for Dragonfly®
+sidebar_label: Migrate Caching or Valkey to Aiven for Dragonfly®
 ---
 import DragonflyLimitations from '@site/static/includes/dragonfly-limitations.md';
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-Migrate your Aiven for Caching databases to Aiven for Dragonfly using the Aiven Console migration tool.
+Migrate your Aiven for Caching or Aiven for Valkey databases to Aiven for Dragonfly using the Aiven Console migration tool.
 
 import Note from "@site/static/includes/dragonflysla-note.md"
 
@@ -12,81 +13,74 @@ import Note from "@site/static/includes/dragonflysla-note.md"
 
 ## Compatibility overview
 
-Before migrating an external Redis database to Aiven for Dragonfly,
-carefully review your current Redis setup.
+Before migrating an external Redis database or an Aiven for Valkey database to
+Aiven for Dragonfly, review your current database setup.
 
-- **Review database setup:** Examine your Redis database's data
-  structures, storage patterns, and configurations. Identify any unique
-  features, custom settings, and specific configurations.
-- **API compatibility:** While Dragonfly is designed to mirror Redis API commands
-  closely, variations exist, particularly with the newer versions of Redis.
+- **Review database setup:**  Examine your Redis database's data structures, storage
+  patterns, and configurations within Aiven for Caching or Aiven for Valkey. Identify any
+  unique features, custom settings, and specific configurations.
+- **API compatibility:** While Dragonfly is designed to closely mirror Redis API commands,
+  there are some differences, particularly with the newer versions of Redis and Valkey.
   For detailed insights on command compatibility, refer to the
   [Dragonfly API compatibility documentation](https://www.dragonflydb.io/docs/command-reference/compatibility).
 
 ## Prerequisites
 
-Before starting the migration from an Aiven for Caching service:
+Before starting the migration:
 
--   Confirm the Aiven for Caching service is accessible over the Internet.
-    For more information, see
-    [Public internet access](/docs/platform/howto/public-access-in-vpc).
--   Make a note of the Aiven project and Aiven for Caching service names
-    for migration in the Aiven Console.
+- Confirm that your Aiven for Caching or Aiven for Valkey service is accessible over
+  the Internet. For more information, see
+  [Public internet access](/docs/platform/howto/public-access-in-vpc).
+- Note the project and service names for migration in the Aiven Console.
 
 The Aiven Console migration tool automatically uses connection details
-like the hostname, port, and credentials linked to the selected Aiven
-for Redis service.
+like the hostname, port, and credentials associated with the selected service.
 
 <DragonflyLimitations />
 
 ## Database migration steps
 
 1. Log in to the [Aiven Console](https://console.aiven.io/) and select
-   the Aiven for Dragonfly service for your Redis database migration.
-1. Go to **Service settings** from the sidebar.
-1. Scroll to the **Service management** section, and
+   the Aiven for Dragonfly service for your database migration.
+1. Click **Service settings** from the sidebar.
+1. Go to the **Service management** section, and
    click <ConsoleLabel name="actions"/> > **Import database**.
    to initiate the import process.
 1. Follow the wizard to guide you through the database migration process.
 
 ### Step 1: Configure
 
-Begin the migration process by selecting **Import an Aiven for Caching
-service**:
+To begin the migration, select **Migrate existing Aiven for Caching/Valkey database**:
 
-1. From the drop-down menu, select your project name.
-1. From the subsequent drop-down, select the Aiven for Caching database
-   you intend to migrate.
+1. In the **Project name** drop-down, select the project with the service to migrate.
+1. In the **Service name** drop-down, choose the Aiven for Caching or Aiven for Valkey
+   service.
 1. Click **Get started** to proceed with the migration.
 
 ### Step 2: Validate
 
-The [Aiven Console](https://console.aiven.io/) automatically
-attempts to validate the database configurations for the selected Aiven
-for Redis service. Click **Run validation** to validate the connection.
+The [Aiven Console](https://console.aiven.io/) automatically validates the database
+configuration for the selected service. Click **Run validation** to check the connection.
 
 :::warning
 If a validation error occurs during migration, follow the on-screen
 instructions to fix it. Rerun validation to ensure the database meets
-migration criteria. Note that the migration doesn't include service
-user accounts and commands in progress.
+migration criteria. The migration doesn't include service
+user accounts and commands that are in progress.
 :::
 
 ### Step 3: Migrate
 
-Once all the necessary checks have been completed successfully, you can
-proceed with the migration process.
-
-- Click **Start migration** to initiate the data migration process to
-  Aiven for Dragonfly.
+Once all necessary checks are successfully completed, proceed by
+clicking **Start migration** to begin the data migration process to Aiven for Dragonfly.
 
 ### Step 4: Replicate
 
-While the migration is in progress:
+During migration:
 
 - You can close the migration wizard by clicking **Close window** and
   return later to monitor the progress. Check the service's **Overview** page to track
-  the migration progress.
+  the migration status.
 
 - To stop the migration, click **Stop migration**. The data already transferred
   to Aiven for Dragonfly is preserved.
@@ -97,15 +91,14 @@ While the migration is in progress:
   - The target database is in a read-only state during
     migration. Writing to the database is only possible once the
     migration is stopped.
-  - Do not manually change the replication settings of the source
-    database.
+  - Avoid manually changing the replication settings of the source database.
   - Avoid making network or configuration changes that can disrupt
-    the ongoing connection between the source and target databases,
+    the connection between the source and target databases,
     such as modifying firewall rules or altering trusted sources.
   :::
 
     :::note
-    If the migration fails, investigate, resolve, and restart the
+    If the migration fails, investigate, resolve the issue, and restart the
     migration using **Start over**.
     :::
 
@@ -113,7 +106,7 @@ While the migration is in progress:
 
 Upon successful migration:
 
-- **Stop replication**: If no further synchronization is required and
+- **Stop replication**: If no further synchronization is required, and
   you are ready to switch to Aiven for Dragonfly after thoroughly
   testing the service.
 - **Keep replicating**: If ongoing data synchronization is necessary
@@ -125,11 +118,12 @@ to prevent unintentional migrations.
 :::
 
 :::note
-When replication mode is active, Aiven for Dragonfly ensures your data remains in sync,
-with continuous synchronization of new writes from the source database.
+When replication mode is active, Aiven for Dragonfly continuously synchronizes new
+writes from the source database, ensuring your data remains up to date.
 :::
 
 ## Related pages
 
 - [Aiven for Caching* documentation](/docs/products/caching/get-started)
 - [Aiven for Dragonfly overview](/docs/products/dragonfly)
+- [Aiven for Valkey overview](/docs/products/valkey)

--- a/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
+++ b/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
@@ -5,7 +5,7 @@ sidebar_label: Migrate Caching or Valkey to Aiven for Dragonfly®
 import DragonflyLimitations from '@site/static/includes/dragonfly-limitations.md';
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-Migrate external Redis® or Valkey databases to Aiven for Dragonfly® using the Aiven Console migration tool.
+Migrate your Aiven for Caching or Aiven for Valkey databases to Aiven for Dragonfly using the Aiven Console migration tool.
 
 import Note from "@site/static/includes/dragonflysla-note.md"
 

--- a/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
+++ b/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
@@ -5,7 +5,7 @@ sidebar_label: Migrate Caching or Valkey to Aiven for Dragonfly®
 import DragonflyLimitations from '@site/static/includes/dragonfly-limitations.md';
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-Migrate your Aiven for Caching or Aiven for Valkey databases to Aiven for Dragonfly using the Aiven Console migration tool.
+Migrate external Redis® or Valkey databases to Aiven for Dragonfly® using the Aiven Console migration tool.
 
 import Note from "@site/static/includes/dragonflysla-note.md"
 
@@ -16,18 +16,20 @@ import Note from "@site/static/includes/dragonflysla-note.md"
 Before migrating an external Redis database or an Aiven for Valkey database to
 Aiven for Dragonfly, review your current database setup.
 
-- **Review database setup:**  Examine your Redis database's data structures, storage
-  patterns, and configurations within Aiven for Caching or Aiven for Valkey. Identify any
+- **Review database setup:** Examine the data structures, storage patterns, and
+  configurations in your Aiven for Caching or Aiven for Valkey database. Identify any
   unique features, custom settings, and specific configurations.
-- **API compatibility:** While Dragonfly is designed to closely mirror Redis API commands,
-  there are some differences, particularly with the newer versions of Redis and Valkey.
-  For detailed insights on command compatibility, refer to the
+- **API compatibility:** While Dragonfly closely mirrors Redis API commands, some
+  differences exist, especially with newer versions of Redis and Valkey.
+  For information on command compatibility, refer to the
   [Dragonfly API compatibility documentation](https://www.dragonflydb.io/docs/command-reference/compatibility).
 
 ## Prerequisites
 
 Before starting the migration:
 
+- A target Aiven for Dragonfly service set up and ready. For more information,
+  see [Get started with Aiven for Dragonfly®](/docs/products/dragonfly/get-started).
 - Confirm that your Aiven for Caching or Aiven for Valkey service is accessible over
   the Internet. For more information, see
   [Public internet access](/docs/platform/howto/public-access-in-vpc).
@@ -42,10 +44,10 @@ like the hostname, port, and credentials associated with the selected service.
 
 1. Log in to the [Aiven Console](https://console.aiven.io/) and select
    the Aiven for Dragonfly service for your database migration.
-1. Click **Service settings** from the sidebar.
-1. Go to the **Service management** section, and
-   click <ConsoleLabel name="actions"/> > **Import database**.
-   to initiate the import process.
+1. On the <ConsoleLabel name="overview"/> page, click
+   <ConsoleLabel name="service settings"/> in the sidebar.
+1. In the **Service management** section, click
+   <ConsoleLabel name="actions"/> > **Migrate database**.
 1. Follow the wizard to guide you through the database migration process.
 
 ### Step 1: Configure
@@ -62,7 +64,7 @@ To begin the migration, select **Migrate existing Aiven for Caching/Valkey datab
 The [Aiven Console](https://console.aiven.io/) automatically validates the database
 configuration for the selected service. Click **Run validation** to check the connection.
 
-:::warning
+:::note
 If a validation error occurs during migration, follow the on-screen
 instructions to fix it. Rerun validation to ensure the database meets
 migration criteria. The migration doesn't include service
@@ -71,50 +73,50 @@ user accounts and commands that are in progress.
 
 ### Step 3: Migrate
 
-Once all necessary checks are successfully completed, proceed by
-clicking **Start migration** to begin the data migration process to Aiven for Dragonfly.
+After completing validation, click **Start migration** to begin migrating data to
+Aiven for Dragonfly.
 
-### Step 4: Replicate
+While the migration is in progress:
 
-During migration:
+- Click **Close window** to close the migration wizard, and return later to monitor t
+  he migration status from the service <ConsoleLabel name="overview"/> page.
+- The migration duration depends on the size of your database. During migration, the
+  target database is read-only, and writing to the database is only possible after
+  stopping the migration.
+- Certain managed database features are disabled during migration.
+- To stop the migration, click **Stop migration**. Any data already transferred to
+  Aiven for Dragonfly is preserved.
 
-- You can close the migration wizard by clicking **Close window** and
-  return later to monitor the progress. Check the service's **Overview** page to track
-  the migration status.
+:::note
+To avoid conflicts during migration:
 
-- To stop the migration, click **Stop migration**. The data already transferred
-  to Aiven for Dragonfly is preserved.
+- Avoid actions that may disrupt replication, such as changing replication settings,
+  modifying firewall rules, or altering trusted sources.
+- Stopping migration halts replication immediately, but any transferred data is
+  preserved. Starting a new migration overwrites the entire database with the latest
+  data from the source.
 
-  :::important
-  To prevent conflicts during replication:
+:::
 
-  - The target database is in a read-only state during
-    migration. Writing to the database is only possible once the
-    migration is stopped.
-  - Avoid manually changing the replication settings of the source database.
-  - Avoid making network or configuration changes that can disrupt
-    the connection between the source and target databases,
-    such as modifying firewall rules or altering trusted sources.
-  :::
-
-    :::note
-    If the migration fails, investigate, resolve the issue, and restart the
-    migration using **Start over**.
-    :::
+:::note
+If the migration fails, investigate, resolve the issue, and restart the
+migration using **Start over**.
+:::
 
 ### Step 5: Close the connection and next steps
 
-Upon successful migration:
+Once migration completes:
 
-- **Stop replication**: If no further synchronization is required, and
-  you are ready to switch to Aiven for Dragonfly after thoroughly
-  testing the service.
-- **Keep replicating**: If ongoing data synchronization is necessary
-  to maintain active synchronization.
+- Click **Stop replication** if no further synchronization is required and
+  you are ready to switch to Aiven for Dragonfly after thoroughly testing the service.
+- Click **Keep replicating** to maintain ongoing data synchronization if further
+  testing or syncing with the source database is needed.
+
 
 :::warning
-Avoid system updates or configuration changes during active replication
-to prevent unintentional migrations.
+Avoid system updates or configuration changes during active replication, as these can
+restart nodes and trigger a new database migration. Ensure replication is complete or
+stopped before making any modifications.
 :::
 
 :::note

--- a/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
+++ b/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
@@ -1,6 +1,6 @@
 ---
-title: Migrate Aiven for Caching or Aiven for Valkey™ to Aiven for Dragonfly®
-sidebar_label: Migrate Caching or Valkey to Aiven for Dragonfly®
+title: Migrate Aiven for Caching or Aiven for Valkey™ to Aiven for Dragonfly
+sidebar_label: Migrate Caching or Valkey to Dragonfly
 ---
 import DragonflyLimitations from '@site/static/includes/dragonfly-limitations.md';
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
@@ -11,7 +11,7 @@ import Note from "@site/static/includes/dragonflysla-note.md"
 
 <Note/>
 
-## Compatibility overview
+## Compatibility check
 
 Before migrating an Aiven for Caching or Aiven for Valkey database to Aiven for
 Dragonfly, review your current database setup.
@@ -28,7 +28,7 @@ Dragonfly, review your current database setup.
 
 Before starting the migration:
 
-- A target Aiven for Dragonfly service set up and ready. For more information,
+- Confirm a target Aiven for Dragonfly service set up and ready. For more information,
   see [Get started with Aiven for Dragonfly®](/docs/products/dragonfly/get-started).
 - Confirm that your Aiven for Caching or Aiven for Valkey service is accessible over
   the Internet. For more information, see
@@ -62,13 +62,17 @@ To begin the migration, select **Migrate existing Aiven for Caching/Valkey datab
 ### Step 2: Validate
 
 The [Aiven Console](https://console.aiven.io/) automatically validates the database
-configuration for the selected service. Click **Run validation** to check the connection.
+configuration for the selected service.
+
+Click **Run validation** to check the connection.
 
 :::note
-If a validation error occurs during migration, follow the on-screen
-instructions to fix it. Rerun validation to ensure the database meets
-migration criteria. The migration doesn't include service
-user accounts and commands that are in progress.
+
+- If a validation error occurs during migration, follow the on-screen
+  instructions to fix it. Rerun validation to ensure the database meets
+migration criteria.
+- The migration doesn't include service
+  user accounts and commands that are in progress.
 :::
 
 ### Step 3: Migrate
@@ -78,8 +82,8 @@ Aiven for Dragonfly.
 
 While the migration is in progress:
 
-- Click **Close window** to close the migration wizard, and return later to monitor t
-  he migration status from the service <ConsoleLabel name="overview"/> page.
+- Click **Close window** to close the migration wizard, and return later to monitor the
+  migration status from the service <ConsoleLabel name="overview"/> page.
 - The migration duration depends on the size of your database. During migration, the
   target database is read-only, and writing to the database is only possible after
   stopping the migration.
@@ -98,7 +102,7 @@ To avoid conflicts during migration:
 
 :::
 
-:::note
+:::tip
 If the migration fails, investigate, and resolve the issue. Click **Start over** in
 the Data migration window to restart the migration.
 :::

--- a/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
+++ b/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
@@ -13,8 +13,8 @@ import Note from "@site/static/includes/dragonflysla-note.md"
 
 ## Compatibility overview
 
-Before migrating an external Redis database or an Aiven for Valkey database to
-Aiven for Dragonfly, review your current database setup.
+Before migrating an Aiven for Caching or Aiven for Valkey database to Aiven for
+Dragonfly, review your current database setup.
 
 - **Review database setup:** Examine the data structures, storage patterns, and
   configurations in your Aiven for Caching or Aiven for Valkey database. Identify any

--- a/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
+++ b/docs/products/dragonfly/howto/migrate-aiven-caching-df-console.md
@@ -99,8 +99,8 @@ To avoid conflicts during migration:
 :::
 
 :::note
-If the migration fails, investigate, resolve the issue, and restart the
-migration using **Start over**.
+If the migration fails, investigate, and resolve the issue. Click **Start over** in
+the Data migration window to restart the migration.
 :::
 
 ### Step 5: Close the connection and next steps

--- a/docs/products/dragonfly/howto/migrate-ext-redis-df-console.md
+++ b/docs/products/dragonfly/howto/migrate-ext-redis-df-console.md
@@ -1,11 +1,11 @@
 ---
-title: Migrate external Redis®* databases to Aiven for Dragonfly®
+title: Migrate external Redis®* or Valkey databases to Aiven for Dragonfly®
 ---
 
 import DragonflyLimitations from '@site/static/includes/dragonfly-limitations.md';
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-Migrate your external Redis® databases to Aiven for Dragonfly® using the Aiven Console's intuitive wizard for a smooth transition, enhancing your data storage and management capabilities.
+Migrate external Redis® or Valkey databases to Aiven for Dragonfly® using the Aiven Console migration tool.
 
 :::important
 The migration of databases from Google Cloud Memorystore for Redis is
@@ -18,36 +18,34 @@ import Note from "@site/static/includes/dragonflysla-note.md"
 
 ## Compatibility overview
 
-Before migrating an external Redis database to Aiven for Dragonfly,
-carefully review your current Redis setup.
+Before migrating an external Redis or Valkey database to Aiven for Dragonfly,
+review your current database setup.
 
--   **Review database setup:** Examine your Redis database's data
-    structures, storage patterns, and configurations. Identify any unique
-    features, custom settings, and specific configurations.
--   **API compatibility:** While Dragonfly closely mirrors Redis API
-    commands, there may be variations, especially with newer versions of
-    Redis. For detailed insights on command compatibility, refer to the
-    [Dragonfly API compatibility documentation](https://www.dragonflydb.io/docs/command-reference/compatibility).
+- **Review database setup:** Examine the data structures, storage patterns, and
+  configurations in your Redis or Valkey database. Identify any unique features,
+  custom settings, or specific configurations.
+- **API compatibility:** While Dragonfly closely mirrors Redis API commands, some
+  differences exist, especially with newer versions of Redis and Valkey.
+  For information on command compatibility, refer to the
+  [Dragonfly API compatibility documentation](https://www.dragonflydb.io/docs/command-reference/compatibility).
 
 ## Prerequisites
 
-Before starting the migration process, ensure you have the following:
+Before starting the migration process, ensure the following:
 
-- A target Aiven for Dragonfly service set up and ready. For setup
-  instructions, see to
+- A target Aiven for Dragonfly service set up and ready. For more information, see
   [Get started with Aiven for Dragonfly®](/docs/products/dragonfly/get-started).
 - Source database information:
   - **Hostname or connection string:** The public hostname,
     connection string, or IP address used to connect to the
     database, [accessible from the public Internet](/docs/platform/howto/public-access-in-vpc).
   - **Port:** The port number used for connecting to the database.
-  - **Username:** The username with appropriate permissions for
-    accessing the database data you intend to migrate.
+  - **Username:** The username with appropriate permissions to access the data for
+    migration.
   - **Password:** The password associated with the username.
-- Ensure firewall rules allow traffic between databases or turn them off
-  temporarily.
-- Using an SSL-secured connection for data transfer is highly
-  recommended during the source Redis database migration.
+- Firewall rules allow traffic between databases or temporarily disabled firewalls.
+- An SSL-secured connection is recommended for data transfer during the source
+  Redis database migration.
 - If the source Redis service is not publicly accessible, establish a
   VPC peering connection between the private networks. You need
   the VPC ID and cloud name for the migration.
@@ -62,29 +60,26 @@ migration.
 
 ## Database migration steps
 
-To migrate a Redis database to Aiven for Dragonfly:
+To migrate a Redis or Valkey database to Aiven for Dragonfly:
 
 1. Log in to the [Aiven Console](https://console.aiven.io/) and select
-   the Aiven for Dragonfly service for your Redis database migration.
-
-1. Go to **Service settings** from the sidebar.
-1. Scroll to the **Service management** section, and
-   click <ConsoleLabel name="actions"/> > **Import database**.
-   to initiate the import process.
+   the Aiven for Dragonfly service for your database migration.
+1. On the <ConsoleLabel name="overview"/> page, click
+   <ConsoleLabel name="service settings"/> in the sidebar.
+1. In the **Service management** section, click
+   <ConsoleLabel name="actions"/> > **Migrate database**.
 1. Follow the wizard to guide you through the database migration process.
 
 ### Step 1: Configure
 
-Start by reviewing the database migration configuration guidelines.
-Confirm compatibility with Dragonfly and:
+To begin the migration:
 
-1. Select **Import an external Redis database**.
-1. Click **Get started** to begin the migration.
+1. Select **Migrate an external Redis or Valkey database**.
+1. Click **Get started** to begin.
 
 ### Step 2: Validation
 
-Enter the required details to establish a connection with your source
-Redis database:
+Enter the required connection details for your source Redis or Valkey database:
 
 - **Hostname:** The public hostname, connection string, or IP address
   for the database connection.
@@ -94,61 +89,57 @@ Redis database:
 - Select the SSL encryption option for a secure migration and click
   **Run check** to verify the connection.
 
-:::important
-Address issues to ensure a smooth migration. The migration does not include all
-components of your Redis setup, such as user accounts, ACLs, specific settings,
-and ongoing commands or scripts. However, it does transfer all your database data and its contents.
+:::note
+Resolve any issues to ensure a smooth migration. Migration does not include all
+components of your Redis setup, such as user accounts, ACLs, specific settings, and
+ongoing commands or scripts. It does transfer all database data and contents.
 :::
 
 ### Step 3: Migration
 
-Once all the necessary checks have been completed successfully, you can
-proceed with the migration process:
+After completing validation, click **Start migration** to begin migrating data to
+Aiven for Dragonfly.
 
-- Click **Start migration** to initiate the data migration process to
-  Aiven for Dragonfly.
+While the migration is in progress:
 
-Keep in mind the following information when the migration is in progress:
+- Click **Close window** to close the migration wizard, and return later to monitor t
+  he migration status from the service <ConsoleLabel name="overview"/> page.
+- The migration duration depends on the size of your database. During migration, the
+  target database is read-only, and writing to the database is only possible after
+  stopping the migration.
+- Certain managed database features are disabled during migration.
+- To stop the migration, click **Stop migration**. Any data already transferred to
+  Aiven for Dragonfly is preserved.
 
-- You can close the migration wizard by clicking **Close window** and later
-  return to monitor the migration status from the service overview
-  page.
-- The duration of the migration depends on the size of your database.
-  During migration, the target database are in a read-only state.
-  Writing to the database is only possible once the migration is
-  stopped.
-- Certain managed database features are disabled.
-- If needed, halt the migration by selecting **Stop migration**.
-  Data already transferred to Aiven for Dragonfly is preserved.
+:::note
+To avoid conflicts during migration:
 
-:::warning
-
-- Stopping this migration immediately halts the ongoing
-  replication process, preserving the data already transferred to
-  Aiven. You can initiate a new database migration at any time in the future.
-  This migration overwrites the entire database and its contents on Aiven
-  with the latest data from the source.
-- Avoid actions that can disrupt the replication process, such as
-  changing replication configurations or firewall settings.
+- Avoid actions that may disrupt replication, such as changing replication settings,
+  modifying firewall rules, or altering trusted sources.
+- Stopping migration halts replication immediately, but any transferred data is
+  preserved. Starting a new migration overwrites the entire database with the latest
+  data from the source.
 
 :::
 
 ### Step 4: Close the connection and next steps
 
-Once the migration is complete:
+Once migration completes:
 
-1. Click **Close connection** to end the replication.
-1. Click **Keep replicating** to maintain ongoing data synchronization.
+- Click **Stop replication** if no further synchronization is required and
+  you are ready to switch to Aiven for Dragonfly after thoroughly testing the service.
+- Click **Keep replicating** to maintain ongoing data synchronization if further
+  testing or syncing with the source database is needed.
 
 :::warning
-System updates or any configuration changes during replication can
-restart nodes and trigger a new database migration. Before making any
-modifications, confirm that replication is either complete or stopped.
+Avoid system updates or configuration changes during active replication, as these
+can restart nodes and trigger a new database migration. Ensure replication is complete
+or stopped before making any modifications.
 :::
 
 :::note
-When replication mode is active, Aiven for Dragonfly ensures your data remains in sync,
-with continuous synchronization of new writes from the source database.
+When replication mode is active, Aiven for Dragonfly continuously synchronizes new
+writes from the source database, ensuring your data remains up to date.
 :::
 
 ## Related pages

--- a/docs/products/dragonfly/howto/migrate-ext-redis-df-console.md
+++ b/docs/products/dragonfly/howto/migrate-ext-redis-df-console.md
@@ -1,5 +1,6 @@
 ---
 title: Migrate external Redis®* or Valkey databases to Aiven for Dragonfly®
+sidebar_label: Migrate external Redis®* or Valkey to Dragonfly
 ---
 
 import DragonflyLimitations from '@site/static/includes/dragonfly-limitations.md';
@@ -16,7 +17,7 @@ import Note from "@site/static/includes/dragonflysla-note.md"
 
 <Note/>
 
-## Compatibility overview
+## Compatibility check
 
 Before migrating an external Redis or Valkey database to Aiven for Dragonfly,
 review your current database setup.
@@ -33,7 +34,7 @@ review your current database setup.
 
 Before starting the migration process, ensure the following:
 
-- A target Aiven for Dragonfly service set up and ready. For more information, see
+- Confirm a target Aiven for Dragonfly service set up and ready. For more information, see
   [Get started with Aiven for Dragonfly®](/docs/products/dragonfly/get-started).
 - Source database information:
   - **Hostname or connection string:** The public hostname,
@@ -102,8 +103,8 @@ Aiven for Dragonfly.
 
 While the migration is in progress:
 
-- Click **Close window** to close the migration wizard, and return later to monitor t
-  he migration status from the service <ConsoleLabel name="overview"/> page.
+- Click **Close window** to close the migration wizard, and return later to monitor the
+  migration status from the service <ConsoleLabel name="overview"/> page.
 - The migration duration depends on the size of your database. During migration, the
   target database is read-only, and writing to the database is only possible after
   stopping the migration.

--- a/static/includes/dragonfly-limitations.md
+++ b/static/includes/dragonfly-limitations.md
@@ -1,12 +1,10 @@
-## Migration limitations at General Availability (GA)
+## Migration limitations for General Availability (GA)
 
 As Aiven for Dragonfly moves to General Availability (GA), the focus is on delivering
-the most valuable features to you, guided by your feedback. During the initial phase of
-GA, automatic migration of Users, Access Control Lists (ACLs), and service configurations
-from Redis to Dragonflyare not included.
+valuable features on user feedback. During the initial GA phase, automatic migration of
+users, access control lists (ACLs), and service configurations from Redis to Dragonfly
+is not supported.
 
-What this means:
-
-- **Service configurations:** If you’ve customized your Redis service with
-  specific settings, you must manually apply these settings to Dragonfly. Automatic
-  transfer of these custom configurations is not available during the initial phase of GA.
+If you customized your Aiven for Caching or Aiven for Valkey service with specific
+settings, manually apply these settings to Aiven for Dragonfly. Automatic transfer of
+custom configurations isn’t available during the initial GA phase.

--- a/static/includes/dragonfly-limitations.md
+++ b/static/includes/dragonfly-limitations.md
@@ -1,10 +1,8 @@
-## Migration limitations for General Availability (GA)
+## Migration limitations
 
-As Aiven for Dragonfly moves to General Availability (GA), the focus is on delivering
-valuable features on user feedback. During the initial GA phase, automatic migration of
-users, access control lists (ACLs), and service configurations from Redis to Dragonfly
-is not supported.
+Aiven for Dragonfly does not support automatic migration of users, access control lists
+(ACLs), or service configurations from Redis or Valkey.
 
 If you customized your Aiven for Caching or Aiven for Valkey service with specific
-settings, manually apply these settings to Aiven for Dragonfly. Automatic transfer of
-custom configurations isn’t available during the initial GA phase.
+settings, manually apply these configurations to Aiven for Dragonfly. Automatic transfer
+of custom configurations is unavailable due to differences in service configurations.


### PR DESCRIPTION
## Describe your changes
Add Valkey to migration documentation and update migration steps for clarity.

[MA-3062](https://aiven.atlassian.net/browse/MA-3062)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.


[MA-3062]: https://aiven.atlassian.net/browse/MA-3062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ