### PR TITLE
update: cassandra 4.0 EoL and EoA dates

### DIFF
--- a/docs/platform/reference/eol-for-major-versions.md
+++ b/docs/platform/reference/eol-for-major-versions.md
@@ -100,7 +100,7 @@ after they are made available on the Aiven platform.
 | Version | Aiven EOL  | Service creation supported until | Service creation supported from |
 | ------- | ---------- | -------------------------------- | ------------------------------- |
 | 3       | 2022-07-27 | 2022-04-27                       | 2018-11-08                      |
-| 4.0     | 2024-09-30 | 2024-09-30                       | 2021-12-09                      |
+| 4.0     | 2025-01-31 | 2024-10-31                       | 2021-12-09                      |
 | 4.1     | 2025-09-30 | To be announced                  | 2024-01-18                      |
 
 


### PR DESCRIPTION
## Describe your changes

Cassandra 4.0 EoL and EoA dates were extended, but we missed updating the docs in https://aiven.atlassian.net/browse/DDB-1055. Fix with the correct dates.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](styleguide.md).
- [X] My links start with `/docs/`.
