### PR TITLE
update: Kafka and Kafka Connect get started Terraform instructions

### DIFF
--- a/docs/products/kafka/get-started.md
+++ b/docs/products/kafka/get-started.md
@@ -59,7 +59,7 @@ or automate the process with Terraform.
 
 1. Create a file named `service.tf` and add the following:
 
-    <TerraformSample filename='kafka_connect/service.tf' />
+    <TerraformSample filename='kafka_connect/kafka_service.tf' />
 
 1. Create a file named `variables.tf` and add the following:
 

--- a/docs/products/kafka/get-started.md
+++ b/docs/products/kafka/get-started.md
@@ -27,12 +27,12 @@ Before you begin, ensure you have access to the following tools:
 - Access to the [Aiven Console](https://console.aiven.io)
 
 </TabItem>
-<TabItem value="terraform" label="Terraform" default>
+<TabItem value="terraform" label="Terraform">
 
 <TerraformPrereqs />
 
 </TabItem>
-<TabItem value="cli" label="CLI" default>
+<TabItem value="cli" label="CLI">
 
 - [Aiven CLI](https://github.com/aiven/aiven-client#installation) installed
 - [A personal token](https://docs.aiven.io/docs/platform/howto/create_authentication_token.html)

--- a/docs/products/kafka/get-started.md
+++ b/docs/products/kafka/get-started.md
@@ -53,6 +53,11 @@ or automate the process with Terraform.
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
+The following example files are part of the Kafka Connect example in the
+[Aiven Terraform Provider repository](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/kafka_connect) on GitHub. The complete example creates a Kafka service and
+integrates it with a Kafka Connect service. You can create just the Kafka service
+by using the following files.
+
 1. Create a file named `provider.tf` and add the following:
 
     <TerraformSample filename='kafka_connect/provider.tf' />

--- a/docs/products/kafka/get-started.md
+++ b/docs/products/kafka/get-started.md
@@ -53,10 +53,11 @@ or automate the process with Terraform.
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
-The following example files are part of the Kafka Connect example in the
-[Aiven Terraform Provider repository](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/kafka_connect) on GitHub. The complete example creates a Kafka service and
-integrates it with a Kafka Connect service. You can create just the Kafka service
-by using the following files.
+The following example files create only one Kafka service in your Aiven project.
+They are part of the Kafka Connect example in the
+[Aiven Terraform Provider repository](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/kafka_connect) on GitHub. The complete example in the repository creates a
+Kafka service and
+[integrates it with a Kafka Connect service](/docs/products/kafka/kafka-connect/get-started).
 
 1. Create a file named `provider.tf` and add the following:
 

--- a/docs/products/kafka/kafka-connect/get-started.md
+++ b/docs/products/kafka/kafka-connect/get-started.md
@@ -4,17 +4,37 @@ sidebar_label: Get started
 keywords: [quick start]
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import TerraformPrereqs from "@site/static/includes/terraform-get-started-prerequisites.md";
+import TerraformApply from "@site/static/includes/terraform-apply-changes.md";
+import TerraformSample from '@site/src/components/CodeSamples/TerraformSample';
+
 Get started with Aiven for Apache Kafka® Connect and integrate it with your Apache Kafka® service.
 
 ## Prerequisites
 
 Ensure that you have at least one Aiven for Apache Kafka® service in your project.
-If your project does not have any Aiven for Apache Kafka
+If your project does not have an Aiven for Apache Kafka
 service, [create one](/docs/platform/howto/create_new_service).
+
+<Tabs groupId="group1">
+<TabItem value="console" label="Console" default>
+
+- Access to the [Aiven Console](https://console.aiven.io)
+
+</TabItem>
+<TabItem value="terraform" label="Terraform" default>
+
+<TerraformPrereqs />
+
+</TabItem>
+</Tabs>
 
 ## Create a dedicated Aiven for Apache Kafka® Connect service {#apache_kafka_connect_dedicated_cluster}
 
-To create an Aiven for Apache Kafka Connect dedicated service:
+<Tabs groupId="group1">
+<TabItem value="console" label="Console" default>
 
 1.  Log into [Aiven Console](https://console.aiven.io) and select the
     **Aiven for Apache Kafka** service where to create a
@@ -46,6 +66,28 @@ integration. Selecting the service name will take you to the **Service
 Overview** page to monitor the service status. Before using it, it's
 important to wait until the service status changes from *REBUILDING* to
 *RUNNING*.
+
+</TabItem>
+<TabItem value="terraform" label="Terraform" default>
+
+1. Create a file named `provider.tf` and add the following:
+
+    <TerraformSample filename='kafka_connect/provider.tf' />
+
+1. Create a file named `service.tf` and add the following:
+
+    <TerraformSample filename='kafka_connect/kafka_connect_service.tf' />
+
+1. Create a file named `variables.tf` and add the following:
+
+    <TerraformSample filename='kafka_connect/variables.tf' />
+
+1. Create the `terraform.tfvars` file and add the values for your token and project name.
+
+<TerraformApply />
+
+</TabItem>
+</Tabs>
 
 ## Next steps
 

--- a/docs/products/kafka/kafka-connect/get-started.md
+++ b/docs/products/kafka/kafka-connect/get-started.md
@@ -24,7 +24,7 @@ service, [create one](/docs/platform/howto/create_new_service).
 - Access to the [Aiven Console](https://console.aiven.io)
 
 </TabItem>
-<TabItem value="terraform" label="Terraform" default>
+<TabItem value="terraform" label="Terraform">
 
 <TerraformPrereqs />
 
@@ -68,7 +68,7 @@ important to wait until the service status changes from *REBUILDING* to
 *RUNNING*.
 
 </TabItem>
-<TabItem value="terraform" label="Terraform" default>
+<TabItem value="terraform" label="Terraform">
 
 1. Create a file named `provider.tf` and add the following:
 

--- a/docs/products/kafka/kafka-connect/get-started.md
+++ b/docs/products/kafka/kafka-connect/get-started.md
@@ -70,6 +70,9 @@ important to wait until the service status changes from *REBUILDING* to
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
+The following example files are also available in the
+[Aiven Terraform Provider repository](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/kafka_connect) on GitHub.
+
 1. Create a file named `provider.tf` and add the following:
 
     <TerraformSample filename='kafka_connect/provider.tf' />

--- a/static/includes/terraform-apply-changes.md
+++ b/static/includes/terraform-apply-changes.md
@@ -1,0 +1,34 @@
+To apply your Terraform configuration:
+
+1. Initialize Terraform by running:
+
+   ```bash
+   terraform init
+   ```
+
+   The output is similar to the following:
+
+   ```bash
+
+   Initializing the backend...
+
+   Initializing provider plugins...
+   - Finding aiven/aiven versions matching ">= 4.0.0, < 5.0.0"...
+   - Installing aiven/aiven v4.9.2...
+   - Installed aiven/aiven v4.9.2
+   ...
+   Terraform has been successfully initialized!
+   ...
+   ```
+
+1. To create an execution plan and preview the changes, run:
+
+   ```bash
+   terraform plan
+   ```
+
+1. To deploy your changes, run:
+
+   ```bash
+   terraform apply --auto-approve
+   ```

--- a/static/includes/terraform-get-started-prerequisites.md
+++ b/static/includes/terraform-get-started-prerequisites.md
@@ -1,0 +1,2 @@
+- [Terraform installed](https://www.terraform.io/downloads)
+- A [personal token](https://docs.aiven.io/docs/platform/howto/create_authentication_token.html)


### PR DESCRIPTION
## Describe your changes

Replaces TF code with synced samples from the TF repository. Adds TF code to the Kafka Connect get started guide.

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
