### PR TITLE
add(clickhouse kafka): cross link btw clickhouse sink connector and kafka engine integration

### DIFF
--- a/docs/products/clickhouse/howto/integrate-kafka.md
+++ b/docs/products/clickhouse/howto/integrate-kafka.md
@@ -2,7 +2,14 @@
 title: Connect Apache Kafka® to Aiven for ClickHouse®
 ---
 
-You can integrate Aiven for ClickHouse® with either *Aiven for Apache Kafka®* service located in the same project, or *an external Apache Kafka endpoint*.
+You can integrate Aiven for ClickHouse® with either Aiven for Apache Kafka® service located in the same project, or an external Apache Kafka endpoint.
+
+:::tip
+To deliver data from Apache Kafka® topics to a ClickHouse database for efficient querying
+and analysis,
+[create a ClickHouse sink connector](/docs/products/kafka/kafka-connect/howto/clickhouse-sink-connector).
+:::
+
 A single Aiven for ClickHouse instance can connect to
 multiple Kafka clusters with different authentication mechanism and
 credentials.

--- a/docs/products/kafka/kafka-connect/howto/clickhouse-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/clickhouse-sink-connector.md
@@ -8,6 +8,11 @@ import ConsoleLabel from "@site/src/components/ConsoleIcons";
 
 The ClickHouse sink connector delivers data from Apache Kafka® topics to a ClickHouse database for efficient querying and analysis.
 
+:::tip
+You can also
+[connect Aiven for ClickHouse® with Apache Kafka® or Aiven for Apache Kafka® using ClickHouse Kafka Engine](/docs/products/clickhouse/howto/integrate-kafka).
+:::
+
 ## Prerequisites
 
 Before you begin, ensure that you have the following:


### PR DESCRIPTION
https://aiven.atlassian.net/browse/DDB-1374

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
