### PR TITLE
fix: k8 link in clickhouse get-started doc

### DIFF
--- a/docs/products/clickhouse/get-started.md
+++ b/docs/products/clickhouse/get-started.md
@@ -300,7 +300,7 @@ changes to `RUNNING`, you are ready to access it.
 
 See the available configuration options in:
 
-- [Aiven Operator for Kubernetes®: ClickHouse](https://aiven.github.io/aiven-operator/api-reference/clickhouse.html)
+- [Aiven Operator for Kubernetes®: ClickHouse](https://aiven.github.io/aiven-operator/resources/clickhouse.html)
 - [Advanced parameters for Aiven for ClickHouse®](/docs/products/clickhouse/reference/advanced-params).
 
 ## Connect to the service{#connect-to-service}


### PR DESCRIPTION
https://aiven.atlassian.net/browse/DOC-1343

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
