### PR TITLE
update: remove LA tag from Kafka Connect with PostgreSQL integration

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/kafka-connect-debezium-tls-pg.md
+++ b/docs/products/kafka/kafka-connect/howto/kafka-connect-debezium-tls-pg.md
@@ -1,15 +1,11 @@
 ---
-title: Integrate Apache Kafka Connect with PostgreSQL using Debezium and mutual TLS
+title: Integrate Aiven for Apache Kafka® Connect with PostgreSQL using Debezium with mutual TLS
 ---
 
-Learn how to set up Apache Kafka Connect with PostgreSQL and Debezium using mutual TLS for secure data synchronization.
+Integrate Aiven for Apache Kafka Connect with PostgreSQL using Debezium with mutual TLS (mTLS) to enhance security with mutual authentication.
 
-## Overview
-
-Integrating Apache Kafka Connect with PostgreSQL using Debezium and mutual TLS (mTLS)
-enhances data security by enforcing mutual authentication between the client and server.
-The configuration process establishes a secure and efficient data synchronization channel
-between Apache Kafka Connect and a PostgreSQL database.
+This configuration establishes a secure and efficient data synchronization channel
+between Aiven for Apache Kafka Connect and a PostgreSQL database.
 
 ## Prerequisites
 

--- a/docs/products/kafka/kafka-connect/howto/kafka-connect-debezium-tls-pg.md
+++ b/docs/products/kafka/kafka-connect/howto/kafka-connect-debezium-tls-pg.md
@@ -1,6 +1,5 @@
 ---
 title: Integrate Apache Kafka Connect with PostgreSQL using Debezium and mutual TLS
-limited: true
 ---
 
 Learn how to set up Apache Kafka Connect with PostgreSQL and Debezium using mutual TLS for secure data synchronization.
@@ -86,7 +85,7 @@ your actual environment values in the provided code snippets:
 | `<integration_endpoint_id>`   | ID of the created PostgreSQL endpoint              |
 | `<connector_config>`          | JSON configuration for Debezium connector          |
 
-## ## Configure the integration
+## Configure the integration
 
 1. Verify your existing Aiven for Apache Kafka service is active and accessible.
    If you don't have one, create an Apache Kafka cluster using this command:
@@ -215,7 +214,7 @@ your actual environment values in the provided code snippets:
 
 ## Verification
 
-After successfully configuring the setup, verify the following:
+Confirm the following after completing the setup:
 
 1. Apache Kafka Connect establishes a secure SSL connection with the PostgreSQL database.
 1. Apache Kafka topics exist as expected, whether created automatically or manually.
@@ -223,8 +222,6 @@ After successfully configuring the setup, verify the following:
    `{connector_name}.{database_name}.{table_name}`.
 
 ## Limitations
-
-Consider the following limitations:
 
 - The process of delivering SSL keys to Apache Kafka Connect is asynchronous.
   Therefore, a delay of approximately five minutes may occur from the creation of


### PR DESCRIPTION
## Describe your changes
Remove LA [EC-224](https://aiven.atlassian.net/browse/EC-224)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.


[EC-224]: https://aiven.atlassian.net/browse/EC-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ