### PR TITLE
update: add base URL to Okta provisioning instructions

### DIFF
--- a/docs/platform/howto/saml/add-okta-idp.md
+++ b/docs/platform/howto/saml/add-okta-idp.md
@@ -72,7 +72,8 @@ To configure user provisioning for Okta:
 1. Click **Provisioning**.
 1. Click **Settings** > **Integration** > **Configure API Integration**.
 1. Select **Enable API Integration**.
-1. In the **API Token field**, paste the **Access token** from the Aiven Console.
+1. In the **Base URL** field, paste the **Base URL** from the Aiven Console.
+1. In the **API Token** field, paste the **Access token** from the Aiven Console.
 1. Click **Test API Credentials** to confirm the connection is working
    and save the configuration.
    :::important


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
