### PR TITLE
update: Added note about M3 deprecation

### DIFF
--- a/docs/platform/concepts/service_backups.md
+++ b/docs/platform/concepts/service_backups.md
@@ -9,8 +9,7 @@ import Variables from "@site/static/variables.json"
 
 Most services have automatic time-based backups that are encrypted and securely stored.
 
-**Backed-up services:** All Aiven services, except for Apache Kafka® and M3
-Aggregator/Coordinator.
+**Backed-up services:** All Aiven services, except for Apache Kafka®.
 
 **Backup location:** Backups are stored in the object storage of the cloud region
 where the service is first created, for example, S3 for AWS or GCS for GCP.
@@ -127,20 +126,6 @@ data.
       <td>Hourly backup up to 2 hours</td>
       <td>Hourly backup up to 2 hours</td>
       <td>Plan not available</td>
-    </tr>
-    <tr>
-      <td>Aiven for M3</td>
-      <td>Plan not available</td>
-      <td>Single day backup</td>
-      <td>Daily backup up to 6 days</td>
-      <td>Daily backup up to 13 days</td>
-    </tr>
-    <tr>
-      <td>Aiven for M3 Aggregator / Coordinator</td>
-      <td>Plan not available</td>
-      <td>Plan not available</td>
-      <td>No backups</td>
-      <td>No backups</td>
     </tr>
     <tr>
       <td>Aiven for Grafana®</td>

--- a/docs/products/m3db.md
+++ b/docs/products/m3db.md
@@ -9,10 +9,11 @@ Aiven for M3 consists of `n` number of **M3DB** and **M3 Coordinator**
 pairs (where `n` is the number of nodes as chosen for your Aiven plan).
 
 :::important
-Aiven for M3DB will be deprecated later this year. Consider using
-[Aiven for Metrics](/docs/products/metrics) as an alternative.
+Aiven for M3DB will be **deprecated later this year and will no longer be available.**
+Use [Aiven for Metrics](/docs/products/metrics), powered by Thanos, to store and q
+uery metrics efficiently.
 
-For details about the deprecation timeline and migration options, see
+For details on the deprecation timeline and migration options, see
 [Aiven for M3DB end of life](/docs/platform/reference/end-of-life#aiven-for-m3db).
 :::
 

--- a/docs/products/m3db.md
+++ b/docs/products/m3db.md
@@ -9,9 +9,9 @@ Aiven for M3 consists of `n` number of **M3DB** and **M3 Coordinator**
 pairs (where `n` is the number of nodes as chosen for your Aiven plan).
 
 :::important
-Aiven for M3DB will be **deprecated later this year and will no longer be available.**
-Use [Aiven for Metrics](/docs/products/metrics), powered by Thanos, to store and q
-uery metrics efficiently.
+Aiven for M3DB will be **deprecated later this year and will no longer be available**.
+Use [Aiven for Metrics](/docs/products/metrics), powered by Thanos, to store and
+query metrics efficiently.
 
 For details on the deprecation timeline and migration options, see
 [Aiven for M3DB end of life](/docs/platform/reference/end-of-life#aiven-for-m3db).

--- a/docs/products/m3db.md
+++ b/docs/products/m3db.md
@@ -8,15 +8,12 @@ Aiven for M3 is a fully managed **distributed time series database**, deployable
 Aiven for M3 consists of `n` number of **M3DB** and **M3 Coordinator**
 pairs (where `n` is the number of nodes as chosen for your Aiven plan).
 
-M3 is a great choice if your organization has a very large volume of
-metrics to handle, and it can be used as part of your observability
-solution. It is optimized for storing and serving time series through
-associated pairs of times and values. It also provides a reverse index
-of time series.
+:::important
+Aiven for M3DB will be deprecated later this year. Consider using
+[Aiven for Metrics](/docs/products/metrics) as an alternative.
 
-:::note
-Aiven offers M3 because we ourselves needed a solution that would work
-with the size of our own metrics.
+For details about the deprecation timeline and migration options, see
+[Aiven for M3DB end of life](/docs/platform/reference/end-of-life#aiven-for-m3db).
 :::
 
 Read more about [the M3

--- a/docs/products/m3db/get-started.md
+++ b/docs/products/m3db/get-started.md
@@ -8,7 +8,17 @@ To begin your journey with Aiven for M3DB, there are two M3-related
 services available in the [Aiven console](https://console.aiven.io).
 Start with an **M3DB** service, which is responsible for data storage.
 Follow
-[these instructions](/docs/platform/howto/create_new_service) to create an Aiven for M3DB service.
+[these instructions](/docs/platform/howto/create_new_service) to create an
+Aiven for M3DB service.
+
+:::important
+Aiven for M3DB will be deprecated later this year. Consider using
+[Aiven for Metrics](/docs/products/metrics) as an alternative.
+
+For details about the deprecation timeline and migration options, see
+[Aiven for M3DB end of life](/docs/platform/reference/end-of-life#aiven-for-m3db).
+:::
+
 
 For initial experimentation with M3DB, you can opt for a single-node
 setup using our startup plans. However, it is important to note that


### PR DESCRIPTION
## Describe your changes

- Added a note about M3DB deprecation.  
- Removed references to M3DB in the service backup table. 

[MA-3203](https://aiven.atlassian.net/browse/MA-3203)
[DOC-1298](https://aiven.atlassian.net/browse/DOC-1298)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.


[MA-3203]: https://aiven.atlassian.net/browse/MA-3203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-1298]: https://aiven.atlassian.net/browse/DOC-1298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ