### PR TITLE
fix: wording in the ECE doc 

### DIFF
--- a/docs/platform/concepts/enhanced-compliance-env.md
+++ b/docs/platform/concepts/enhanced-compliance-env.md
@@ -12,7 +12,7 @@ the standard Aiven deployment environment. This decreases the blast
 radius of the environment to prevent inadvertent data sharing.
 
 <!-- vale off -->
-Users of an ECE **must** encrypt all data before reaching
+Users of an ECE **must** encrypt all regulated data before reaching
 an Aiven service. As part of the increased compliance of the
 environment, enhanced logging is enabled for - `stderr`, `stout`, and
 `stdin`.


### PR DESCRIPTION
https://aiven.atlassian.net/browse/DOC-1328

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
