### PR TITLE
fix: Format of key/cert upon creation of ext kafka integration endpoint

### DIFF
--- a/docs/products/flink/howto/ext-kafka-flink-integration.md
+++ b/docs/products/flink/howto/ext-kafka-flink-integration.md
@@ -117,12 +117,23 @@ Where:
         and ports to connect to.
     -   `security_protocol`: The type of security protocol to use
         for the connection, which is `SASL` in this case.
-    -   `ssl_ca_cert`: The path to the SSL CA certificate.
-    -   `ssl_client_cert`: The path to the SSL client certificate.
-    -   `ssl_client_key`: The path to the SSL client key.
+    -   `ssl_ca_cert`: The content of the SSL CA certificate.
+    -   `ssl_client_cert`: The content of the SSL client certificate.
+    -   `ssl_client_key`: The content of the SSL client key.
     -   `ssl_endpoint_identification_algorithm`: The endpoint
         identification algorithm to use for SSL verification. For
         example, `https`.
+
+:::important
+After downloading your keys or certificates, ensure the cipher is on its own line,
+and the PEM markers are delimited by a line feed, following the
+guidelines in [RFC 1421](https://www.rfc-editor.org/rfc/rfc1421#section-4.4).
+
+Use the following bash command to format the content correctly:
+```
+cat $downloaded_cert_or_key | tr -d '\n' | sed 's/\([EY]---[-]*\)\([^-]\)/\1\n\2/g;s/\(=\)\(---[-]*\)/\1\n\2/g'
+```
+:::
 
 #### SASL_PLAINTEXT
 

--- a/docs/tools/cli/service/integration.md
+++ b/docs/tools/cli/service/integration.md
@@ -86,6 +86,10 @@ avn service integration-endpoint-create --endpoint-name demo-ext-kafka \
     --user-config-json  '{"bootstrap_servers":"servertest:123","security_protocol":"PLAINTEXT"}'
 ```
 
+:::note
+For more examples of creating external Apache Kafka® endpoints, see [Integrate Aiven for Apache Flink® with Apache Kafka®](/docs/products/flink/howto/ext-kafka-flink-integration#step-4-create-an-external-apache-kafka-endpoint).
+:::
+
 **Example:** Create an external Loggly endpoint named `Loggly-ext`.
 
 ```bash


### PR DESCRIPTION
## Describe your changes

The documentation mistakenly suggested to pass a path to SSL key/cert when calling ServiceIntegrationEndpointCreate via API or CLI. Moreover the format of these values should match RFC-1421.

[EH-1434 ](https://aiven.atlassian.net/browse/EH-1434)
[DOC-1245](https://aiven.atlassian.net/browse/DOC-1245)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.


[EH-1434]: https://aiven.atlassian.net/browse/EH-1434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOC-1245]: https://aiven.atlassian.net/browse/DOC-1245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ