### PR TITLE
fix: Kafka services do not have replica uri

### DIFF
--- a/docs/platform/howto/integrations/prometheus-metrics.md
+++ b/docs/platform/howto/integrations/prometheus-metrics.md
@@ -191,7 +191,7 @@ your service.
    sure to include the replica DNS names in the list. If you have
    `<PROMETHEUS_SERVICE_URI>` as `public-example.aivencloud.com`, then you
    will need to add `public-replica-example.aivencloud.com`. This applies
-   to PostgreSQL®, MySQL®, Apache Kafka®, and Caching services.
+   to PostgreSQL®, MySQL®, and Caching services.
    :::
 
 ### View full list of metrics


### PR DESCRIPTION
## Describe your changes

Prometheus client needs to have additional replica uri if multi node service has separate replica uri. Kafka is multi node service, but it does not have replica uri. For Kafka all nodes are behind one uri.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](styleguide.md).
- [X] My links start with `/docs/`.
