### PR TITLE
update(aws-privatelink): add mirrormaker as not supported for aws privatelink

### DIFF
--- a/docs/platform/howto/use-aws-privatelinks.md
+++ b/docs/platform/howto/use-aws-privatelinks.md
@@ -28,8 +28,17 @@ To set up AWS PrivateLink, use the
 [Aiven CLI](/docs/tools/cli). You also
 need the AWS console or CLI to create a VPC endpoint.
 
-**Note:** Aiven for Apache Cassandra® and Aiven for M3 services do not
-currently support AWS PrivateLink.
+:::note
+AWS PrivateLink is not supported in:
+
+- Aiven for AlloyDB Omni
+- Aiven for Apache Cassandra®
+- Aiven for Apache Flink®
+- Aiven for Apache Kafka® MirrorMaker 2
+- Aiven for M3
+- Aiven for Metrics
+
+:::
 
 1.  Create an AWS PrivateLink resource on the Aiven service.
 


### PR DESCRIPTION
https://aiven.atlassian.net/browse/MILK-367

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
