### PR TITLE
update: standardize tab naming for TF samples

### DIFF
--- a/docs/platform/howto/manage-application-users.md
+++ b/docs/platform/howto/manage-application-users.md
@@ -31,7 +31,7 @@ to access this feature.
 1.  Enter a name and click **Create application user**.
 
 </TabItem>
-<TabItem value="terraform" label="Terraform example usage">
+<TabItem value="terraform" label="Terraform">
 
 <TerraformSample filename='resources/aiven_organization_application_user/resource.tf' />
 
@@ -62,7 +62,7 @@ More information on this resource and its configuration options are available in
 1.  Click **Close**.
 
 </TabItem>
-<TabItem value="terraform" label="Terraform example usage">
+<TabItem value="terraform" label="Terraform">
 
 <TerraformSample filename='resources/aiven_organization_application_user_token/resource.tf' />
 

--- a/docs/platform/howto/manage-groups.md
+++ b/docs/platform/howto/manage-groups.md
@@ -25,7 +25,7 @@ for projects, giving them the right level of access to the project and its servi
 1.  Click **Create group**.
 
 </TabItem>
-<TabItem value="terraform" label="Terraform example usage">
+<TabItem value="terraform" label="Terraform">
 
 <TerraformSample filename='resources/aiven_organization_user_group/resource.tf' />
 
@@ -49,7 +49,7 @@ You can only add users that are
 1.  Click **Add users**.
 
 </TabItem>
-<TabItem value="terraform" label="Terraform example usage">
+<TabItem value="terraform" label="Terraform">
 
 <TerraformSample filename='resources/aiven_organization_user_group_member/resource.tf' />
 

--- a/docs/platform/howto/manage-project.md
+++ b/docs/platform/howto/manage-project.md
@@ -26,7 +26,7 @@ projects in your organization or its organizational units.
     payment method for this billing group.
 
 </TabItem>
-<TabItem value="terraform" label="Terraform example usage">
+<TabItem value="terraform" label="Terraform">
 
 <TerraformSample filename='resources/aiven_project/resource.tf' />
 


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
