### PR TITLE
fix: AWS VPC URL typo 

### DIFF
--- a/docs/platform/concepts/vpcs.md
+++ b/docs/platform/concepts/vpcs.md
@@ -75,7 +75,7 @@ Learn how to
 
 For information on VPCs supported by particular cloud providers, see the following:
 
-- AWS: [How Amazon VPC works](https://docs.aws.amazon.com/vpc/latest/userguide/how-it-works.html])
+- AWS: [How Amazon VPC works](https://docs.aws.amazon.com/vpc/latest/userguide/how-it-works.html)
 - Google Cloud: [VPC networks](https://cloud.google.com/vpc/docs/vpc)
 - Azure: [What is Azure Virtual Network?](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview)
 - UpCloud:


### PR DESCRIPTION
https://aiven.atlassian.net/browse/DOC-1381

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
