### PR TITLE
feat: Support credential rotation for Kafka subscriptions

### DIFF
--- a/docs/products/kafka/howto/rotate-credentials.md
+++ b/docs/products/kafka/howto/rotate-credentials.md
@@ -1,0 +1,71 @@
+---
+title: Rotate credentials for an Apache Kafka subscription
+sidebar_label: Rotate credentials
+---
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Rotate credentials for an Apache Kafka subscription to replace outdated credentials and maintain secure, approved access.
+The request must be approved by another member of the owner group before new
+credentials can be downloaded.
+
+## Prerequisites
+
+You must be a member of the **owner group** of the access to rotate.
+
+## Request a credential rotation
+
+1. In the [Aiven Console](https://console.aiven.io/), go to
+   **Tools > Apache Kafka governance operations**.
+1. In the sidebar, click <ConsoleLabel name="Streaming catalog"/> > **Access overview**.
+1. In the **Access overview** page, locate the service user for which you need
+   credentials.
+1. Click <ConsoleLabel name="actions"/> > **Request credential rotation**.
+1. In the **Request credential rotation** dialog, enter a message for the approvers.
+1. Click **Submit**.
+
+### What happens after you submit a rotation request
+
+- The request is sent to the **owner group** for approval.
+- The request must be approved by another member of the owner group.
+- After approval:
+  - New credentials are generated for the service user associated with the subscription.
+  - The requester is notified when credentials are ready.
+  - The requester can download the credentials from the request details.
+- Only one active rotation request is allowed per access at a time.
+
+## Approve a credential rotation
+
+1. Go to **Tools > Apache Kafka governance operations**.
+1. In sidebar, click **Approvals**.
+1. Find the request with type **Rotate credentials**.
+1. Click the request to view details.
+1. Click **Approve** or **Decline**.
+
+:::note
+Another member of the owner group must approve the request.
+:::
+
+## View and download credentials
+
+After your request is approved, you can download the new credentials.
+
+1. Open the request from the email notification or go to
+   **Tools > Apache Kafka governance operations**.
+1. In the sidebar, click <ConsoleLabel name="streamingcatalog" /> > **Access overview**.
+1. Locate the service user related to your request.
+1. Click <ConsoleLabel name="actions" /> > **Review credentials**.
+1. In the confirmation dialog, click **Show credentials**.
+1. In the **Save service user credentials** dialog:
+   - Click **Show** next to each field to reveal the credentials.
+   - Click **Copy** next to each field to copy credentials.
+   - Click **Download credentials** to save them.
+
+:::warning
+Credentials can only be viewed once. Make sure to save them securely.
+:::
+
+<RelatedPages/>
+
+[Request access to an Apache Kafka topic](/docs/products/kafka/howto/request-access-topic)

--- a/docs/products/kafka/howto/rotate-credentials.md
+++ b/docs/products/kafka/howto/rotate-credentials.md
@@ -6,7 +6,7 @@ sidebar_label: Rotate credentials
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Rotate credentials for an Apache Kafka subscription to replace outdated credentials and maintain secure, approved access.
+Rotate credentials for an Apache Kafka subscription to replace outdated credentials and keep access secure and approved.
 The request must be approved by another member of the owner group before new
 credentials can be downloaded.
 

--- a/docs/products/kafka/howto/rotate-credentials.md
+++ b/docs/products/kafka/howto/rotate-credentials.md
@@ -30,7 +30,7 @@ You must be a member of the **owner group** of the access to rotate.
 - The request is sent to the **owner group** for approval.
 - The request must be approved by another member of the owner group.
 - After approval:
-  - New credentials are generated for the service user associated with the subscription.
+  - New credentials are generated for the service user associated with the access.
   - The requester is notified when credentials are ready.
   - The requester can download the credentials from the request details.
 - Only one active rotation request is allowed per access at a time.

--- a/docs/products/kafka/howto/rotate-credentials.md
+++ b/docs/products/kafka/howto/rotate-credentials.md
@@ -1,12 +1,12 @@
 ---
-title: Rotate credentials for an Apache Kafka subscription
+title: Rotate credentials for an Apache Kafka® subscription
 sidebar_label: Rotate credentials
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Rotate credentials for an Apache Kafka subscription to replace outdated credentials and keep access secure and approved.
+Rotate credentials for an Apache Kafka® subscription to replace outdated credentials and maintain secure, approved access.
 The request must be approved by another member of the owner group before new
 credentials can be downloaded.
 
@@ -25,7 +25,7 @@ You must be a member of the **owner group** of the access to rotate.
 1. In the **Request credential rotation** dialog, enter a message for the approvers.
 1. Click **Submit**.
 
-### What happens after you submit a rotation request
+After you submit a rotation request:
 
 - The request is sent to the **owner group** for approval.
 - The request must be approved by another member of the owner group.
@@ -38,7 +38,7 @@ You must be a member of the **owner group** of the access to rotate.
 ## Approve a credential rotation
 
 1. Go to **Tools > Apache Kafka governance operations**.
-1. In sidebar, click **Approvals**.
+1. In the sidebar, click **Approvals**.
 1. Find the request with type **Rotate credentials**.
 1. Click the request to view details.
 1. Click **Approve** or **Decline**.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -920,6 +920,7 @@ const sidebars: SidebarsConfig = {
                         'products/kafka/howto/approvals',
                         'products/kafka/howto/group-requests',
                         'products/kafka/howto/terraform-governance-approvals',
+                        'products/kafka/howto/rotate-credentials',
                       ],
                     },
                   ],


### PR DESCRIPTION
## Describe your changes

Add documentation for rotating Apache Kafka service user credentials using the Console, including request, approval, and download steps.

https://aiven.atlassian.net/browse/GOV-1003

Preview - https://gov-1003-documentation-acces.aiven-docs.pages.dev/docs/products/kafka/howto/rotate-credentials

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
