### PR TITLE
fix: Correct the `avn` tiered storage topic commands

### DIFF
--- a/docs/products/kafka/howto/configure-topic-tiered-storage.md
+++ b/docs/products/kafka/howto/configure-topic-tiered-storage.md
@@ -70,11 +70,10 @@ To create a topic with tiered storage enabled:
 ```bash
 avn service topic-create \
     --project demo-kafka-project \
-    --service-name demo-kafka-service \
-    --topic exampleTopic \
     --partitions 2 \
     --replication 2 \
-    --remote-storage-enable
+    --remote-storage-enable \
+    demo-kafka-service exampleTopic
 ```
 
 In this example:
@@ -91,10 +90,10 @@ After enabling tiered storage, you can configure the retention policies for loca
 ```bash
 avn service topic-update \
   --project demo-kafka-project \
-  --service-name demo-kafka-service \
-  --topic exampleTopic \
+  --partitions 2 \
   --local-retention-ms 100 \
-  --local-retention-bytes 10
+  --local-retention-bytes 10 \
+  demo-kafka-service exampleTopic
 ```
 
 This command sets the local retention time to 100 milliseconds and the local retention


### PR DESCRIPTION
With `avn` version 4.6.1, the commands as originally given do not work, as there are no `--service-name` or `--topic` switches for `topic-create` or `topic-update`.

## Describe your changes

With
```
$ avn --version
aiven-client 4.6.1
```

there are no `--service-name` or `--topic` switches for `topic-create` and `topic-update`.

So for instance:
```
$ avn service topic-update \
          --project $PROJECT_NAME \
          --service-name $KAFKA_SERVICE_NAME \
          --topic $KAFKA_TOPIC_NAME        \
          --remote-storage-enable            \
          --local-retention-ms 5000

usage: avn service topic-update [-h] [--project PROJECT] --partitions PARTITIONS
                                [--min-insync-replicas MIN_INSYNC_REPLICAS] [--retention RETENTION]
                                [--retention-ms RETENTION_MS] [--retention-bytes RETENTION_BYTES]
                                [--remote-storage-enable] [--remote-storage-disable]
                                [--local-retention-ms LOCAL_RETENTION_MS]
                                [--local-retention-bytes LOCAL_RETENTION_BYTES] [--tag KEY[=VALUE]] [--untag KEY]
                                [--replication REPLICATION]
                                service_name topic
avn service topic-update: error: the following arguments are required: --partitions
```

I'm not sure why `--partitions` is required again for topic update, but it continues to complain if I don't give it. I guess this might actually be a bug.

The following did work
```
$ avn service topic-update \
          --project $PROJECT_NAME \
          --remote-storage-enable  \
          --local-retention-ms 5000 \
          --partitions 3 \
          $KAFKA_SERVICE_NAME $KAFKA_TOPIC_NAME

updated
```

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
