### PR TITLE
fix: privatelink doc improvements

### DIFF
--- a/docs/platform/howto/use-aws-privatelinks.md
+++ b/docs/platform/howto/use-aws-privatelinks.md
@@ -76,7 +76,7 @@ AWS PrivateLink is not supported for:
 1.  In the AWS CLI, run the following command to create a VPC endpoint:
 
     ```bash
-    aws ec2 --region eu-west-1 create-vpc-endpoint --vpc-endpoint-type Interface --vpc-id $your_vpc_id --subnet-ids $space_separated_list_of_subnet_ids --security-group-ids $security_group_ids --service-name com.amazonaws.vpce.eu-west-1.vpce-svc-0b16e88f3b706aaf1
+    aws ec2 --region eu-west-1 create-vpc-endpoint --vpc-endpoint-type Interface --vpc-id $your_aws_vpc_id --subnet-ids $space_separated_list_of_subnet_ids --security-group-ids $security_group_ids --service-name com.amazonaws.vpce.eu-west-1.vpce-svc-0b16e88f3b706aaf1
     ```
 
     Replace the `--service-name` value with the value shown either in
@@ -85,7 +85,7 @@ AWS PrivateLink is not supported for:
     or as an output of:
 
     ```bash
-    avn service privatelink aws get aws_service_name
+    avn service privatelink aws get aiven_service_name
     ```
 
     Note that for fault tolerance, you should specify a subnet ID for
@@ -130,7 +130,7 @@ AWS PrivateLink is not supported for:
         ```bash
         # For PostgreSQL
 
-        avn service update -c privatelink_access.postgresql=true --project $project_name $Aiven_service_name
+        avn service update -c privatelink_access.pg=true --project $project_name $Aiven_service_name
         ```
 
         ```bash
@@ -198,7 +198,8 @@ PrivateLink connection.
 
 Each endpoint (connection) has a `PRIVATELINK_CONNECTION_ID`, which you can
 check using the
-[avn service privatelink AWS connection list SERVICE_NAME](/docs/tools/cli/service/privatelink) command.
+[`avn service privatelink aws connection list`](/docs/tools/cli/service/privatelink#avn_service_privatelink_aws_connection_list)
+command.
 
 To acquire connection information for your service component using AWS
 PrivateLink, run the
@@ -257,7 +258,7 @@ allowed to connect a VPC endpoint:
 
 -   In [Aiven Console](https://console.aiven.io):
 
-    1.  click your service from the **Services** page.
+    1.  Click your service from the **Services** page.
     1.  On the **Overview** page, click **Service settings** from the
         sidebar.
     1.  On the **Service settings** page, go to the **Cloud and

--- a/docs/tools/cli/service/privatelink.md
+++ b/docs/tools/cli/service/privatelink.md
@@ -18,7 +18,7 @@ Lists PrivateLink cloud availability and prices.
 
 **Example:** Lists PrivateLink cloud availability and prices.
 
-```
+```bash
 avn service privatelink availability
 ```
 
@@ -48,7 +48,7 @@ Lists AWS PrivateLink connection information for a service.
 **Example:** List AWS PrivateLink connection information for the
 `kafka-12a3b4c5` service.
 
-```
+```bash
 avn service privatelink aws connection list kafka-12a3b4c5
 ```
 
@@ -77,7 +77,7 @@ repeat `\--principal` parameter.
 
 **Example:** Create an AWS PrivateLink for the `kafka-12a3b4c5` service.
 
-```
+```bash
 avn service privatelink aws create --principal 'arn:aws:iam::123456789012:user/cloud_user' --principal 'arn:aws:iam::987654321098:user/cloud_user' kafka-12a3b4c5
 ```
 
@@ -102,7 +102,7 @@ Deletes an AWS PrivateLink defined for a service.
 **Example:** Delete the AWS PrivateLink for the `kafka-12a3b4c5`
 service.
 
-```
+```bash
 avn service privatelink aws delete kafka-12a3b4c5
 ```
 
@@ -132,7 +132,7 @@ Lists AWS PrivateLink information for a service.
 **Example:** List AWS PrivateLink information for the `kafka-12a3b4c5`
 service.
 
-```
+```bash
 avn service privatelink aws get kafka-12a3b4c5
 ```
 
@@ -158,7 +158,7 @@ principals, repeat `\--principal` parameter.
 
 **Example:** Update AWS principals for the `kafka-12a3b4c5` service.
 
-```
+```bash
 avn service privatelink aws update                        \
   --principal 'arn:aws:iam::123456789012:user/cloud_user' \
   kafka-12a3b4c5
@@ -186,7 +186,7 @@ Approves a pending Azure Private Link connection endpoint.
 **Example:** Approve the Azure Private Link `plc12345abcdef` connection
 for the `kafka-12a3b4c5` service.
 
-```
+```bash
 avn service privatelink azure connection approve kafka-12a3b4c5 plc12345abcdef
 ```
 
@@ -211,7 +211,7 @@ Lists Azure Private Link connection information for a service.
 **Example:** List Azure Private Link connection information for the
 `kafka-12a3b4c5` service.
 
-```
+```bash
 avn service privatelink azure connection list kafka-12a3b4c5
 ```
 
@@ -228,18 +228,18 @@ plc12345abcdef             /subscriptions/12345678-90ab-cdef-0987-6543210abcde/r
 Updates an Azure Private Link connection with the Private IP address of
 the private endpoint's Network interface.
 
-| Parameter                     Information
-| ----------------------------- -------------------------------------------------------------
-| `service_name`                The name of the service
-| `privatelink_connection_id`   The Aiven PrivateLink connection ID
-| `--endpoint-ip-address`       (Private) IP address of Azure endpoint in user subscription
-| `--project`                   The project to fetch details for
-| `--format`                    Format of the output string
+| Parameter                   | Information                                                  |
+| --------------------------- | ------------------------------------------------------------ |
+| `service_name`              | The name of the service                                      |
+| `privatelink_connection_id` | The Aiven PrivateLink connection ID                          |
+| `--endpoint-ip-address`     | (Private) IP address of Azure endpoint in user subscription  |
+| `--project`                 | The project to fetch details for                             |
+| `--format`                  | Format of the output string                                  |
 
 **Example:** In the `kafka-12a3b4c5` service, update the IP of the Azure
 Private Link connection `plc12345abcdef` to `10.19.1.4`.
 
-```
+```bash
 avn service privatelink azure connection update   \
   --endpoint-ip-address 10.19.1.4                 \
   kafka-12a3b4c5                                  \
@@ -268,7 +268,7 @@ Creates an Azure Private Link for a service.
 **Example:** Create an Azure Private Link for the `kafka-12a3b4c5`
 service.
 
-```
+```bash
 avn service privatelink azure create    \
   --user-subscription-id                \
   12345678-90ab-cdef-0987-6543210abcde  \
@@ -295,7 +295,7 @@ Deletes an Azure Private Link defined for a service.
 
 **Example:** Delete Azure Private Link for the `kafka-12a3b4c5` service.
 
-```
+```bash
 avn service privatelink azure delete kafka-12a3b4c5
 ```
 
@@ -320,7 +320,7 @@ Lists Azure Private Link information for a service.
 **Example:** List Azure Private Link information for the
 `kafka-12a3b4c5` service.
 
-```
+```bash
 avn service privatelink azure get kafka-12a3b4c5
 ```
 
@@ -345,6 +345,6 @@ Refreshes incoming Azure Private Link endpoint connections.
 **Example:** Refresh incoming Azure Private Link endpoint connections
 for the `kafka-12a3b4c5` service.
 
-```
+```bash
 avn service privatelink azure refresh kafka-12a3b4c5
 ```


### PR DESCRIPTION
https://aiven.atlassian.net/browse/DOC-1384

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
