### PR TITLE
update: kafka topic exclusion conditions for datadog

### DIFF
--- a/docs/products/kafka/howto/datadog-customised-metrics.md
+++ b/docs/products/kafka/howto/datadog-customised-metrics.md
@@ -78,6 +78,10 @@ parameters:
 -   `exclude_topics`: Specify a comma-separated list of topics to
     exclude.
 
+    :::warning
+    When `exclude_topics` are defined, some `include_consumer_groups` are also required so that it applies.
+    :::
+
 -   `include_consumer_groups`: Specify a comma-separated list of
     consumer groups to include.
 

--- a/docs/products/kafka/howto/datadog-customised-metrics.md
+++ b/docs/products/kafka/howto/datadog-customised-metrics.md
@@ -79,7 +79,8 @@ parameters:
     exclude.
 
     :::warning
-    When `exclude_topics` are defined, some `include_consumer_groups` are also required so that it applies.
+    To use `exclude_topics`, you must specify at least one `include_consumer_groups`
+    value. Without this, `exclude_topics` does not take effect.
     :::
 
 -   `include_consumer_groups`: Specify a comma-separated list of


### PR DESCRIPTION
## Describe your changes

It is not clear that at least one value for `include_consumer_groups` is required for `exlude_topics` to apply.

[DOC-1256]

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.


[DOC-1256]: https://aiven.atlassian.net/browse/DOC-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ