### PR TITLE
update: clarify offset sync behavior in MirrorMaker 2

### DIFF
--- a/docs/products/kafka/kafka-mirrormaker/howto/log-analysis-offset-sync-tool.md
+++ b/docs/products/kafka/kafka-mirrormaker/howto/log-analysis-offset-sync-tool.md
@@ -33,6 +33,18 @@ to analyze offset syncing in Aiven for Apache Kafka MirrorMaker 2.
 
 The offset sync inspection tool outputs data in CSV format. Use this output to check
 the sync status and detect any issues with the offset syncing process.
+
+:::note
+The offset sync inspection tool reports only on topics that Aiven for
+Apache Kafka MirrorMaker 2 actively synchronizes. It does not capture information for all
+topics in a Kafka cluster. Each replication flow has its own offset sync topic,
+which contains only offset synchronization data for that flow.
+
+If your setup includes multiple MirrorMaker 2 replication flows, run the tool separately
+for each flow to analyze its synchronization status. The tool does not aggregate data
+across flows, you must manually combine the results if you need a complete view.
+:::
+
 Run the tool using the following command:
 
 ```bash


### PR DESCRIPTION
## Describe your changes

Clarify offset sync behavior in MirrorMaker 2 docs.

[EC-678](https://aiven.atlassian.net/browse/EC-678)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.


[EC-678]: https://aiven.atlassian.net/browse/EC-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ