### PR TITLE
update: EOL to include Kafka 3.9

### DIFF
--- a/docs/platform/reference/eol-for-major-versions.md
+++ b/docs/platform/reference/eol-for-major-versions.md
@@ -94,6 +94,18 @@ after they are made available on the Aiven platform.
 | 3.6     | 2024-10-18 | 2024-09-01                       | 2023-10-18                      |
 | 3.7     | 2025-04-17 | 2025-01-17                       | 2024-04-17                      |
 | 3.8     | 2026-09-03 | 2026-06-03                       | 2024-09-06                      |
+| 3.9 (EA) | TBD       | TBD                              | 2024-03-20                      |
+
+:::note
+Starting with Apache Kafka 3.9, Aiven for Apache Kafka uses KRaft (Kafka Raft)
+to manage metadata and controllers, replacing ZooKeeper. Migration to Apache Kafka 3.9
+from earlier versions is not yet supported. For details and current limitations, see:
+
+- [KRaft in Apache Kafka®](/docs/products/kafka/concepts/kraft-mode)
+- [Transitioning to KRaft](/docs/products/kafka/concepts/upgrade-procedure#transitioning-to-kraft-)
+
+To support this transition, Aiven has extended support for Apache Kafka 3.8 by one year.
+:::
 
 ### Aiven for Apache Cassandra® {#h_0f2929c770}
 

--- a/docs/platform/reference/eol-for-major-versions.md
+++ b/docs/platform/reference/eol-for-major-versions.md
@@ -94,7 +94,7 @@ after they are made available on the Aiven platform.
 | 3.6     | 2024-10-18 | 2024-09-01                       | 2023-10-18                      |
 | 3.7     | 2025-04-17 | 2025-01-17                       | 2024-04-17                      |
 | 3.8     | 2026-09-03 | 2026-06-03                       | 2024-09-06                      |
-| 3.9 (EA) | TBD       | TBD                              | 2024-03-20                      |
+| 3.9 (EA) | 2027-03-03 | 2026-12-03                      | 2024-03-20                      |
 
 :::note
 Starting with Apache Kafka 3.9, Aiven for Apache Kafka uses KRaft (Kafka Raft)


### PR DESCRIPTION
## Describe your changes
Add Kafka 3.9 and note about KRaft to EOL major versions page. 


## Checklist

- [ ] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
