### PR TITLE
add: instructions for downloading invoices

### DIFF
--- a/docs/platform/howto/download-invoices.md
+++ b/docs/platform/howto/download-invoices.md
@@ -1,0 +1,15 @@
+---
+title: Download invoices
+---
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
+
+You can download monthly invoices from the Aiven Console in PDF or CSV format.
+
+:::info
+You must be a [super admin](/docs/platform/howto/make-super-admin) to access this feature.
+:::
+
+1. Click **Billing**.
+1. Click **Invoices**.
+1. Click <ConsoleLabel name="Actions"/> > **Download PDF** or **Download CSV**.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -106,6 +106,7 @@ const sidebars: SidebarsConfig = {
                 'platform/howto/billing-assign-projects',
               ],
             },
+            'platform/howto/download-invoices',
           ],
         },
         {


### PR DESCRIPTION
## Describe your changes
Adds instructions for downloading invoices in the Console.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](styleguide.md).
- [X] My links start with `/docs/`.
