### PR TITLE
fix: remove cloud providers from PG max connections list

### DIFF
--- a/docs/products/postgresql/reference/pg-connection-limits.md
+++ b/docs/products/postgresql/reference/pg-connection-limits.md
@@ -7,15 +7,15 @@ Aiven for PostgreSQL® instances limit the number of allowed connections to make
 
 The `max_connections` setting varies according to the service plan as follows:
 
-| Plan                                                    | Max connections |
-| ------------------------------------------------------- | --------------- |
-| Free (DigitalOcean only)                                | 20              |
-| Hobbyist (Google Cloud, DigitalOcean, and UpCloud only) | 25              |
-| Startup/Business/Premium-4                              | 100             |
-| Startup/Business/Premium-8                              | 200             |
-| Startup/Business/Premium-16                             | 400             |
-| Startup/Business/Premium-32                             | 800             |
-| Startup/Business/Premium-64 and above                   | 1000            |
+|                 Plan                  | Max connections |
+| ------------------------------------- | --------------- |
+| Free                                  | 20              |
+| Hobbyist                              | 25              |
+| Startup/Business/Premium-4            | 100             |
+| Startup/Business/Premium-8            | 200             |
+| Startup/Business/Premium-16           | 400             |
+| Startup/Business/Premium-32           | 800             |
+| Startup/Business/Premium-64 and above | 1000            |
 
 :::note
 Aiven can utilize any number of the connections for managing the service.


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
