### PR TITLE
add: howto link for Java

### DIFF
--- a/docs/products/valkey/get-started.md
+++ b/docs/products/valkey/get-started.md
@@ -61,3 +61,4 @@ languages or through `valkey-cli`:
 - [Node](/docs/products/valkey/howto/connect-node)
 - [PHP](/docs/products/valkey/howto/connect-php)
 - [Python](/docs/products/valkey/howto/connect-python)
+- [Java](/docs/products/valkey/howto/connect-java)


### PR DESCRIPTION
## Describe your changes

Add missing link for Java under "Connect to Aiven for Valkey" section

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
