### PR TITLE
update: correct the loc of redis_persistence setting

### DIFF
--- a/docs/platform/concepts/service_backups.md
+++ b/docs/platform/concepts/service_backups.md
@@ -280,8 +280,9 @@ data persistence using Redis Database Backup (RDB).
 
 #### Persistence settings
 
-You can configure the `redis_persistence` settings from the **Configure backup settings**
-section on your <ConsoleLabel name="Backups"/> page in the [Aiven Console](https://console.aiven.io).
+You can configure the `redis_persistence` settings from <ConsoleLabel name="actions"/> >
+the **Configure backup settings** section on your <ConsoleLabel name="Backups"/> page
+in the [Aiven Console](https://console.aiven.io).
 
 - **Enabled (`rdb`)**: When you set `redis_persistence` to `rdb`, Aiven for Caching
   performs RDB dumps every 10 minutes whenever a key changes. These dumps provide

--- a/docs/platform/concepts/service_backups.md
+++ b/docs/platform/concepts/service_backups.md
@@ -280,8 +280,8 @@ data persistence using Redis Database Backup (RDB).
 
 #### Persistence settings
 
-You can configure the `redis_persistence` settings from the **Advanced configuration**
-section on your <ConsoleLabel name="service settings"/> page in the [Aiven Console](https://console.aiven.io).
+You can configure the `redis_persistence` settings from the **Configure backup settings**
+section on your <ConsoleLabel name="Backups"/> page in the [Aiven Console](https://console.aiven.io).
 
 - **Enabled (`rdb`)**: When you set `redis_persistence` to `rdb`, Aiven for Caching
   performs RDB dumps every 10 minutes whenever a key changes. These dumps provide


### PR DESCRIPTION
## Describe your changes
The parameter is in "Backups -> Configure backup settings" not "Service Settings-> Advanced configurations"

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
