### PR TITLE
fix: IdP category title

### DIFF
--- a/docs/platform/howto/list-identity-providers.md
+++ b/docs/platform/howto/list-identity-providers.md
@@ -1,5 +1,5 @@
 ---
-title: Identity providers and SAML authentication
+title: SAML identity providers and verified domains
 sidebar_label: Identity providers
 ---
 


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
