### PR TITLE
fix: Typo in title

### DIFF
--- a/docs/products/kafka/kafka-connect/reference/advanced-params.md
+++ b/docs/products/kafka/kafka-connect/reference/advanced-params.md
@@ -1,5 +1,5 @@
 ---
-title: Advanced parameters for Apacheh Kafka® Connect
+title: Advanced parameters for Apache Kafka® Connect
 sidebar_label: Advanced parameters
 ---
 


### PR DESCRIPTION
## Describe your changes
Fixed typo in the Kafka Connect advanced parameter topic title.
## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
