### PR TITLE
feat: Iceberg sink connector to Apache Kafka Connect

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
@@ -1,0 +1,321 @@
+---
+title: Create an Iceberg sink connector for Aiven for Apache Kafka®
+sidebar_label: Iceberg sink connector
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/non-swizzled/ConsoleIcons";
+
+Integrate Aiven for Apache Kafka with Apache Iceberg for real-time data ingestion into Iceberg tables.
+<!-- vale off -->
+The connector supports exactly-once delivery semantics, schema evolution, and metadata
+management, making it ideal for high-performance, large-scale data processing.
+
+## Catalogs in Iceberg
+
+A catalog in Apache Iceberg serves as a layer to manage metadata related to your
+Iceberg tables. It connects the connector to storage backends, enabling
+schema management, table discovery, and configuration.
+
+The Iceberg Sink Connector supports multiple catalog types, but the focus is on
+setting up and configuring:
+
+- **AWS Glue as REST Catalog:** An AWS-managed catalog leveraging the Iceberg REST API.
+- **AWS Glue as Glue Catalog:** A native AWS Glue implementation for Iceberg.
+
+## Prerequisites
+
+- An [Aiven for Apache Kafka® service](/docs/products/kafka/kafka-connect/howto/enable-connect)
+  with Apache Kafka Connect enabled or a
+  [dedicated Aiven for Apache Kafka Connect® service](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
+
+### AWS Glue as REST Catalog
+
+- Create an S3 bucket for storing data.
+- Set up AWS IAM roles with permissions for:
+  - Read/write access to the S3 bucket.
+  - AWS Glue database and table management.
+- Create an AWS Glue database and tables with a schema matching the Apache Kafka records.
+  Specify the created S3 bucket as the storage location. For detailed steps, see
+  the [AWS Glue Data Catalog documentation](https://docs.aws.amazon.com/glue/latest/dg/start-data-catalog.html).
+
+### AWS Glue as Glue Catalog
+
+- Create an S3 bucket for storing data.
+- Set up AWS IAM roles with permissions for:
+  - Read/write access to the S3 bucket.
+  - AWS Glue database and table management.
+- Create an AWS Glue database and tables.
+
+## Set up and configure
+
+Configure AWS Glue resources and the Iceberg Sink Connector.
+
+<Tabs groupId="catalog-type">
+  <TabItem value="rest-catalog" label="AWS Glue as REST Catalog" default>
+
+1. Create AWS resources, including an S3 bucket, Glue database, and tables.
+1. Add the following configurations to the Iceberg sink connector:
+
+   ```JSON
+   {
+      "iceberg.tables": "<database-name>.<table-name>",
+      "iceberg.tables.auto-create-enabled": "false",
+      "iceberg.control.commit.interval-ms": "1000",
+      "iceberg.control.commit.timeout-ms": "2147483647",
+      "iceberg.control.topic": "<your-iceberg-control-topic-name>",
+      "name": "<your-connector-name>",
+      "connector.class": "org.apache.iceberg.connect.IcebergSinkConnector",
+      "tasks.max": "2",
+      "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+      "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+      "topics": "<your-topics>",
+      "consumer.override.auto.offset.reset": "earliest",
+      "iceberg.catalog.client.region": "<your-aws-region>",
+      "iceberg.catalog.io-impl": "org.apache.iceberg.aws.s3.S3FileIO",
+      "iceberg.catalog.rest-metrics-reporting-enabled": "false",
+      "iceberg.catalog.rest.access-key-id": "<your-access-key-id>",
+      "iceberg.catalog.rest.secret-access-key": "<your-secret-access-key>",
+      "iceberg.catalog.rest.signing-name": "glue",
+      "iceberg.catalog.rest.signing-region": "<your-aws-region>",
+      "iceberg.catalog.rest.sigv4-enabled": "true",
+      "iceberg.catalog.s3.access-key-id": "<your-access-key-id>",
+      "iceberg.catalog.s3.path-style-access": "true",
+      "iceberg.catalog.s3.secret-access-key": "<your-secret-access-key>",
+      "iceberg.catalog.type": "rest",
+      "iceberg.catalog.uri": "https://glue.<your-aws-region>.amazonaws.com/iceberg",
+      "iceberg.catalog.warehouse": "<your-aws-account-id>",
+      "iceberg.kafka.auto.offset.reset": "earliest",
+      "key.converter.schemas.enable": "false",
+      "value.converter.schemas.enable": "false"
+   }
+   ```
+
+   Parameters:
+
+   - `iceberg.tables`: The target Glue database and table in the
+     format `<database-name>.<table-name>`.
+   - `iceberg.tables.auto-create-enabled`: Indicates whether tables can be
+     automatically created. Set to `false` for AWS Glue REST Catalog.
+   - `iceberg.control.commit.interval-ms`: The frequency in milliseconds at which
+     commits are made to Iceberg tables.
+   - `iceberg.control.commit.timeout-ms`: The maximum time in milliseconds to
+     wait for a commit to complete.
+   - `iceberg.control.topic`: The control topic for Iceberg operations. If omitted,
+     the default is `control-iceberg`.
+   - `name`: The name of the connector.
+   - `connector.class`: Specifies the class to use for the Iceberg Sink Connector.
+   - `tasks.max`: The maximum number of tasks to run for this connector.
+   - `key.converter` and `value.converter`: Specify the converters for the keys
+     and values. Use `JsonConverter` for JSON data.
+   - `topics`: The Kafka topics containing the data to sink into Iceberg tables.
+   - `consumer.override.auto.offset.reset`: Configures the offset reset policy
+     (`earliest` or `latest`).
+   - `iceberg.catalog.client.region`: The AWS region for Iceberg catalog operations.
+   - `iceberg.catalog.io-impl`: The file I/O implementation. Use
+     `org.apache.iceberg.aws.s3.S3FileIO` for AWS S3.
+   - `iceberg.catalog.rest-metrics-reporting-enabled`: Enables or disables metrics
+     reporting for the REST catalog.
+   - `iceberg.catalog.rest.access-key-id` and
+     `iceberg.catalog.rest.secret-access-key`: AWS credentials for accessing the
+     REST catalog.
+   - `iceberg.catalog.rest.signing-name`: The AWS service name for request
+     signing (for example, `glue`).
+   - `iceberg.catalog.rest.signing-region`: The AWS region for request signing.
+   - `iceberg.catalog.rest.sigv4-enabled`: Enables AWS SigV4 signing for REST
+     requests.
+   - `iceberg.catalog.s3.access-key-id` and
+     `iceberg.catalog.s3.secret-access-key`: AWS credentials for S3 access.
+   - `iceberg.catalog.s3.path-style-access`: Enables path-style access for S3 buckets.
+   - `iceberg.catalog.type`: Specifies the catalog type. Use `rest` for AWS Glue REST Catalog.
+   - `iceberg.catalog.uri`: The URI of the Iceberg REST endpoint for AWS Glue.
+   - `iceberg.catalog.warehouse`: The S3 bucket URI to store data.
+   - `iceberg.kafka.auto.offset.reset`: Configures the offset reset policy for
+     Iceberg Apache Kafka.
+   - `key.converter.schemas.enable` and `value.converter.schemas.enable`: Enable
+     or disable schemas for the converters.
+
+</TabItem>
+<TabItem value="glue-catalog" label="AWS Glue Catalog">
+
+1. Create AWS resources, including an S3 bucket, Glue database, and tables.
+
+1. Add the following configurations to the Iceberg sink connector:
+
+   ```json
+   {
+      "iceberg.tables": "<database-name>.<table-name>",
+      "iceberg.tables.auto-create-enabled": "true",
+      "iceberg.control.commit.interval-ms": "1000",
+      "iceberg.control.commit.timeout-ms": "2147483647",
+      "iceberg.control.topic": "<your-iceberg-control-topic-name>",
+      "name": "<your-connector-name>",
+      "connector.class": "org.apache.iceberg.connect.IcebergSinkConnector",
+      "tasks.max": "2",
+      "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+      "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+      "topics": "<your-topics>",
+      "consumer.override.auto.offset.reset": "earliest",
+      "iceberg.catalog.client.region": "<your-aws-region>",
+      "iceberg.catalog.client.credentials-provider": "org.apache.iceberg.aws.StaticCredentialsProvider",
+      "iceberg.catalog.client.credentials-provider.access-key-id": "<your-access-key-id>",
+      "iceberg.catalog.client.credentials-provider.secret-access-key": "<your-secret-access-key>",
+      "iceberg.catalog.io-impl": "org.apache.iceberg.aws.s3.S3FileIO",
+      "iceberg.catalog.s3.access-key-id": "<your-access-key-id>",
+      "iceberg.catalog.s3.path-style-access": "true",
+      "iceberg.catalog.s3.secret-access-key": "<your-secret-access-key>",
+      "iceberg.catalog.type": "glue",
+      "iceberg.catalog.glue_catalog.glue.id": "<your-aws-account-id>",
+      "iceberg.catalog.warehouse": "s3://<your-bucket-name>",
+      "iceberg.kafka.auto.offset.reset": "earliest",
+      "key.converter.schemas.enable": "false",
+      "value.converter.schemas.enable": "false"
+   }
+   ```
+
+   Parameters:
+
+   - All parameters are identical to those listed for AWS Glue as REST Catalog, with
+     the following differences:
+   - `iceberg.tables.auto-create-enabled`: Set to `true` for AWS Glue Catalog to enable
+     automatic table creation.
+   - `iceberg.catalog.type`: Use `glue` for AWS Glue Catalog.
+   - `iceberg.catalog.glue_catalog.glue.id`: The AWS account ID for AWS Glue Catalog.
+   - `iceberg.catalog.client.credentials-provider`: Specifies the credentials provider
+     for AWS Glue Catalog.
+
+</TabItem>
+</Tabs>
+
+## Create the connector
+
+<Tabs groupId="setup-method">
+  <TabItem value="console" label="Aiven Console" default>
+
+1. Access the [Aiven Console](https://console.aiven.io/).
+1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
+1. Click <ConsoleLabel name="Connectors"/>.
+1. Click **Create connector** if Apache Kafka Connect is already enabled on the service.
+   If not, click **Enable connector on this service**.
+
+   Alternatively, to enable connectors:
+
+   1. Click <ConsoleLabel name="Service settings"/> in the sidebar.
+   1. In the **Service management** section, click
+      <ConsoleLabel name="Actions"/> > **Enable Kafka connect**.
+
+1. In the sink connectors list, select **Iceberg Sink Connector**, and click
+   **Get started**.
+1. On the **Iceberg Sink Connector** page, go to the **Common** tab.
+1. Locate the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
+1. Paste the configuration from your `iceberg_sink_connector.json` file into the text box.
+1. Click **Create connector**.
+1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+
+</TabItem>
+<TabItem value="cli" label="Aiven CLI">
+
+To create the Iceberg sink connector using the [Aiven CLI](/docs/tools/cli), run:
+
+```bash
+avn service connector create SERVICE_NAME @iceberg_sink_connector.json
+```
+
+Parameters:
+
+- `SERVICE_NAME`: The name of your Aiven for Apache Kafka® service.
+- `@iceberg_sink_connector.json`: The path to the JSON configuration file.
+
+</TabItem>
+</Tabs>
+
+## Example: Define and create an Iceberg sink connector
+
+<Tabs groupId="catalog-type">
+  <TabItem value="rest-catalog" label="AWS Glue as REST Catalog" default>
+
+This example shows how to create an Iceberg sink connector using AWS Glue as
+REST Catalog with the following properties:
+
+- Connector name: `iceberg_sink_rest`
+- Apache Kafka topic: `test-topic`
+- AWS Glue region: `us-west-1`
+- AWS S3 bucket: `my-s3-bucket`
+- AWS IAM access key ID: `your-access-key-id`
+- AWS IAM secret access key: `your-secret-access-key`
+- Target table: `mydatabase.mytable`
+- Commit interval: `1000 ms`
+- Tasks: `2`
+
+```json
+{
+  "name": "iceberg_sink_rest",
+  "connector.class": "org.apache.iceberg.connect.IcebergSinkConnector",
+  "tasks.max": "2",
+  "topics": "test-topic",
+  "iceberg.catalog.type": "rest",
+  "iceberg.catalog.uri": "https://glue.us-west-1.amazonaws.com/iceberg",
+  "iceberg.catalog.rest.signing-name": "glue",
+  "iceberg.catalog.rest.signing-region": "us-west-1",
+  "iceberg.catalog.io-impl": "org.apache.iceberg.aws.s3.S3FileIO",
+  "iceberg.catalog.s3.access-key-id": "your-access-key-id",
+  "iceberg.catalog.s3.secret-access-key": "your-secret-access-key",
+  "iceberg.catalog.warehouse": "s3://my-s3-bucket",
+  "iceberg.tables": "mydatabase.mytable",
+  "iceberg.tables.auto-create-enabled": "false",
+  "iceberg.control.commit.interval-ms": "1000",
+  "iceberg.control.commit.timeout-ms": "2147483647",
+  "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter"
+}
+```
+
+</TabItem>
+<TabItem value="glue-catalog" label="AWS Glue Catalog">
+
+This example shows how to create an Iceberg sink connector using AWS Glue Catalog
+with the following properties:
+
+- Connector name: `iceberg_sink_glue`
+- Apache Kafka topic: `test-topic`
+- AWS Glue region: `us-west-1`
+- AWS S3 bucket: `my-s3-bucket`
+- AWS IAM access key ID: `your-access-key-id`
+- AWS IAM secret access key: `your-secret-access-key`
+- Target table: `mydatabase.mytable`
+- Commit interval: `1000 ms`
+- Tasks: `2`
+
+```json
+{
+  "name": "iceberg_sink_glue",
+  "connector.class": "org.apache.iceberg.connect.IcebergSinkConnector",
+  "tasks.max": "2",
+  "topics": "test-topic",
+  "iceberg.catalog.type": "glue",
+  "iceberg.catalog.glue_catalog.glue.id": "123456789012",
+  "iceberg.catalog.client.region": "us-west-1",
+  "iceberg.catalog.client.credentials-provider": "org.apache.iceberg.aws.StaticCredentialsProvider",
+  "iceberg.catalog.client.credentials-provider.access-key-id": "your-access-key-id",
+  "iceberg.catalog.client.credentials-provider.secret-access-key": "your-secret-access-key",
+  "iceberg.catalog.io-impl": "org.apache.iceberg.aws.s3.S3FileIO",
+  "iceberg.catalog.s3.access-key-id": "your-access-key-id",
+  "iceberg.catalog.s3.secret-access-key": "your-secret-access-key",
+  "iceberg.catalog.warehouse": "s3://my-s3-bucket",
+  "iceberg.tables": "mydatabase.mytable",
+  "iceberg.tables.auto-create-enabled": "true",
+  "iceberg.control.commit.interval-ms": "1000",
+  "iceberg.control.commit.timeout-ms": "2147483647",
+  "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter"
+}
+```
+
+</TabItem>
+</Tabs>
+
+Once these configurations are saved in `iceberg_sink_rest.json` or
+`iceberg_sink_glue.json`, you can create the connector using the Aiven Console or
+Aiven CLI. Verify that data from the Apache Kafka topic `test-topic` is successfully
+ingested into your Iceberg table.

--- a/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
@@ -8,22 +8,21 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import ConsoleLabel from "@site/src/components/non-swizzled/ConsoleIcons";
 
-Integrate Aiven for Apache Kafka® with Apache Iceberg for real-time data ingestion into Iceberg tables.
+Integrate Aiven for Apache Kafka® with the Iceberg sink connector to ingest real-time data into Iceberg tables for analytics and storage.
 <!-- vale off -->
-The connector supports exactly-once delivery, schema evolution, and metadata management.
-It is optimized for large-scale, high-performance data processing. For more
-details, see the
+It supports exactly-once delivery, schema evolution, and metadata management and is
+optimized for large-scale, high-performance data processing. For more details, see the
 [official Iceberg documentation](https://iceberg.apache.org/docs/latest/kafka-connect/#apache-iceberg-sink-connector).
 
 ## Catalogs in Iceberg
 
 In Apache Iceberg, a catalog stores table metadata and supports key operations such as
-creating, renaming, and deleting tables. Catalogs manage collections of tables organized
-into namespaces and provide the metadata needed for access.
+creating, renaming, and deleting tables. It manages collections of tables organized
+into namespaces and provides the metadata needed for access.
 
 The Iceberg sink connector writes data to storage backends, while the catalog manages
-metadata, enabling multiple compute engines to share a common data layer. It supports
-the following catalog types in Aiven for Apache Kafka Connect:
+metadata, allowing multiple compute engines to share a common data layer. The connector
+supports the following catalog types:
 
 - **AWS Glue REST catalog:** An AWS-managed catalog leveraging the Iceberg REST API.
 - **AWS Glue catalog:** A native AWS Glue implementation for Iceberg.
@@ -46,7 +45,7 @@ The Iceberg sink connector supports the following settings:
 
 ## Future enhancements
 
-Future updates to the Iceberg sink connector includes:
+Future updates to the Iceberg sink connector include:
 
 - **FileIO implementations:** Support for GCS and Azure FileIO.
 - **Write formats:** Additional support for Avro and ORC formats.
@@ -57,6 +56,9 @@ Future updates to the Iceberg sink connector includes:
 - An [Aiven for Apache Kafka® service](/docs/products/kafka/kafka-connect/howto/enable-connect)
   with Apache Kafka Connect enabled, or a
   [dedicated Aiven for Apache Kafka Connect® service](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
+- Apache Kafka client settings: The Iceberg sink connector requires these settings to
+  connect to the Iceberg control topic. For a full list of supported configurations, see
+  [Iceberg configuration](https://iceberg.apache.org/docs/latest/kafka-connect/#kafka-configuration).
 - AWS-specific setup:
   - Create an **S3 bucket** to store data.
   - Configure **AWS IAM roles** with the following permissions:
@@ -75,17 +77,12 @@ are not supported in this release.
 
 ## Create an Iceberg sink connector configuration
 
-The Iceberg sink connector requires Apache Kafka client settings to connect to the
-Iceberg control topic. See the
-[Iceberg configuration](https://iceberg.apache.org/docs/latest/kafka-connect/#kafka-configuration)
-for a complete list of supported Apache Kafka configurations.
+To configure the Iceberg sink connector, define a JSON configuration file. Use the
+examples below based on your selected catalog type:
 
 :::note
 Loading worker properties is not supported. Use `iceberg.kafka.*` properties instead.
 :::
-
-To configure the Iceberg sink connector, define a JSON configuration file. Use the
-examples below based on your selected catalog type:
 
 <Tabs groupId="setup-method">
   <TabItem value="rest-catalog" label="AWS Glue REST catalog" default>
@@ -266,13 +263,13 @@ examples below based on your selected catalog type:
    - `iceberg.catalog.client.credentials-provider`: Specify the credentials provider for
      AWS Glue catalog.
 
-   :::note
-   The Kafka security settings remain the same as in the AWS Glue REST catalog
-   configuration.
-   :::
-
 </TabItem>
 </Tabs>
+
+:::note
+Apache Kafka security settings are the same for both AWS Glue REST and AWS Glue
+catalog configurations.
+:::
 
 For a complete list of configurations,
 see [Iceberg configuration](https://iceberg.apache.org/docs/latest/kafka-connect/#configuration).

--- a/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
@@ -29,15 +29,22 @@ following catalog types:
 - **AWS Glue as REST Catalog:** An AWS-managed catalog leveraging the Iceberg REST API.
 - **AWS Glue as Glue Catalog:** A native AWS Glue implementation for Iceberg.
 
+:::note
+When AWS Glue is used as the REST catalog, the connector cannot create tables
+automatically. You must manually create the tables in AWS Glue and match the schema to
+the Apache Kafka data.
+:::
+
+For more details, see the
+[Iceberg catalogs documentation](https://iceberg.apache.org/concepts/catalog/).
+
 ## FileIO and write format support
 
 The Iceberg sink connector supports the following configurations:
 
-- **FileIO**: Supports S3FileIO for AWS S3 storage. Other implementations, such as GCS,
-  ADLS, and Hadoop, are not supported.
+- **FileIO**: Supports S3FileIO for AWS S3 storage.
 
-- **Write format**: Supports Parquet format. Other formats, such as Avro and ORC,
-  are not supported.
+- **Write format**: Supports Parquet format.
 
 ## Future enhancements
 
@@ -71,6 +78,13 @@ based on the catalog type:
   <TabItem value="rest-catalog" label="AWS Glue as REST Catalog" default>
 
 1. Create AWS resources, including an S3 bucket, Glue database, and tables.
+
+   :::note
+   When AWS Glue is used as the REST catalog, the connector cannot create tables
+   automatically. You must manually create the tables in AWS Glue and match the schema to
+   the Apache Kafka data.
+   :::
+
 1. Add the following configurations to the Iceberg sink connector:
 
    ```JSON
@@ -150,6 +164,9 @@ based on the catalog type:
      Iceberg Apache Kafka.
    - `key.converter.schemas.enable` and `value.converter.schemas.enable`: Enable
      or disable schemas for the converters.
+
+For a complete list of configurations,
+see [Iceberg configuration](https://iceberg.apache.org/docs/latest/kafka-connect/#configuration).
 
 </TabItem>
 <TabItem value="glue-catalog" label="AWS Glue Catalog">

--- a/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
@@ -11,26 +11,24 @@ Integrate Aiven for Apache Kafka with Apache Iceberg for real-time data ingestio
 <!-- vale off -->
 The connector supports exactly-once delivery semantics, schema evolution, and metadata
 management, optimized for large-scale, high-performance data processing. For more
-information about the Apache Iceberg Sink Connector, see the
+details, see the
 [official Iceberg documentation](https://iceberg.apache.org/docs/latest/kafka-connect/#apache-iceberg-sink-connector).
 
 ## Catalogs in Iceberg
 
 A catalog in Apache Iceberg stores table metadata and supports key operations such as
 creating, renaming, and deleting tables. Catalogs manage collections of tables organized
-into namespaces and provide the metadata needed to access them.
+into namespaces and provide the metadata needed for access.
 
-The Iceberg Sink Connector writes data to storage backends, while the catalog manages
-metadata to enable multiple compute engines to share a common data layer.
+The Iceberg sink connector writes data to storage backends, while the catalog manages
+metadata, allowing multiple compute engines to share a common data layer. It supports
+the following catalog types in Aiven for Apache Kafka Connect:
 
-The Iceberg Sink Connector for Aiven for Apache Kafka Connect currently supports the
-following catalog types:
-
-- **AWS Glue as REST Catalog:** An AWS-managed catalog leveraging the Iceberg REST API.
-- **AWS Glue as Glue Catalog:** A native AWS Glue implementation for Iceberg.
+- **AWS Glue as REST catalog:** An AWS-managed catalog leveraging the Iceberg REST API.
+- **AWS Glue as Glue catalog:** A native AWS Glue implementation for Iceberg.
 
 :::note
-When AWS Glue is used as the REST catalog, the connector cannot create tables
+When AWS Glue is used as a REST catalog, the connector cannot create tables
 automatically. You must manually create the tables in AWS Glue and match the schema to
 the Apache Kafka data.
 :::
@@ -38,13 +36,13 @@ the Apache Kafka data.
 For more details, see the
 [Iceberg catalogs documentation](https://iceberg.apache.org/concepts/catalog/).
 
-## FileIO and write format support
+## File I/O and write format
 
 The Iceberg sink connector supports the following configurations:
 
-- **FileIO**: Supports S3FileIO for AWS S3 storage.
+- **File I/O**: Supports `S3FileIO` for AWS S3 storage.
 
-- **Write format**: Supports Parquet format.
+- **Write format**: Supports the Parquet format.
 
 ## Future enhancements
 
@@ -64,12 +62,12 @@ The following features are planned for future updates to the Iceberg sink connec
   - Configure AWS IAM roles with permissions for:
     - Read and write access to the S3 bucket.
     - Managing AWS Glue databases and tables.
-  - Create an AWS Glue database and tables. For REST Catalog, ensure the schema matches
+  - Create an AWS Glue database and tables. For REST catalog, ensure the schema matches
     the Apache Kafka records and specify the S3 bucket as the storage location. For more
     details, see the
-    [AWS Glue Data Catalog documentation](https://docs.aws.amazon.com/glue/latest/dg/start-data-catalog.html).
+    [AWS Glue data catalog documentation](https://docs.aws.amazon.com/glue/latest/dg/start-data-catalog.html).
 
-## Create an Iceberg sink connector configuration file
+## Create an Iceberg sink connector configuration
 
 Create a JSON configuration file for the Iceberg sink connector. Use the examples below,
 based on the catalog type:
@@ -123,53 +121,52 @@ based on the catalog type:
 
    Parameters:
 
-   - `iceberg.tables`: The target Glue database and table in the
-     format `<database-name>.<table-name>`.
-   - `iceberg.tables.auto-create-enabled`: Indicates whether tables can be
-     automatically created. Set to `false` for AWS Glue REST Catalog.
-   - `iceberg.control.commit.interval-ms`: The frequency in milliseconds at which
-     commits are made to Iceberg tables.
-   - `iceberg.control.commit.timeout-ms`: The maximum time in milliseconds to
-     wait for a commit to complete.
-   - `iceberg.control.topic`: The control topic for Iceberg operations. If omitted,
-     the default is `control-iceberg`.
-   - `name`: The name of the connector.
-   - `connector.class`: Specifies the class to use for the Iceberg Sink Connector.
-   - `tasks.max`: The maximum number of tasks to run for this connector.
-   - `key.converter` and `value.converter`: Specify the converters for the keys
-     and values. Use `JsonConverter` for JSON data.
-   - `topics`: The Kafka topics containing the data to sink into Iceberg tables.
-   - `consumer.override.auto.offset.reset`: Configures the offset reset policy
-     (`earliest` or `latest`).
-   - `iceberg.catalog.client.region`: The AWS region for Iceberg catalog operations.
-   - `iceberg.catalog.io-impl`: The file I/O implementation. Use
+   - `iceberg.tables`: Specify the target Glue database and table in
+     `<database-name>.<table-name>` format.
+   - `iceberg.tables.auto-create-enabled`: Set to `true` to allow the connector to create
+     tables automatically. Set to `false` for AWS Glue REST catalog.
+   - `iceberg.control.commit.interval-ms`: Define how often (in milliseconds) the
+     connector commits data to Iceberg tables.
+   - `iceberg.control.commit.timeout-ms`: Set the maximum time (in milliseconds) the
+     connector waits for a commit.
+   - `iceberg.control.topic`: Specify the control topic for Iceberg operations. Defaults
+     to `control-iceberg` if not set.
+   - `name`: Enter the connector name.
+   - `connector.class`: Specify the class for the Iceberg sink connector.
+   - `tasks.max`: Set the maximum number of tasks the connector can run.
+   - `key.converter` and `value.converter`: Choose the key and value converters. Use
+     `JsonConverter` for JSON data.
+   - `topics`: Specify the Apache Kafka topics containing data for Iceberg tables.
+   - `consumer.override.auto.offset.reset`: Set the offset reset policy to `earliest` or
+     `latest`.
+   - `iceberg.catalog.client.region`: Enter the AWS region for Iceberg catalog operations.
+   - `iceberg.catalog.io-impl`: Specify the file I/O implementation. Use
      `org.apache.iceberg.aws.s3.S3FileIO` for AWS S3.
-   - `iceberg.catalog.rest-metrics-reporting-enabled`: Enables or disables metrics
+   - `iceberg.catalog.rest-metrics-reporting-enabled`: Enable or disable metrics
      reporting for the REST catalog.
-   - `iceberg.catalog.rest.access-key-id` and
-     `iceberg.catalog.rest.secret-access-key`: AWS credentials for accessing the
-     REST catalog.
-   - `iceberg.catalog.rest.signing-name`: The AWS service name for request
-     signing (for example, `glue`).
-   - `iceberg.catalog.rest.signing-region`: The AWS region for request signing.
-   - `iceberg.catalog.rest.sigv4-enabled`: Enables AWS SigV4 signing for REST
-     requests.
-   - `iceberg.catalog.s3.access-key-id` and
-     `iceberg.catalog.s3.secret-access-key`: AWS credentials for S3 access.
-   - `iceberg.catalog.s3.path-style-access`: Enables path-style access for S3 buckets.
-   - `iceberg.catalog.type`: Specifies the catalog type. Use `rest` for AWS Glue REST Catalog.
-   - `iceberg.catalog.uri`: The URI of the Iceberg REST endpoint for AWS Glue.
-   - `iceberg.catalog.warehouse`: The S3 bucket URI to store data.
-   - `iceberg.kafka.auto.offset.reset`: Configures the offset reset policy for
-     Iceberg Apache Kafka.
-   - `key.converter.schemas.enable` and `value.converter.schemas.enable`: Enable
-     or disable schemas for the converters.
+   - `iceberg.catalog.rest.access-key-id` and `iceberg.catalog.rest.secret-access-key`:
+     Enter AWS credentials for REST catalog access.
+   - `iceberg.catalog.rest.signing-name`: Specify the AWS service name for signing
+     requests (for example, `glue`).
+   - `iceberg.catalog.rest.signing-region`: Enter the AWS region for request signing.
+   - `iceberg.catalog.rest.sigv4-enabled`: Enable AWS SigV4 signing for REST requests.
+   - `iceberg.catalog.s3.access-key-id` and `iceberg.catalog.s3.secret-access-key`: Enter
+     AWS credentials for S3 access.
+   - `iceberg.catalog.s3.path-style-access`: Enable or disable path-style access for
+     S3 buckets.
+   - `iceberg.catalog.type`: Specify the catalog type. Use `rest` for AWS Glue REST
+     catalog.
+   - `iceberg.catalog.uri`: Enter the URI of the Iceberg REST endpoint for AWS Glue.
+   - `iceberg.catalog.warehouse`: Enter the S3 bucket URI for storing data.
+   - `iceberg.kafka.auto.offset.reset`: Set the offset reset policy for Iceberg Kafka.
+   - `key.converter.schemas.enable` and `value.converter.schemas.enable`: Enable or
+      disable schemas for converters.
 
 For a complete list of configurations,
 see [Iceberg configuration](https://iceberg.apache.org/docs/latest/kafka-connect/#configuration).
 
 </TabItem>
-<TabItem value="glue-catalog" label="AWS Glue Catalog">
+<TabItem value="glue-catalog" label="AWS Glue catalog">
 
 1. Create AWS resources, including an S3 bucket, Glue database, and tables.
 
@@ -208,14 +205,15 @@ see [Iceberg configuration](https://iceberg.apache.org/docs/latest/kafka-connect
 
    Parameters:
 
-   - All parameters are identical to those listed for AWS Glue as REST Catalog, with
-     the following differences:
-   - `iceberg.tables.auto-create-enabled`: Set to `true` for AWS Glue Catalog to enable
-     automatic table creation.
-   - `iceberg.catalog.type`: Use `glue` for AWS Glue Catalog.
-   - `iceberg.catalog.glue_catalog.glue.id`: The AWS account ID for AWS Glue Catalog.
-   - `iceberg.catalog.client.credentials-provider`: Specifies the credentials provider
-     for AWS Glue Catalog.
+   Use the same parameters as those listed for AWS Glue as REST catalog, except for
+   the following differences:
+
+   - `iceberg.tables.auto-create-enabled`: Set to `true` to enable automatic table
+     creation for AWS Glue catalog.
+   - `iceberg.catalog.type`: Specify `glue` for AWS Glue catalog.
+   - `iceberg.catalog.glue_catalog.glue.id`: Enter the AWS account ID for AWS Glue catalog.
+   - `iceberg.catalog.client.credentials-provider`: Specify the credentials provider for
+     AWS Glue catalog.
 
 </TabItem>
 </Tabs>
@@ -256,8 +254,8 @@ avn service connector create SERVICE_NAME @iceberg_sink_connector.json
 
 Parameters:
 
-- `SERVICE_NAME`: The name of your Aiven for Apache Kafka® service.
-- `@iceberg_sink_connector.json`: The path to the JSON configuration file.
+- `SERVICE_NAME`: Name of your Aiven for Apache Kafka® service.
+- `@iceberg_sink_connector.json`: Path to the JSON configuration file.
 
 </TabItem>
 </Tabs>
@@ -265,7 +263,7 @@ Parameters:
 ## Example: Define and create an Iceberg sink connector
 
 <Tabs groupId="setup-method">
-  <TabItem value="rest-catalog" label="AWS Glue as REST Catalog" default>
+  <TabItem value="rest-catalog" label="AWS Glue as REST catalog" default>
 
 This example shows how to create an Iceberg sink connector using AWS Glue as
 REST Catalog with the following properties:
@@ -304,7 +302,7 @@ REST Catalog with the following properties:
 ```
 
 </TabItem>
-<TabItem value="glue-catalog" label="AWS Glue Catalog">
+<TabItem value="glue-catalog" label="AWS Glue catalog">
 
 This example shows how to create an Iceberg sink connector using AWS Glue Catalog
 with the following properties:

--- a/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
@@ -71,11 +71,11 @@ The following features are planned for future updates to the Iceberg sink connec
 
 ## Create an Iceberg sink connector configuration file
 
-Create a JSON configuration file for the Iceberg Sink Connector. Use the examples below,
+Create a JSON configuration file for the Iceberg sink connector. Use the examples below,
 based on the catalog type:
 
-<Tabs groupId="catalog-type">
-  <TabItem value="rest-catalog" label="AWS Glue as REST Catalog" default>
+<Tabs groupId="setup-method">
+  <TabItem value="rest-catalog" label="AWS Glue as REST catalog" default>
 
 1. Create AWS resources, including an S3 bucket, Glue database, and tables.
 
@@ -87,7 +87,7 @@ based on the catalog type:
 
 1. Add the following configurations to the Iceberg sink connector:
 
-   ```JSON
+   ```json
    {
       "iceberg.tables": "<database-name>.<table-name>",
       "iceberg.tables.auto-create-enabled": "false",
@@ -264,7 +264,7 @@ Parameters:
 
 ## Example: Define and create an Iceberg sink connector
 
-<Tabs groupId="catalog-type">
+<Tabs groupId="setup-method">
   <TabItem value="rest-catalog" label="AWS Glue as REST Catalog" default>
 
 This example shows how to create an Iceberg sink connector using AWS Glue as
@@ -351,8 +351,6 @@ Once these configurations are saved in `iceberg_sink_rest.json` or
 `iceberg_sink_glue.json`, you can create the connector using the Aiven Console or
 Aiven CLI. Verify that data from the Apache Kafka topic `test-topic` is successfully
 ingested into your Iceberg table.
-
-
 
 ## Related pages
 

--- a/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
@@ -36,6 +36,14 @@ The Iceberg sink connector supports the following configurations:
 - **Write format**: Supports Parquet format. Other formats, such as Avro and ORC,
   are not supported.
 
+## Future enhancements
+
+The following features are planned for future updates to the Iceberg sink connector:
+
+- **FileIO implementations:** Support for GCS and Azure FileIO.
+- **Write formats:** Additional support for Avro and ORC formats.
+- **Catalogs:** Expand catalog support to include Hive, JDBC, and Amazon S3 Tables.
+
 ## Prerequisites
 
 - An [Aiven for Apache Kafka® service](/docs/products/kafka/kafka-connect/howto/enable-connect)

--- a/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
@@ -1,6 +1,7 @@
 ---
 title: Create an Iceberg sink connector for Aiven for Apache Kafka®
 sidebar_label: Iceberg sink connector
+early: true
 ---
 
 import Tabs from '@theme/Tabs';
@@ -358,7 +359,15 @@ REST Catalog with the following properties:
   "iceberg.control.commit.interval-ms": "1000",
   "iceberg.control.commit.timeout-ms": "2147483647",
   "key.converter": "org.apache.kafka.connect.json.JsonConverter",
-  "value.converter": "org.apache.kafka.connect.json.JsonConverter"
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "iceberg.kafka.bootstrap.servers": "kafka.example.com:9092",
+  "iceberg.kafka.security.protocol": "SSL",
+  "iceberg.kafka.ssl.keystore.location": "/run/aiven/keys/public.keystore.p12",
+  "iceberg.kafka.ssl.keystore.password": "password",
+  "iceberg.kafka.ssl.keystore.type": "PKCS12",
+  "iceberg.kafka.ssl.truststore.location": "/run/aiven/keys/public.truststore.jks",
+  "iceberg.kafka.ssl.truststore.password": "<your-truststore-password>",
+  "iceberg.kafka.ssl.key.password": "<your-key-password>"
 }
 ```
 
@@ -399,7 +408,15 @@ with the following properties:
   "iceberg.control.commit.interval-ms": "1000",
   "iceberg.control.commit.timeout-ms": "2147483647",
   "key.converter": "org.apache.kafka.connect.json.JsonConverter",
-  "value.converter": "org.apache.kafka.connect.json.JsonConverter"
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "iceberg.kafka.bootstrap.servers": "kafka.example.com:9092",
+  "iceberg.kafka.security.protocol": "SSL",
+  "iceberg.kafka.ssl.keystore.location": "/run/aiven/keys/public.keystore.p12",
+  "iceberg.kafka.ssl.keystore.password": "password",
+  "iceberg.kafka.ssl.keystore.type": "PKCS12",
+  "iceberg.kafka.ssl.truststore.location": "/run/aiven/keys/public.truststore.jks",
+  "iceberg.kafka.ssl.truststore.password": "<your-truststore-password>",
+  "iceberg.kafka.ssl.key.password": "<your-key-password>"
 }
 ```
 
@@ -408,8 +425,8 @@ with the following properties:
 
 Once these configurations are saved in `iceberg_sink_rest.json` or
 `iceberg_sink_glue.json`, you can create the connector using the Aiven Console or
-Aiven CLI. Verify that data from the Apache Kafka topic `test-topic` is successfully
-ingested into your Iceberg table.
+Aiven CLI. Verify that the connector is running and that data from the Apache Kafka
+topic` test-topic` is successfully written to the Iceberg table.
 
 ## Related pages
 

--- a/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
@@ -16,12 +16,15 @@ information about the Apache Iceberg Sink Connector, see the
 
 ## Catalogs in Iceberg
 
-A catalog in Apache Iceberg serves as a layer to manage metadata related to your
-Iceberg tables. It connects the connector to storage backends, enabling
-schema management, table discovery, and configuration.
+A catalog in Apache Iceberg stores table metadata and supports key operations such as
+creating, renaming, and deleting tables. Catalogs manage collections of tables organized
+into namespaces and provide the metadata needed to access them.
 
-The Iceberg Sink Connector supports multiple catalog types, but the focus is on
-setting up and configuring:
+The Iceberg Sink Connector writes data to storage backends, while the catalog manages
+metadata to enable multiple compute engines to share a common data layer.
+
+The Iceberg Sink Connector for Aiven for Apache Kafka Connect currently supports the
+following catalog types:
 
 - **AWS Glue as REST Catalog:** An AWS-managed catalog leveraging the Iceberg REST API.
 - **AWS Glue as Glue Catalog:** A native AWS Glue implementation for Iceberg.
@@ -59,10 +62,10 @@ The following features are planned for future updates to the Iceberg sink connec
     details, see the
     [AWS Glue Data Catalog documentation](https://docs.aws.amazon.com/glue/latest/dg/start-data-catalog.html).
 
+## Create an Iceberg sink connector configuration file
 
-## Set up and configure
-
-Configure AWS Glue resources and the Iceberg Sink Connector.
+Create a JSON configuration file for the Iceberg Sink Connector. Use the examples below,
+based on the catalog type:
 
 <Tabs groupId="catalog-type">
   <TabItem value="rest-catalog" label="AWS Glue as REST Catalog" default>

--- a/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
@@ -8,30 +8,29 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import ConsoleLabel from "@site/src/components/non-swizzled/ConsoleIcons";
 
-Integrate Aiven for Apache Kafka with Apache Iceberg for real-time data ingestion into Iceberg tables.
+Integrate Aiven for Apache Kafka® with Apache Iceberg for real-time data ingestion into Iceberg tables.
 <!-- vale off -->
-The connector supports exactly-once delivery semantics, schema evolution, and metadata
-management, optimized for large-scale, high-performance data processing. For more
+The connector supports exactly-once delivery, schema evolution, and metadata management.
+It is optimized for large-scale, high-performance data processing. For more
 details, see the
 [official Iceberg documentation](https://iceberg.apache.org/docs/latest/kafka-connect/#apache-iceberg-sink-connector).
 
 ## Catalogs in Iceberg
 
-A catalog in Apache Iceberg stores table metadata and supports key operations such as
+In Apache Iceberg, a catalog stores table metadata and supports key operations such as
 creating, renaming, and deleting tables. Catalogs manage collections of tables organized
 into namespaces and provide the metadata needed for access.
 
 The Iceberg sink connector writes data to storage backends, while the catalog manages
-metadata, allowing multiple compute engines to share a common data layer. It supports
+metadata, enabling multiple compute engines to share a common data layer. It supports
 the following catalog types in Aiven for Apache Kafka Connect:
 
-- **AWS Glue as REST catalog:** An AWS-managed catalog leveraging the Iceberg REST API.
-- **AWS Glue as Glue catalog:** A native AWS Glue implementation for Iceberg.
+- **AWS Glue REST catalog:** An AWS-managed catalog leveraging the Iceberg REST API.
+- **AWS Glue catalog:** A native AWS Glue implementation for Iceberg.
 
 :::note
-When AWS Glue is used as a REST catalog, the connector cannot create tables
-automatically. You must manually create the tables in AWS Glue and match the schema to
-the Apache Kafka data.
+The AWS Glue REST catalog does not support automatic table creation. You must
+manually create tables in AWS Glue and ensure the schema matches the Apache Kafka data.
 :::
 
 For more details, see the
@@ -39,7 +38,7 @@ For more details, see the
 
 ## File I/O and write format
 
-The Iceberg sink connector supports the following configurations:
+The Iceberg sink connector supports the following settings:
 
 - **File I/O**: Supports `S3FileIO` for AWS S3 storage.
 
@@ -47,11 +46,11 @@ The Iceberg sink connector supports the following configurations:
 
 ## Future enhancements
 
-The following features are planned for future updates to the Iceberg sink connector:
+Future updates to the Iceberg sink connector includes:
 
 - **FileIO implementations:** Support for GCS and Azure FileIO.
 - **Write formats:** Additional support for Avro and ORC formats.
-- **Catalogs:** Expand catalog support to include Hive, JDBC, and Amazon S3 Tables.
+- **Catalogs:** Planned support for Hive, JDBC, and Amazon S3 Tables.
 
 ## Prerequisites
 
@@ -62,7 +61,7 @@ The following features are planned for future updates to the Iceberg sink connec
   - Create an **S3 bucket** to store data.
   - Configure **AWS IAM roles** with the following permissions:
     - Read and write access to the S3 bucket.
-    - Managing AWS Glue databases and tables.
+    - Manage AWS Glue databases and tables.
   - Create an **AWS Glue database and tables**:
     - If using the **AWS Glue REST catalog**, manually create tables and ensure the
       schema matches Apache Kafka records.
@@ -76,28 +75,26 @@ are not supported in this release.
 
 ## Create an Iceberg sink connector configuration
 
-To connect to the Iceberg control topic, the Iceberg sink connector requires Apache Kafka
-client settings. See the
+The Iceberg sink connector requires Apache Kafka client settings to connect to the
+Iceberg control topic. See the
 [Iceberg configuration](https://iceberg.apache.org/docs/latest/kafka-connect/#kafka-configuration)
-for a complete list of supported Kafka configurations.
+for a complete list of supported Apache Kafka configurations.
 
 :::note
-Loading worker properties, as described in the Iceberg documentation, is not supported
-in this release.
+Loading worker properties is not supported. Use `iceberg.kafka.*` properties instead.
 :::
 
-To configure the Iceberg sink connector, create a JSON configuration file. Use the
+To configure the Iceberg sink connector, define a JSON configuration file. Use the
 examples below based on your selected catalog type:
 
-
 <Tabs groupId="setup-method">
-  <TabItem value="rest-catalog" label="AWS Glue as REST catalog" default>
+  <TabItem value="rest-catalog" label="AWS Glue REST catalog" default>
 
 1. Create AWS resources, including an S3 bucket, Glue database, and tables.
 
    :::note
-   The AWS Glue REST catalog does not support automatic table creation. You must
-   manually create tables in AWS Glue and ensure the schema matches the Apache Kafka data.
+   The AWS Glue REST catalog does not support automatic table creation. Manually create
+   tables in AWS Glue and ensure the schema matches the Apache Kafka data.
    :::
 
 1. Add the following configurations to the Iceberg sink connector:
@@ -121,7 +118,7 @@ examples below based on your selected catalog type:
     "iceberg.control.commit.timeout-ms": "2147483647",
     "iceberg.catalog.type": "rest",
     "iceberg.catalog.uri": "https://glue.<your-aws-region>.amazonaws.com/iceberg",
-    "iceberg.catalog.warehouse": "<your-aws-account-id>",
+    "iceberg.catalog.warehouse": "s3://<your-bucket-name>",
     "iceberg.catalog.client.region": "<your-aws-region>",
     "iceberg.catalog.io-impl": "org.apache.iceberg.aws.s3.S3FileIO",
     "iceberg.catalog.rest.signing-name": "glue",
@@ -147,7 +144,7 @@ examples below based on your selected catalog type:
    Parameters:
 
    - `name`: Specify the connector name.
-   - `connector.class`: Set the connector class.
+   - `connector.class`: Defines the connector class.
      Use `org.apache.iceberg.connect.IcebergSinkConnector`.
    - `tasks.max`: Define the maximum number of tasks the connector can run.
    - `topics`: List the Apache Kafka topics containing data for Iceberg tables.
@@ -197,9 +194,9 @@ examples below based on your selected catalog type:
      S3 authentication.
    - `iceberg.catalog.s3.path-style-access`: Enable (`true`) or disable (`false`)
      path-style access for S3 buckets.
-   - `iceberg.kafka.bootstrap.servers`: Specify the Kafka broker connection details
+   - `iceberg.kafka.bootstrap.servers`: Define the Kafka broker connection details
      in `<APACHE_KAFKA_HOST>:<APACHE_KAFKA_PORT>` format.
-   - `iceberg.kafka.security.protocol`: Set the security protocol. Use `SSL` for
+   - `iceberg.kafka.security.protocol`: Defines the security protocol. Use `SSL` for
      encrypted communication.
    - `iceberg.kafka.ssl.keystore.location`: Specify the file path to the keystore
      containing the SSL certificate.
@@ -259,7 +256,7 @@ examples below based on your selected catalog type:
 
    Parameters:
 
-   Use the same parameters as those listed for AWS Glue as REST catalog, except for
+   Use the same parameters as those listed for AWS Glue REST catalog, except for
    the following differences:
 
    - `iceberg.tables.auto-create-enabled`: Set to `true` to enable automatic table
@@ -270,7 +267,7 @@ examples below based on your selected catalog type:
      AWS Glue catalog.
 
    :::note
-   The Kafka security settings remain the same as in the AWS Glue as REST catalog
+   The Kafka security settings remain the same as in the AWS Glue REST catalog
    configuration.
    :::
 
@@ -288,7 +285,7 @@ see [Iceberg configuration](https://iceberg.apache.org/docs/latest/kafka-connect
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
 1. Click <ConsoleLabel name="Connectors"/>.
-1. Click **Create connector** if Apache Kafka Connect is already enabled on the service.
+1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
    If not, click **Enable connector on this service**.
 
    Alternatively, to enable connectors:
@@ -325,7 +322,7 @@ Parameters:
 ## Example: Define and create an Iceberg sink connector
 
 <Tabs groupId="setup-method">
-  <TabItem value="rest-catalog" label="AWS Glue as REST catalog" default>
+  <TabItem value="rest-catalog" label="AWS Glue REST catalog" default>
 
 This example shows how to create an Iceberg sink connector using AWS Glue as
 REST Catalog with the following properties:
@@ -366,8 +363,8 @@ REST Catalog with the following properties:
   "iceberg.kafka.ssl.keystore.password": "password",
   "iceberg.kafka.ssl.keystore.type": "PKCS12",
   "iceberg.kafka.ssl.truststore.location": "/run/aiven/keys/public.truststore.jks",
-  "iceberg.kafka.ssl.truststore.password": "<your-truststore-password>",
-  "iceberg.kafka.ssl.key.password": "<your-key-password>"
+  "iceberg.kafka.ssl.truststore.password": "password",
+  "iceberg.kafka.ssl.key.password": "password"
 }
 ```
 
@@ -415,8 +412,8 @@ with the following properties:
   "iceberg.kafka.ssl.keystore.password": "password",
   "iceberg.kafka.ssl.keystore.type": "PKCS12",
   "iceberg.kafka.ssl.truststore.location": "/run/aiven/keys/public.truststore.jks",
-  "iceberg.kafka.ssl.truststore.password": "<your-truststore-password>",
-  "iceberg.kafka.ssl.key.password": "<your-key-password>"
+  "iceberg.kafka.ssl.truststore.password": "password",
+  "iceberg.kafka.ssl.key.password": "password"
 }
 ```
 
@@ -426,7 +423,7 @@ with the following properties:
 Once these configurations are saved in `iceberg_sink_rest.json` or
 `iceberg_sink_glue.json`, you can create the connector using the Aiven Console or
 Aiven CLI. Verify that the connector is running and that data from the Apache Kafka
-topic` test-topic` is successfully written to the Iceberg table.
+topic `test-topic` is successfully written to the Iceberg table.
 
 ## Related pages
 

--- a/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
@@ -10,7 +10,9 @@ import ConsoleLabel from "@site/src/components/non-swizzled/ConsoleIcons";
 Integrate Aiven for Apache Kafka with Apache Iceberg for real-time data ingestion into Iceberg tables.
 <!-- vale off -->
 The connector supports exactly-once delivery semantics, schema evolution, and metadata
-management, making it ideal for high-performance, large-scale data processing.
+management, optimized for large-scale, high-performance data processing. For more
+information about the Apache Iceberg Sink Connector, see the
+[official Iceberg documentation](https://iceberg.apache.org/docs/latest/kafka-connect/#apache-iceberg-sink-connector).
 
 ## Catalogs in Iceberg
 
@@ -24,29 +26,31 @@ setting up and configuring:
 - **AWS Glue as REST Catalog:** An AWS-managed catalog leveraging the Iceberg REST API.
 - **AWS Glue as Glue Catalog:** A native AWS Glue implementation for Iceberg.
 
+## FileIO and write format support
+
+The Iceberg sink connector supports the following configurations:
+
+- **FileIO**: Supports S3FileIO for AWS S3 storage. Other implementations, such as GCS,
+  ADLS, and Hadoop, are not supported.
+
+- **Write format**: Supports Parquet format. Other formats, such as Avro and ORC,
+  are not supported.
+
 ## Prerequisites
 
 - An [Aiven for Apache Kafka® service](/docs/products/kafka/kafka-connect/howto/enable-connect)
-  with Apache Kafka Connect enabled or a
+  with Apache Kafka Connect enabled, or a
   [dedicated Aiven for Apache Kafka Connect® service](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
+- AWS-specific setup:
+  - Create an S3 bucket for storing data.
+  - Configure AWS IAM roles with permissions for:
+    - Read and write access to the S3 bucket.
+    - Managing AWS Glue databases and tables.
+  - Create an AWS Glue database and tables. For REST Catalog, ensure the schema matches
+    the Apache Kafka records and specify the S3 bucket as the storage location. For more
+    details, see the
+    [AWS Glue Data Catalog documentation](https://docs.aws.amazon.com/glue/latest/dg/start-data-catalog.html).
 
-### AWS Glue as REST Catalog
-
-- Create an S3 bucket for storing data.
-- Set up AWS IAM roles with permissions for:
-  - Read/write access to the S3 bucket.
-  - AWS Glue database and table management.
-- Create an AWS Glue database and tables with a schema matching the Apache Kafka records.
-  Specify the created S3 bucket as the storage location. For detailed steps, see
-  the [AWS Glue Data Catalog documentation](https://docs.aws.amazon.com/glue/latest/dg/start-data-catalog.html).
-
-### AWS Glue as Glue Catalog
-
-- Create an S3 bucket for storing data.
-- Set up AWS IAM roles with permissions for:
-  - Read/write access to the S3 bucket.
-  - AWS Glue database and table management.
-- Create an AWS Glue database and tables.
 
 ## Set up and configure
 
@@ -188,7 +192,7 @@ Configure AWS Glue resources and the Iceberg Sink Connector.
 </TabItem>
 </Tabs>
 
-## Create the connector
+## Create the Iceberg sink connector
 
 <Tabs groupId="setup-method">
   <TabItem value="console" label="Aiven Console" default>
@@ -319,3 +323,10 @@ Once these configurations are saved in `iceberg_sink_rest.json` or
 `iceberg_sink_glue.json`, you can create the connector using the Aiven Console or
 Aiven CLI. Verify that data from the Apache Kafka topic `test-topic` is successfully
 ingested into your Iceberg table.
+
+
+
+## Related pages
+
+- [Apache Iceberg sink connector](https://iceberg.apache.org/docs/latest/kafka-connect/#apache-iceberg-sink-connector)
+- [AWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/start-data-catalog.html)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -976,6 +976,7 @@ const sidebars: SidebarsConfig = {
                         'products/kafka/kafka-connect/howto/gcs-sink',
                         'products/kafka/kafka-connect/howto/http-sink',
                         'products/kafka/kafka-connect/howto/ibm-mq-sink-connector',
+                        'products/kafka/kafka-connect/howto/iceberg-sink-connector',
                         'products/kafka/kafka-connect/howto/influx-sink',
                         'products/kafka/kafka-connect/howto/jdbc-sink',
                         'products/kafka/kafka-connect/howto/mongodb-sink-lenses',


### PR DESCRIPTION
## Describe your changes

Add content for Iceberg sink connector to Apache Kafka Connect for real-time data ingestion into Iceberg tables.
- Support for AWS Glue as REST Catalog and AWS Glue Catalog.

[KCON-80](https://aiven.atlassian.net/browse/KCON-80)

Preview - https://harshini-iceberg-sink-connec.aiven-docs.pages.dev/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.


[KCON-80]: https://aiven.atlassian.net/browse/KCON-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ