### PR TITLE
Add max-connections limit for PG on free plan

### DIFF
--- a/docs/platform/concepts/free-plan.md
+++ b/docs/platform/concepts/free-plan.md
@@ -38,7 +38,9 @@ There are some limitations of the free plan services:
 -   No static IPs
 -   No external service integrations
 -   No forking
--   For PostgreSQL: no connection pooling
+-   For PostgreSQL:
+    -   no connection pooling
+    -   `max_connections` limit set to 20
 -   No support services
 -   Only one service per service type per user and
     [organization](/docs/platform/concepts/orgs-units-projects)


### PR DESCRIPTION
## Describe your changes

Adds the the `max_connections` limit to the free plan limitations.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](styleguide.md).
- [X] My links start with `/docs/`.
