### PR TITLE
update: Datadog integration withdrawal for startup-2 plans

### DIFF
--- a/docs/integrations/datadog.md
+++ b/docs/integrations/datadog.md
@@ -21,6 +21,12 @@ If you're using Aiven for Apache Kafka® you can also
 [customise the metrics sent to Datadog](/docs/products/kafka/howto/datadog-customised-metrics).
 :::
 
+:::note
+New `startup-2` plans in Aiven for Apache Kafka do not support Datadog integration.
+Upgrade to a `business-4` plan or higher to enable Datadog. Existing services with
+Datadog integration are not affected.
+:::
+
 ## Datadog for logs
 
 The RSyslog integration can be used with any Aiven service to send the

--- a/docs/integrations/datadog.md
+++ b/docs/integrations/datadog.md
@@ -23,10 +23,15 @@ If you're using Aiven for Apache Kafka® you can also
 
 :::note
 Datadog integration is not available for new Startup-2 plans in Aiven for Apache Kafka.
-Upgrade to a Business-4 plan or higher to use Datadog. Existing services with
-Datadog integration are not affected.
+Existing customers using Startup-2 with Datadog integration can continue to create new
+Startup-2 plans with Datadog integration and use their existing services without
+upgrading to a higher plan.
 
-If you have questions, contact [Aiven Support](mailto:support@aiven.io).
+Aiven recommends using a **Business-4 plan or higher** for Aiven for Apache Kafka
+services with Datadog integration to avoid resource pressure on Startup-2 plans.
+
+If you are an existing customer and cannot create a Startup-2 plan with Datadog
+integration in a new project, contact [Aiven Support](mailto:support@aiven.io).
 :::
 
 ## Datadog for logs

--- a/docs/integrations/datadog.md
+++ b/docs/integrations/datadog.md
@@ -22,9 +22,11 @@ If you're using Aiven for Apache Kafka® you can also
 :::
 
 :::note
-New `startup-2` plans in Aiven for Apache Kafka do not support Datadog integration.
-Upgrade to a `business-4` plan or higher to enable Datadog. Existing services with
+Datadog integration is not available for new Startup-2 plans in Aiven for Apache Kafka.
+Upgrade to a Business-4 plan or higher to use Datadog. Existing services with
 Datadog integration are not affected.
+
+If you have questions, contact [Aiven Support](mailto:support@aiven.io).
 :::
 
 ## Datadog for logs

--- a/docs/integrations/datadog.md
+++ b/docs/integrations/datadog.md
@@ -2,6 +2,8 @@
 title: Datadog and Aiven
 ---
 
+import Note from "@site/static/includes/startup-plan-datadog.md"
+
 [Datadog](https://www.datadoghq.com/) is a monitoring platform, allowing
 you to keep an eye on all aspects of your cloud estate. Aiven has
 integrations that make it easy to include an Aiven service in your
@@ -21,18 +23,7 @@ If you're using Aiven for Apache Kafka® you can also
 [customise the metrics sent to Datadog](/docs/products/kafka/howto/datadog-customised-metrics).
 :::
 
-:::note
-Datadog integration is not available for new Startup-2 plans in Aiven for Apache Kafka.
-Existing customers using Startup-2 with Datadog integration can continue to create new
-Startup-2 plans with Datadog integration and use their existing services without
-upgrading to a higher plan.
-
-Aiven recommends using a **Business-4 plan or higher** for Aiven for Apache Kafka
-services with Datadog integration to avoid resource pressure on Startup-2 plans.
-
-If you are an existing customer and cannot create a Startup-2 plan with Datadog
-integration in a new project, contact [Aiven Support](mailto:support@aiven.io).
-:::
+<Note/>
 
 ## Datadog for logs
 

--- a/docs/integrations/datadog/datadog-metrics.md
+++ b/docs/integrations/datadog/datadog-metrics.md
@@ -29,9 +29,11 @@ You can use the Datadog integration endpoint for multiple services.
 ## Add a Datadog metrics integration to an Aiven service
 
 :::note
-Datadog integration is not available for new `startup-2` plans in Aiven for Apache Kafka.
-Upgrade to a higher-tier plan that supports Datadog. Existing services with Datadog
-integration are not affected.
+Datadog integration is not available for new Startup-2 plans in Aiven for Apache Kafka.
+Upgrade to a Business-4 plan or higher to use Datadog. Existing services with
+Datadog integration are not affected.
+
+If you have questions, contact [Aiven Support](mailto:support@aiven.io).
 :::
 
 1.  In the service, click **Integrations**.

--- a/docs/integrations/datadog/datadog-metrics.md
+++ b/docs/integrations/datadog/datadog-metrics.md
@@ -28,6 +28,12 @@ You can use the Datadog integration endpoint for multiple services.
 
 ## Add a Datadog metrics integration to an Aiven service
 
+:::note
+Datadog integration is not available for new `startup-2` plans in Aiven for Apache Kafka.
+Upgrade to a higher-tier plan that supports Datadog. Existing services with Datadog
+integration are not affected.
+:::
+
 1.  In the service, click **Integrations**.
 1.  In the **Endpoint integrations** select **Datadog Metrics**.
 1.  Select your Datadog integration endpoint and click **Enable**.

--- a/docs/integrations/datadog/datadog-metrics.md
+++ b/docs/integrations/datadog/datadog-metrics.md
@@ -30,10 +30,15 @@ You can use the Datadog integration endpoint for multiple services.
 
 :::note
 Datadog integration is not available for new Startup-2 plans in Aiven for Apache Kafka.
-Upgrade to a Business-4 plan or higher to use Datadog. Existing services with
-Datadog integration are not affected.
+Existing customers using Startup-2 with Datadog integration can continue to create new
+Startup-2 plans with Datadog integration and use their existing services without
+upgrading to a higher plan.
 
-If you have questions, contact [Aiven Support](mailto:support@aiven.io).
+Aiven recommends using a **Business-4 plan or higher** for Aiven for Apache Kafka
+services with Datadog integration to avoid resource pressure on Startup-2 plans.
+
+If you are an existing customer and cannot create a Startup-2 plan with Datadog
+integration in a new project, contact [Aiven Support](mailto:support@aiven.io).
 :::
 
 1.  In the service, click **Integrations**.

--- a/docs/integrations/datadog/datadog-metrics.md
+++ b/docs/integrations/datadog/datadog-metrics.md
@@ -4,6 +4,7 @@ title: Send metrics to Datadog
 
 import ConsoleLabel from "@site/src/components/non-swizzled/ConsoleIcons"
 import RelatedPages from "@site/src/components/non-swizzled/RelatedPages";
+import Note from "@site/static/includes/startup-plan-datadog.md"
 
 Send metrics from your Aiven service to your external Datadog account.
 
@@ -28,18 +29,7 @@ You can use the Datadog integration endpoint for multiple services.
 
 ## Add a Datadog metrics integration to an Aiven service
 
-:::note
-Datadog integration is not available for new Startup-2 plans in Aiven for Apache Kafka.
-Existing customers using Startup-2 with Datadog integration can continue to create new
-Startup-2 plans with Datadog integration and use their existing services without
-upgrading to a higher plan.
-
-Aiven recommends using a **Business-4 plan or higher** for Aiven for Apache Kafka
-services with Datadog integration to avoid resource pressure on Startup-2 plans.
-
-If you are an existing customer and cannot create a Startup-2 plan with Datadog
-integration in a new project, contact [Aiven Support](mailto:support@aiven.io).
-:::
+<Note/>
 
 1.  In the service, click **Integrations**.
 1.  In the **Endpoint integrations** select **Datadog Metrics**.

--- a/docs/products/kafka/howto/datadog-customised-metrics.md
+++ b/docs/products/kafka/howto/datadog-customised-metrics.md
@@ -14,9 +14,11 @@ When creating a [Datadog service integration](https://docs.datadoghq.com/integra
 - A [Datadog integration endpoint](/docs/integrations/datadog/datadog-metrics#add-a-datadog-metrics-integration-to-an-aiven-service)
 
 :::note
-Datadog integration is not available for new `startup-2` plans in Aiven for Apache Kafka.
-Upgrade to a higher-tier plan that supports Datadog. Existing services with
+Datadog integration is not available for new Startup-2 plans in Aiven for Apache Kafka.
+Upgrade to a Business-4 plan or higher to use Datadog. Existing services with
 Datadog integration are not affected.
+
+If you have questions, contact [Aiven Support](mailto:support@aiven.io).
 :::
 
 ## Supported metrics

--- a/docs/products/kafka/howto/datadog-customised-metrics.md
+++ b/docs/products/kafka/howto/datadog-customised-metrics.md
@@ -3,6 +3,7 @@ title: Configure Apache Kafka® metrics sent to Datadog
 ---
 
 import RelatedPages from "@site/src/components/non-swizzled/RelatedPages";
+import Note from "@site/static/includes/startup-plan-datadog.md"
 
 When creating a [Datadog service integration](https://docs.datadoghq.com/integrations/kafka/?tab=host#kafka-consumer-integration), you can customize which metrics are sent to the Datadog endpoint using the [Aiven CLI](/docs/tools/cli).
 
@@ -13,19 +14,7 @@ When creating a [Datadog service integration](https://docs.datadoghq.com/integra
 - A Datadog [API key](https://docs.datadoghq.com/account_management/api-app-keys/)
 - A [Datadog integration endpoint](/docs/integrations/datadog/datadog-metrics#add-a-datadog-metrics-integration-to-an-aiven-service)
 
-:::note
-Datadog integration is not available for new Startup-2 plans in Aiven for Apache Kafka.
-Existing customers using Startup-2 with Datadog integration can continue to create new
-Startup-2 plans with Datadog integration and use their existing services without
-upgrading to a higher plan.
-
-Aiven recommends using a **Business-4 plan or higher** for Aiven for Apache Kafka
-services with Datadog integration to avoid resource pressure on Startup-2 plans.
-
-If you are an existing customer and cannot create a Startup-2 plan with Datadog
-integration in a new project, contact [Aiven Support](mailto:support@aiven.io).
-:::
-
+<Note/>
 
 ## Supported metrics
 

--- a/docs/products/kafka/howto/datadog-customised-metrics.md
+++ b/docs/products/kafka/howto/datadog-customised-metrics.md
@@ -15,11 +15,17 @@ When creating a [Datadog service integration](https://docs.datadoghq.com/integra
 
 :::note
 Datadog integration is not available for new Startup-2 plans in Aiven for Apache Kafka.
-Upgrade to a Business-4 plan or higher to use Datadog. Existing services with
-Datadog integration are not affected.
+Existing customers using Startup-2 with Datadog integration can continue to create new
+Startup-2 plans with Datadog integration and use their existing services without
+upgrading to a higher plan.
 
-If you have questions, contact [Aiven Support](mailto:support@aiven.io).
+Aiven recommends using a **Business-4 plan or higher** for Aiven for Apache Kafka
+services with Datadog integration to avoid resource pressure on Startup-2 plans.
+
+If you are an existing customer and cannot create a Startup-2 plan with Datadog
+integration in a new project, contact [Aiven Support](mailto:support@aiven.io).
 :::
+
 
 ## Supported metrics
 

--- a/docs/products/kafka/howto/datadog-customised-metrics.md
+++ b/docs/products/kafka/howto/datadog-customised-metrics.md
@@ -6,6 +6,19 @@ import RelatedPages from "@site/src/components/non-swizzled/RelatedPages";
 
 When creating a [Datadog service integration](https://docs.datadoghq.com/integrations/kafka/?tab=host#kafka-consumer-integration), you can customize which metrics are sent to the Datadog endpoint using the [Aiven CLI](/docs/tools/cli).
 
+## Prerequisites
+
+- A running Aiven for Apache Kafka service
+- A Datadog account
+- A Datadog [API key](https://docs.datadoghq.com/account_management/api-app-keys/)
+- A [Datadog integration endpoint](/docs/integrations/datadog/datadog-metrics#add-a-datadog-metrics-integration-to-an-aiven-service)
+
+:::note
+Datadog integration is not available for new `startup-2` plans in Aiven for Apache Kafka.
+Upgrade to a higher-tier plan that supports Datadog. Existing services with
+Datadog integration are not affected.
+:::
+
 ## Supported metrics
 
 The following metrics are currently supported for each topic and
@@ -35,23 +48,21 @@ avn service integration-list SERVICE_NAME
 
 ## Customize metrics for Datadog
 
-Before customizing metrics, ensure a Datadog endpoint is configured and
-enabled in your Aiven for Apache Kafka service. For setup instructions,
-see
+Before customizing metrics, configure and enable a Datadog endpoint in your
+Aiven for Apache Kafka service.
+For setup instructions, see
 [Send metrics to Datadog](/docs/integrations/datadog/datadog-metrics).
+
 Format any listed parameters as a comma-separated list:
 `['value0', 'value1', 'value2', ...]`.
 
-To customize the metrics sent to Datadog, you can use the
-`service integration-update` passing the following customized
-parameters:
-
--   `kafka_custom_metrics`: defining the comma-separated list of custom
-    metrics to include (within `kafka.log.log_size`,
-    `kafka.log.log_start_offset` and `kafka.log.log_end_offset`).
+To customize the metrics sent to Datadog, use the `service integration-update` command
+with the `kafka_custom_metrics` parameter. Specify a comma-separated list of custom
+metrics, such as `kafka.log.log_size`, `kafka.log.log_start_offset`, and
+`kafka.log.log_end_offset`.
 
 For example, to send the `kafka.log.log_size` and
-`kafka.log.log_end_offset` metrics, execute the following code:
+`kafka.log.log_end_offset` metrics, run:
 
 ```bash
 avn service integration-update                                                \
@@ -66,33 +77,28 @@ After updating settings, view the collected metrics in your Datadog explorer.
 [Apache Kafka Consumer
 Integration](https://docs.datadoghq.com/integrations/kafka/?tab=host#kafka-consumer-integration)
 collects metrics for message offsets. To customize the metrics sent from
-this Datadog integration to Datadog, you can use the
-`service integration-update` passing the following customized
-parameters:
+this Datadog integration to Datadog, use the `service integration-update` command with
+the following parameters:
 
--   `include_topics`: Specify a comma-separated list of topics to
-    include.
+- `include_topics`: A comma-separated list of topics to include.
 
-    :::note
-    By default, all topics are included.
-    :::
+  :::note
+  By default, all topics are included.
+  :::
 
--   `exclude_topics`: Specify a comma-separated list of topics to
-    exclude.
+- `exclude_topics`: A comma-separated list of topics to exclude.
 
-    :::warning
-    To use `exclude_topics`, you must specify at least one `include_consumer_groups`
-    value. Without this, `exclude_topics` does not take effect.
-    :::
+  :::warning
+  To use `exclude_topics`, you must specify at least one `include_consumer_groups`
+  value. Otherwise, `exclude_topics` does not take effect.
+  :::
 
--   `include_consumer_groups`: Specify a comma-separated list of
-    consumer groups to include.
+- `include_consumer_groups`: A comma-separated list of consumer groups to include.
 
--   `exclude_consumer_groups`: Specify a comma-separated list of
-    consumer groups to exclude.
+- `exclude_consumer_groups`: A comma-separated list of consumer groups to exclude.
 
 For example, to include topics `topic1` and `topic2`, and exclude
-`topic3`, execute the following command:
+`topic3`, run:
 
 ```bash
 avn service integration-update                                                  \

--- a/static/includes/startup-plan-datadog.md
+++ b/static/includes/startup-plan-datadog.md
@@ -1,0 +1,12 @@
+:::note
+Datadog integration is not available for new Startup-2 plans in Aiven for Apache Kafka.
+Existing customers using Startup-2 with Datadog integration can continue to create new
+Startup-2 plans with Datadog integration and use their existing services without
+upgrading to a higher plan.
+
+Aiven recommends using a **Business-4 plan or higher** for Aiven for Apache Kafka
+services with Datadog integration to avoid resource pressure on Startup-2 plans.
+
+If you are an existing customer and cannot create a Startup-2 plan with Datadog
+integration in a new project, contact [Aiven Support](mailto:support@aiven.io).
+:::


### PR DESCRIPTION
## Describe your changes

Update docs to reflect Datadog integration removal for new startup-2 Kafka plans.

[HH-5111](https://aiven.atlassian.net/browse/HH-5111)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.


[HH-5111]: https://aiven.atlassian.net/browse/HH-5111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ