### PR TITLE
update: align Terraform and Kubernetes naming with brand guidelines

### DIFF
--- a/.github/vale/styles/Aiven/Headings.yml
+++ b/.github/vale/styles/Aiven/Headings.yml
@@ -9,8 +9,11 @@ exceptions:
   - Active Directory
   - Aiven
   - Aiven Console
+  - Aiven Kubernetes Operator
+  - Aiven Operator for Kubernetes
   - Aiven Provider
   - Aiven Provider for Terraform
+  - Aiven Terraform Provider
   - Amazon
   - Amazon Aurora
   - Amazon Web Services

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -227,8 +227,8 @@ Add users to groups to streamline access management to your Aiven projects and s
       to="/docs/platform/howto/manage-application-users"
       iconName="clipboard"
       title="Create application users"
-      description="Use application users to access the API,
-      Terraform Provider, CLI, and Aiven Operator."
+      description="Use application users to access the Aiven API,
+      Terraform Provider, CLI, and Kubernetes Operator."
     />
     <Card
       to="/docs/platform/howto/manage-vpc-peering"
@@ -270,7 +270,7 @@ Start deploying services in your project to stream, store, or analyze your data.
 
 See examples of services and integrations using code samples for the
 [Aiven Provider for Terraform](/docs/tools/terraform) or
-[Aiven Operator for Kubernetes](/docs/tools/kubernetes).
+[Aiven Operator for Kubernetes®](/docs/tools/kubernetes).
 
 <GridContainer columns={2}>
      <Card
@@ -281,7 +281,7 @@ See examples of services and integrations using code samples for the
     <Card
       to="https://aiven.github.io/aiven-operator/resources/project.html"
       iconComponent={K8sIcon}
-      title="Aiven Operator for Kubernetes examples"
+      title="Aiven Operator for Kubernetes® examples"
     />
 </GridContainer>
 

--- a/docs/platform/concepts/application-users.md
+++ b/docs/platform/concepts/application-users.md
@@ -4,7 +4,7 @@ title: Application users
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-An application user is a type of user that provides programmatic access to the Aiven platform and services through the [Aiven API](/docs/tools/api.md), [CLI](/docs/tools/), [Terraform](/docs/tools/terraform.md), and [Kubernetes](/docs/tools/kubernetes.md). They're intended for non-human users that need to access Aiven.
+An application user is a type of user that provides programmatic access to the Aiven platform and services through the [Aiven API](/docs/tools/api.md), [CLI](/docs/tools/), [Aiven Terraform Provider](/docs/tools/terraform.md), and [Aiven Kubernetes Operator](/docs/tools/kubernetes). They're intended for non-human users that need to access Aiven.
 
 :::info
 You must be a [super admin](/docs/platform/howto/make-super-admin) to access this feature.
@@ -32,7 +32,7 @@ following are some suggested best practices for using Aiven application users.
 
 Try to create a different application user for each tool or application. For example, if
 you have an application that needs to connect to services in one of your projects and
-you are using Terraform in the same project, create two application users. Use
+you're using Aiven Terraform Provider in the same project, create two application users. Use
 the description field for each user to clearly indicate what it's used for.
 
 This helps you manage the lifecycle of the users and ensure the access permissions are

--- a/docs/platform/concepts/enhanced-compliance-env.md
+++ b/docs/platform/concepts/enhanced-compliance-env.md
@@ -41,7 +41,7 @@ accordingly.
 ## Similarities to a standard environment
 
 In many ways, an ECE is the same as a standard Aiven deployment.
-Aiven's tooling, such as [CLI](/docs/tools/cli) and [Terraform](/docs/tools/terraform),
+Aiven's tooling, such as [Aiven CLI](/docs/tools/cli) and [Aiven Terraform Provider](/docs/tools/terraform),
 interact with ECEs seamlessly, you will still be able to take advantage of Aiven's
 service integrations, and you can access the environment
 through VPC peering or Privatelink (on AWS or Azure).

--- a/docs/platform/concepts/free-plan.md
+++ b/docs/platform/concepts/free-plan.md
@@ -25,8 +25,8 @@ Free plans include:
 -   1 GB RAM
 -   For PostgreSQL and MySQL: 5 GB disk storage
 -   For Valkey: `maxmemory` set to 50%
--   Management via our web console, CLI, API, Terraform provider, or
-    Kubernetes® operator
+-   Management through the Aiven Console, CLI, API, Terraform Provider, or
+    Kubernetes Operator
 -   Monitoring for metrics and logs
 -   Backups
 -   Integrations between different Aiven services including free, paid,

--- a/docs/platform/concepts/free-trial.md
+++ b/docs/platform/concepts/free-trial.md
@@ -2,7 +2,7 @@
 title: 30-day trials
 ---
 
-Aiven offers a free trial for 30 days to explore the platform - including the [Aiven Console](/docs/tools/aiven-console), [API](/docs/tools/api), [CLI](/docs/tools/cli), [Aiven Terraform provider](/docs/tools/terraform), and [Aiven Operator for Kubernetes](/docs/tools/kubernetes) - and the [Aiven services](/docs/products/services). You don't need a credit card to sign up.
+Aiven offers a free trial for 30 days to explore the Aiven Data and AI Platform, including the [Aiven Console](/docs/tools/aiven-console), [API](/docs/tools/api), [CLI](/docs/tools/cli), [Aiven Provider for Terraform](/docs/tools/terraform), [Aiven Operator for Kubernetes®](/docs/tools/kubernetes), and the [Aiven services](/docs/products/services). You don't need a credit card to sign up.
 
 ## Trial features and limitations
 

--- a/docs/platform/concepts/permissions.md
+++ b/docs/platform/concepts/permissions.md
@@ -40,7 +40,7 @@ they are also a [super admin](/docs/platform/howto/make-super-admin).
 
 :::important
 Permissions are not yet fully supported in the Aiven Console. They are intended for
-use with the Aiven API, Aiven Provider for Terraform, and Aiven Operator for Kubernetes.
+use with the Aiven API, Aiven Provider for Terraform, and Aiven Operator for Kubernetes®.
 :::
 
 You can grant the following permissions to principals. The actions listed for each

--- a/docs/platform/howto/byoc/create-custom-cloud.md
+++ b/docs/platform/howto/byoc/create-custom-cloud.md
@@ -100,7 +100,7 @@ you informed on the progress.
 -   You have an active account with your cloud provider.
 -   Depending on the dev tool to use for creating a custom cloud, you have:
     - Access to the [Aiven Console](https://console.aiven.io/) or
-    - [Aiven CLI client](/docs/tools/cli) installed
+    - [Aiven CLI](/docs/tools/cli) installed
 -   You have the [super admin](/docs/platform/howto/make-super-admin) role in your Aiven
     organization.
 -   You have Terraform installed.

--- a/docs/platform/howto/disk-autoscaler.md
+++ b/docs/platform/howto/disk-autoscaler.md
@@ -78,8 +78,8 @@ listed on [Aiven Plans and Pricing](https://aiven.io/pricing?product=kafka).
 - Disk autoscaling works on fully running services only and cannot happen during
   maintenance updates.
 - If you change disk space manually, you might delay an autoscaling process.
-- When using Aiven Autoscaler, don't try to control your disk space with Terraform
-  so that you avoid potential conflicts between those two tools.
+- When using Aiven Autoscaler, don't try to control your disk space with the Aiven
+  Terraform Provider to avoid potential conflicts between those two tools.
 - Disk added for extra storage is slower than the original disk until service maintenance
   is applied. This may have performance implications depending on the load on your service.
   Dynamically adding disk (either manually or in an automated fashion) may not be

--- a/docs/platform/howto/migrate-services-vpc.md
+++ b/docs/platform/howto/migrate-services-vpc.md
@@ -52,9 +52,9 @@ up correctly.
 ## Initial setup
 
 Before you begin, make sure you have created your VPC and that peering
-is active. Automating this process with Terraform is an option. For
+is active. Automating this process with the Aiven Terraform Provider is an option. For
 guidance, refer to
-[setting up VPC peering](/docs/platform/howto/manage-vpc-peering#platform_howto_setup_vpc_peering) on the Aiven platform.
+[setting up VPC peering](/docs/platform/howto/manage-vpc-peering#platform_howto_setup_vpc_peering) on the Aiven Platform.
 
 To illustrate the process, we will use the `google-us-east1` VPC as a
 reference. Ensure both your VPC and its peering connection are in an

--- a/docs/platform/howto/set-authentication-policies.md
+++ b/docs/platform/howto/set-authentication-policies.md
@@ -53,8 +53,9 @@ the Aiven API. When you turn off personal tokens, managed users can't create
 personal tokens. Non-managed users can still create personal tokens, but they can't use
 them to access the organization's resources.
 
-To regularly manage your resources programmatically with the API, CLI, Terraform,
-or other applications, it's best to create an [application user](/docs/platform/howto/manage-application-users) with its own tokens.
+To regularly manage your resources programmatically with the Aiven API, CLI,
+Terraform Provider, or other applications, it's best to create an
+[application user](/docs/platform/howto/manage-application-users) with its own tokens.
 
 Personal tokens are generated with the authentication method that the user logged in with.
 Tokens are linked to the authentication method they are created with. You can ensure that

--- a/docs/platform/reference/eol-for-major-versions.md
+++ b/docs/platform/reference/eol-for-major-versions.md
@@ -159,7 +159,7 @@ tool to test the version upgrade before upgrading their production services.
 
 ## Aiven tools
 
-Aiven offers multiple tools for interacting with the Aiven platform and
+Aiven offers multiple tools for interacting with the Aiven Platform and
 services. These include the Aiven CLI, the Aiven Provider for Terraform,
 and the Aiven Operator for Kubernetes®.
 
@@ -188,7 +188,7 @@ or bug fixes after the EOL date.
 | 3.x     | 2023-12-31      |
 | 4.x     | To be announced |
 
-### Aiven Operator for Kubernetes
+### Aiven Operator for Kubernetes®
 
 | Version | Aiven EOL       |
 | ------- | --------------- |

--- a/docs/products/caching.md
+++ b/docs/products/caching.md
@@ -38,7 +38,7 @@ use:
 -   **DevOps-friendly management and development:** Manage your caching solution
     using [Aiven Console](https://console.aiven.io/),
     [Aiven CLI](https://github.com/aiven/aiven-client), or
-    [Terraform](/docs/tools/terraform) .
+    [Aiven Provider for Terraform](/docs/tools/terraform) .
     Features like scaling, forking, and upgrading your Aiven for Caching cluster
     are simple and efficient. Compatible with open-source software, it integrates
     with your existing applications and facilitates cloud and regional migrations.

--- a/docs/products/cassandra/get-started.md
+++ b/docs/products/cassandra/get-started.md
@@ -114,7 +114,7 @@ Create an Aiven for Apache Cassandra service using the Aiven Provider for Terraf
 The resource can stay in the `REBUILDING` state for a couple of minutes. Once the state
 changes to `RUNNING`, you are ready to access it.
 </TabItem>
-<TabItem value="3" label="K8s">
+<TabItem value="3" label="Kubernetes">
 Create an Aiven for Apache Cassandra service using the Aiven Operator for Kubernetes.
 
 1. [Get authenticated and authorized](https://aiven.github.io/aiven-operator/authentication.html).
@@ -252,7 +252,7 @@ See attributes available for the `aiven_cassandra` resource in
 The resource can stay in the `REBUILDING` state for a couple of minutes. Once the state
 changes to `RUNNING`, you are ready to access it.
 </TabItem>
-<TabItem value="3" label="K8s">
+<TabItem value="3" label="Kubernetes">
 :::note
 Your changes can force the recreation of the `aiven_cassandra` resource.
 :::

--- a/docs/products/clickhouse/get-started.md
+++ b/docs/products/clickhouse/get-started.md
@@ -110,7 +110,7 @@ Depending on a dev tool to use for working with Aiven for ClickHouse:
    ```
 
 </TabItem>
-<TabItem value="3" label="K8s">
+<TabItem value="3" label="Kubernetes">
 
 Create an Aiven for ClickHouse service using the Aiven Operator for Kubernetes.
 
@@ -250,7 +250,7 @@ For all the attributes available for the `aiven_clickhouse` resource, see
 1. Run `terraform plan` > `terraform apply --auto-approve`.
 
 </TabItem>
-<TabItem value="3" label="K8s">
+<TabItem value="3" label="Kubernetes">
 1. Update file `example.yaml`:
 
    - Add `service_log: true` and `terminationProtection: true`.

--- a/docs/products/flink/howto/upgrade-flink-version.md
+++ b/docs/products/flink/howto/upgrade-flink-version.md
@@ -22,8 +22,8 @@ receiving support and take advantage of the latest enhancements.
 ### Step 1: Create an Aiven for Apache Flink service
 
 1. Create an Aiven for Apache Flink service using the
-   [Aiven Console](https://console.aiven.io/), [Aiven Client](/docs/tools/cli/service/flink),
-   or [Terraform](/docs/tools/terraform) (provider version 4.19.0).
+   [Aiven Console](https://console.aiven.io/), [Aiven CLI](/docs/tools/cli/service/flink),
+   or [Aiven Provider for Terraform](/docs/tools/terraform) (provider version 4.19.0).
 1. Select Apache Flink 1.19 as the deployment version for the
    Aiven for Apache Flink service.
 

--- a/docs/products/grafana.md
+++ b/docs/products/grafana.md
@@ -60,8 +60,7 @@ performance.
 ### Automation
 
 You can also automate the process of building, configuring, and managing
-Aiven services by including your Aiven infrastructure in your
-[Terraform](/docs/tools/terraform/get-started) tooling.
+Aiven services using the [Aiven Provider for Terraform](/docs/tools/terraform/get-started).
 
 ## Related pages
 

--- a/docs/products/grafana/concepts/grafana-features.md
+++ b/docs/products/grafana/concepts/grafana-features.md
@@ -60,5 +60,4 @@ performance.
 ## Automation
 
 You can also automate the process of building, configuring, and managing
-Aiven services by including your Aiven infrastructure in your
-[Terraform](/docs/tools/terraform/get-started) tooling.
+Aiven services using the [Aiven Provider for Terraform](/docs/tools/terraform/get-started).

--- a/docs/products/kafka/howto/enable-follower-fetching.md
+++ b/docs/products/kafka/howto/enable-follower-fetching.md
@@ -96,7 +96,7 @@ Parameters:
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
-1. Add the Aiven Terraform provider to the `required_providers` block in your Terraform
+1. Add the Aiven Terraform Provider to the `required_providers` block in your Terraform
    configuration:
 
    ```hcl

--- a/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-aws-secrets-manager.md
@@ -12,7 +12,7 @@ Configure and use [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanag
 - [Aiven for Apache Kafka service with Apache Kafka Connect](/docs/products/kafka/kafka-connect/get-started)
   set up and running.
 - [Aiven CLI](/docs/tools/cli).
-- [Aiven Terraform provider](https://registry.terraform.io/providers/aiven/aiven/latest/docs)
+- [Aiven Terraform Provider](https://registry.terraform.io/providers/aiven/aiven/latest/docs)
   installed.
 - [AWS Secrets Manager access key and secret key](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access.html).
 
@@ -243,7 +243,7 @@ Parameters:
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
-Configure a JDBC sink connector using Terraform with secrets referenced from
+Configure a JDBC sink connector using the Aiven Terraform Provider with secrets referenced from
 AWS Secrets Manager. Add this configuration to your `main.tf` file, or optionally
 create a dedicated `connectors.tf` file for managing Apache Kafka connectors:
 
@@ -358,7 +358,7 @@ Parameters:
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
-Configure a JDBC source connector using Terraform with secrets referenced from
+Configure a JDBC source connector using the Aiven Terraform Provider with secrets referenced from
 AWS Secrets Manager. Add this configuration to your `main.tf` file, or optionally
 create a dedicated `connectors.tf` file for managing Apache Kafka connectors:
 

--- a/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
+++ b/docs/products/kafka/kafka-connect/howto/configure-hashicorp-vault.md
@@ -13,7 +13,7 @@ Configure and use [HashiCorp Vault](https://developer.hashicorp.com/vault/docs) 
 - [Aiven for Apache Kafka service with Apache Kafka Connect](/docs/products/kafka/kafka-connect/get-started)
   set up and running.
 - [Aiven CLI](/docs/tools/cli).
-- [Aiven Terraform provider](https://registry.terraform.io/providers/aiven/aiven/latest/docs)
+- [Aiven Terraform Provider](https://registry.terraform.io/providers/aiven/aiven/latest/docs)
   installed.
 - [HashiCorp Vault address and token](https://developer.hashicorp.com/vault/docs/concepts/tokens).
 
@@ -70,7 +70,7 @@ Parameters:
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
-Configure HashiCorp Vault using Terraform. Add this configuration to your `main.tf` file,
+Configure HashiCorp Vault using the Aiven Terraform Provider. Add this configuration to your `main.tf` file,
 or optionally create a dedicated `vault.tf` file for managing secret providers:
 
 1. Create the `main.tf` file for your resources:
@@ -221,7 +221,7 @@ Parameters:
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
-Configure a JDBC sink connector using Terraform with secrets referenced
+Configure a JDBC sink connector using the Aiven Terraform Provider with secrets referenced
 from HashiCorp Vault. Add this configuration to your `main.tf` file, or optionally create
 a dedicated `vault.tf` file for managing secret providers:
 
@@ -334,7 +334,7 @@ Parameters:
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
-Configure a JDBC source connector using Terraform with secrets referenced from
+Configure a JDBC source connector using the Aiven Terraform Provider with secrets referenced from
 HashiCorp Vault. Add this configuration to your `main.tf` file, or optionally
 create a dedicated `connectors.tf` file for managing Apache Kafka connectors:
 

--- a/docs/products/kafka/karapace/howto/manage-schema-registry-authorization.md
+++ b/docs/products/kafka/karapace/howto/manage-schema-registry-authorization.md
@@ -28,7 +28,7 @@ examples, see
 ## Manage resources via Terraform
 
 Additionally, the
-[Aiven Terraform provider](/docs/tools/terraform) supports managing Karapace schema registry authorization ACL
+[Aiven Terraform Provider](/docs/tools/terraform) supports managing Karapace schema registry authorization ACL
 entries with the `aiven_kafka_schema_registry_acl` resource. For more
 information, see the [resource
 documentation](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/kafka_schema_registry_acl).

--- a/docs/products/opensearch/concepts/opensearch-security-considerations.md
+++ b/docs/products/opensearch/concepts/opensearch-security-considerations.md
@@ -27,7 +27,7 @@ will occur:
     -   [ServiceOpenSearchAclGet](https://api.aiven.io/doc/#tag/Service:_OpenSearch/operation/ServiceOpenSearchAclGet)
     -   [ServiceOpenSearchAclSet](https://api.aiven.io/doc/#tag/Service:_OpenSearch/operation/ServiceOpenSearchAclSet)
     -   [ServiceOpenSearchAclUpdate](https://api.aiven.io/doc/#tag/Service:_OpenSearch/operation/ServiceOpenSearchAclUpdate)
-3.  Aiven for OpenSearch ACL in Aiven Terraform provider will be
+3.  Aiven for OpenSearch ACL in the Aiven Terraform Provider will be
     disabled. The affected resources are:
     -   [Opensearch_acl_config](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/opensearch_acl_config)
     -   [Opensearch_acl_rule](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/opensearch_acl_rule)

--- a/docs/products/opensearch/concepts/os-security.md
+++ b/docs/products/opensearch/concepts/os-security.md
@@ -17,7 +17,7 @@ permissions directly from the
     longer use [Aiven Console](https://console.aiven.io/), [Aiven
     API](https://api.aiven.io/doc/),
     [Aiven CLI](/docs/tools/cli),
-    [Aiven Terraform provider](/docs/tools/terraform) or
+    [Aiven Terraform Provider](/docs/tools/terraform) or
     [Aiven Operator for Kubernetes®](/docs/tools/kubernetes) to manage access controls.
 -   You must use the OpenSearch Security Dashboard or OpenSearch
     Security API for managing user authentication and access control

--- a/docs/products/opensearch/howto/enable-opensearch-security.md
+++ b/docs/products/opensearch/howto/enable-opensearch-security.md
@@ -30,7 +30,7 @@ OpenSearch service, note the following:
     longer use [Aiven Console](https://console.aiven.io/), [Aiven
     API](https://api.aiven.io/doc/),
     [Aiven CLI](/docs/tools/cli),
-    [Aiven Terraform provider](/docs/tools/terraform) or
+    [Aiven Terraform Provider](/docs/tools/terraform) or
     [Aiven Operator for Kubernetes®](/docs/tools/kubernetes) to manage access controls.
 
 ## Enable OpenSearch® Security management

--- a/docs/products/opensearch/howto/setup-cross-cluster-replication-opensearch.md
+++ b/docs/products/opensearch/howto/setup-cross-cluster-replication-opensearch.md
@@ -57,10 +57,10 @@ service using the service integration endpoint and setting the
 information, see [Create new service
 integration](https://api.aiven.io/doc/#tag/Service_Integrations).
 
-## Setup cross-cluster replication via Terraform provider
+## Setup cross-cluster replication via Terraform
 
 You can set up the cross-cluster replication for Aiven for OpenSearch
 service via the
-[Aiven Terraform provider](/docs/tools/terraform). Set the `integration-type` to
+[Aiven Terraform Provider](/docs/tools/terraform). Set the `integration-type` to
 `opensearch_cross_cluster_replication` in the [Service Integration
 resource](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/service_integration).

--- a/docs/tools/kubernetes.md
+++ b/docs/tools/kubernetes.md
@@ -4,7 +4,7 @@ title: Aiven Operator for Kubernetes®
 
 Manage Aiven infrastructure with [Aiven Operator for Kubernetes®](https://github.com/aiven/aiven-operator/) by using [Custom Resource Definitions (CRD)](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/).
 
-The [Aiven Operator documentation](https://aiven.github.io/aiven-operator/index.html) includes an API reference and example usage for the resources.
+The [Aiven Kubernetes Operator documentation](https://aiven.github.io/aiven-operator/index.html) includes an API reference and example usage for the resources.
 
 ## Get started
 
@@ -132,5 +132,5 @@ connection to PostgreSQL from Kubernetes.
 ## Related links
 
 - [Aiven Operator for Kubernetes repository](https://github.com/aiven/aiven-operator/)
-- [Aiven Operator examples](https://aiven.github.io/aiven-operator/resources/project.html)
+- [Aiven Kubernetes Operator examples](https://aiven.github.io/aiven-operator/resources/project.html)
 - [Kubernetes Basics](https://kubernetes.io/docs/tutorials/kubernetes-basics/)

--- a/docs/tools/terraform/get-started.md
+++ b/docs/tools/terraform/get-started.md
@@ -4,7 +4,7 @@ keywords: [quick start, Terraform]
 sidebar_label: Get started
 ---
 
-This example shows you how to use the Aiven Provider to set up your data infrastructure by creating a single Aiven for Caching service in an [Aiven project](/docs/platform/concepts/orgs-units-projects).
+This example shows you how to use the Aiven Terraform Provider to set up your data infrastructure by creating a single Aiven for Caching service in an [Aiven project](/docs/platform/concepts/orgs-units-projects).
 
 :::caution
 Recreating stateful services with Terraform may delete the service and
@@ -185,8 +185,8 @@ To delete the service and its data:
     project](https://github.com/aiven/terraform-provider-aiven/blob/main/sample_project/sample.tf)
     to set up integrated Aiven for Kafka®, PostgreSQL®, and
     Grafana® services.
--   Read the [Terraform
-    Docs](https://www.terraform.io/language/modules/develop/structure)
+-   Read the [Aiven Provider for Terraform
+    docs](https://www.terraform.io/language/modules/develop/structure)
     to learn about more complex project structures.
 -   [Import your existing Aiven
     resources](https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/importing-resources)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -402,7 +402,7 @@ const sidebars: SidebarsConfig = {
         'tools/api',
         {
           type: 'category',
-          label: 'Aiven Provider for Terraform®',
+          label: 'Aiven Provider for Terraform',
           link: {
             id: 'tools/terraform',
             type: 'doc',

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -40,8 +40,8 @@ const FeatureList: FeatureItem[] = [
     to: '/docs/tools',
     description: (
       <>
-        Manage your Aiven infrastructure with the API, Terraform, Kubernetes, or
-        CLI.
+        Manage your Aiven infrastructure with the Aiven API, Terraform Provider,
+        Kubernetes Operator, or CLI.
       </>
     ),
   },


### PR DESCRIPTION
## Describe your changes


## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
