### PR TITLE
update: replace sales team address with billing team's email

### DIFF
--- a/docs/platform/concepts/tax-information.md
+++ b/docs/platform/concepts/tax-information.md
@@ -25,7 +25,7 @@ According to the tax treaty between Finland and the United States,
 no direct tax needs to be withheld from payments by American entities to
 Aiven. Although a W-8 form is not required to confirm this status,
 we're happy to provide a W-8BEN-E form describing Aiven's status.
-Contact the [sales team](mailto:sales@aiven.io) to request one.
+Contact [billing@aiven.io](mailto:billing@aiven.io) to request one.
 
 Aiven charges American sales taxes in several states in the United-States. The
 applicability of these taxes depends on various factors, such as the

--- a/docs/platform/howto/payment-methods.md
+++ b/docs/platform/howto/payment-methods.md
@@ -37,4 +37,4 @@ can also be sent in the following currencies:
 
 Invoices in different currencies are created based on the exchange
 rates on the date of the invoice. To switch from credit card charges to bank transfers,
-contact [sales@aiven.io](mailto:sales@aiven.io) to request invoice billing.
+contact [billing@aiven.io](mailto:billing@aiven.io) to request invoice billing.


### PR DESCRIPTION
## Describe your changes
Change references to the sales team email address to the billing team's email for billing requests.

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
