### PR TITLE
update: Remove m3db from timeseries note and add alloydb and clickhouse

### DIFF
--- a/docs/platform/howto/list-service.md
+++ b/docs/platform/howto/list-service.md
@@ -31,12 +31,11 @@ product portfolio.
 -   Aiven for PostgreSQL® with the TimescaleDB extension is your best
     choice if you already use PostgreSQL, require **SQL compatibility**
     and have a limited time series use case.
--   Aiven for AlloyDB Omni is a solid option for **PostgreSQL Compatibile**
-    workloads with a need for columnar, analytical data, and/or planned
-    usage with
--   Aiven for Clickhouse® is your best choice when you need a high
-    performance columnar time series database for OLAP workloads or a
-    data analytics warehouse.
+-   Aiven for AlloyDB Omni is a solid option for **PostgreSQL compatibile**
+    workloads with a need for columnar analytical data and seamless AI
+    integration across any cloud.
+-   Aiven for Clickhouse® is your best choice when you need a high-prformance
+    columnar time series database for OLAP workloads or a data analytics warehouse.
 
 See our time series on
 [our website](https://aiven.io/time-series-databases/what-are-time-series-databases).

--- a/docs/platform/howto/list-service.md
+++ b/docs/platform/howto/list-service.md
@@ -31,10 +31,10 @@ product portfolio.
 -   Aiven for PostgreSQL® with the TimescaleDB extension is your best
     choice if you already use PostgreSQL, require **SQL compatibility**
     and have a limited time series use case.
--   Aiven for AlloyDB is a solid option for **PostgreSQL Compatibile**
+-   Aiven for AlloyDB Omni is a solid option for **PostgreSQL Compatibile**
     workloads with a need for columnar, analytical data, and/or planned
     usage with
--   Aiven for Clickhouse is your best choice when you need a high
+-   Aiven for Clickhouse® is your best choice when you need a high
     performance columnar time series database for OLAP workloads or a
     data analytics warehouse.
 

--- a/docs/platform/howto/list-service.md
+++ b/docs/platform/howto/list-service.md
@@ -31,9 +31,12 @@ product portfolio.
 -   Aiven for PostgreSQL® with the TimescaleDB extension is your best
     choice if you already use PostgreSQL, require **SQL compatibility**
     and have a limited time series use case.
--   Aiven for M3DB is your best choice when you need a **truly
-    scalable**, high performance time series database that is also
-    **high availability.**
+-   Aiven for AlloyDB is a solid option for **PostgreSQL Compatibile**
+    workloads with a need for columnar, analytical data, and/or planned
+    usage with
+-   Aiven for Clickhouse is your best choice when you need a high
+    performance columnar time series database for OLAP workloads or a
+    data analytics warehouse.
 
 See our time series on
 [our website](https://aiven.io/time-series-databases/what-are-time-series-databases).


### PR DESCRIPTION
## Describe your changes

I'm not sure why this note exists in the page, but it was referencing M3DB which we do not offer anymore. 

The link in the note mentions clickhouse so I added a line in the section on clickhouse. I also added Aiven for AlloyDB Omni.

## Checklist

- [X] The first paragraph of the page is on one line.
- [X] The other lines have a line break at 90 characters.
- [X] I checked the output.
- [X] I applied the [style guide](styleguide.md).
- [X] My links start with `/docs/`.
