### PR TITLE
update: clarify M3DB service creation rules based on project inclusion

### DIFF
--- a/docs/platform/reference/end-of-life.md
+++ b/docs/platform/reference/end-of-life.md
@@ -13,6 +13,12 @@ Learn about the upcoming end of life (EOL) for select Aiven services, including 
 After April 30, 2025, all running Aiven for M3DB
 services are powered off and deleted, making data from these services inaccessible.
 
+:::note
+If your project includes an Aiven for M3DB service, you can continue creating new
+Aiven for M3DB services in the same project. If your project did not previously include
+an Aiven for M3DB service, you cannot create new Aiven for M3DB services.
+:::
+
 ### Migration options
 
 - **Aiven for Metrics**: Provides a seamless transition for time-series workloads,

--- a/docs/platform/reference/end-of-life.md
+++ b/docs/platform/reference/end-of-life.md
@@ -16,7 +16,8 @@ services are powered off and deleted, making data from these services inaccessib
 :::note
 If your project includes an Aiven for M3DB service, you can continue creating new
 Aiven for M3DB services in the same project. If your project did not previously include
-an Aiven for M3DB service, you cannot create new Aiven for M3DB services.
+an Aiven for M3DB service, you cannot create new Aiven for M3DB services. This applies
+until the end of life (EOL) date on April 30, 2025.
 :::
 
 ### Migration options

--- a/docs/platform/reference/eol-for-major-versions.md
+++ b/docs/platform/reference/eol-for-major-versions.md
@@ -102,17 +102,6 @@ after they are made available on the Aiven platform.
 | 4.0     | 2024-09-30 | 2024-09-30                       | 2021-12-09                      |
 | 4.1     | 2025-09-30 | To be announced                  | 2024-01-18                      |
 
-### Aiven for M3DB
-
-Starting from v1.5, Aiven for M3DB versions will reach EOL six months
-after newer major and minor versions are made available on the Aiven
-platform.
-
-| Version | Aiven EOL  | Service creation supported until | Service creation supported from |
-| ------- | ---------- | -------------------------------- | ------------------------------- |
-| 1.1     | 2023-09-01 | 2023-06-01                       | 2021-02-23                      |
-| 1.2     | 2023-09-01 | 2023-06-01                       | 2021-10-11                      |
-| 1.5     | N/A        | N/A                              | 2022-05-05                      |
 
 ### Aiven for Apache Flink® {#aiven-for-flink}
 


### PR DESCRIPTION
## Describe your changes

- Removed M3DB from the end of major version topic.  
- Clarified the ability to create new Aiven for M3DB services based on whether the project already includes an existing service.

[DOC-1259](https://aiven.atlassian.net/browse/DOC-1259)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.


[DOC-1259]: https://aiven.atlassian.net/browse/DOC-1259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ