### PR TITLE
fix: reducing the number of nodes is now possible

### DIFF
--- a/docs/products/clickhouse/reference/limitations.md
+++ b/docs/products/clickhouse/reference/limitations.md
@@ -142,11 +142,6 @@ a
         or the [Aiven Console](https://console.aiven.io/).
       </td>
     </tr>
-    <tr>
-      <td>Scaling down the number of nodes</td>
-      <td>You only can scale up the number of nodes in a cluster.</td>
-      <td>N/A</td>
-    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
## Describe your changes

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
