### PR TITLE
update: add instructions for getting resource IDs

### DIFF
--- a/docs/platform/reference/get-resource-IDs.md
+++ b/docs/platform/reference/get-resource-IDs.md
@@ -1,0 +1,51 @@
+---
+title: Get resource IDs
+---
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
+
+Resource IDs like organzation ID or user ID can be useful for working with the developer tools. You can get the IDs for resources in the [Aiven Console](https://console.aiven.io/).
+
+To access the IDs in the **Admin** part of the Console, you must be a
+[super admin](/docs/platform/howto/make-super-admin).
+
+## Get an organization ID
+
+Go to <ConsoleLabel name="userinformation"/> > <ConsoleLabel name="Organizations"/>.
+
+You can see the ID for each organization you were invited to or are a member of.
+
+## Get an organizational unit ID
+
+1. Click **Admin**.
+1. Click <ConsoleLabel name="organization"/>.
+1. In the list of **Organizational units**, get the **ID**.
+
+## Get a user ID
+
+1. Click **Admin**.
+1. Click <ConsoleLabel name="users"/>.
+1. Get the user ID from the URL. User IDs start with `u` and are usually at the
+   end of the URL. For example, the user ID is `u1abc2345678` in the following URL:
+   `https://console.aiven.io/account/a1f23bcdef4a/admin/users/u1abc2345678`
+
+## Get an application user ID
+
+1. Click **Admin**.
+1. Click <ConsoleLabel name="applicationusers"/>.
+1. Find the application user and get its **User ID**.
+
+## Get a group ID
+
+1. Click **Admin**.
+1. Click <ConsoleLabel name="groups"/>.
+1. Get the group ID from the URL. Group IDs start with `ug` and are usually at the
+   end of the URL. For example, the user ID is `ug1a2bc3d45e6` in the following URL:
+   `https://console.aiven.io/account/a1f23bcdef4a/admin/groups/ug1a2bc3d45e6`
+
+## Get a billing group ID
+
+1. Click **Billing**.
+1. Click <ConsoleLabel name="billinggroups"/>.
+
+The ID is under the billing group names.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -287,6 +287,7 @@ const sidebars: SidebarsConfig = {
           ],
         },
         'platform/reference/eol-for-major-versions',
+        'platform/reference/get-resource-IDs',
       ],
     },
     {

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -245,6 +245,13 @@ export default function ConsoleLabel({name}): ReactElement {
           <ConsoleIconWrapper icon={ConsoleIcons.bankAccount} /> <b>Billing</b>
         </>
       );
+    case 'billinggroups':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.applications} />{' '}
+          <b>Billing groups</b>
+        </>
+      );
     case 'acl':
       return (
         <>
@@ -359,15 +366,16 @@ export default function ConsoleLabel({name}): ReactElement {
     case 'deletedatabase':
       return (
         <>
-          <ConsoleIconWrapper icon={ConsoleIcons.trash} /> <b>Delete database</b>
+          <ConsoleIconWrapper icon={ConsoleIcons.trash} />{' '}
+          <b>Delete database</b>
         </>
       );
-      case 'deletetable':
-        return (
-          <>
-            <ConsoleIconWrapper icon={ConsoleIcons.trash} /> <b>Delete table</b>
-          </>
-        );
+    case 'deletetable':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.trash} /> <b>Delete table</b>
+        </>
+      );
     case 'edit':
       return (
         <>


### PR DESCRIPTION
## Describe your changes
IDs like organization ID, user ID, etc., are often needed by customers for working with dev tools like Terraform. In addition, having these IDs can make it easier for support to investigate an issue. At the moment, not all IDs are easily found in Console, but there are still ways to get them.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](styleguide.md).
- [X] My links start with `/docs/`.
