### PR TITLE
fix: Use updated Iceberg catalog page.

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
@@ -33,7 +33,7 @@ manually create tables in AWS Glue and ensure the schema matches the Apache Kafk
 :::
 
 For more details, see the
-[Iceberg catalogs documentation](https://iceberg.apache.org/concepts/catalog/).
+[Iceberg catalogs documentation](https://iceberg.apache.org/terms/#catalog/).
 
 ## File I/O and write format
 


### PR DESCRIPTION
## Describe your changes

The Iceberg community decided to change the location for the catalog concept: https://lists.apache.org/thread/jnfnf886r4y8q3og668f02pbw8ym7pq6

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
