### PR TITLE
update: clarify access rotation not supported via Terraform

### DIFF
--- a/docs/products/kafka/howto/terraform-governance-approvals.md
+++ b/docs/products/kafka/howto/terraform-governance-approvals.md
@@ -41,6 +41,13 @@ usernames to Aiven users, ensuring that requesters and approvers are correctly i
 - **Approval validation**: A GitHub Action automatically checks that pull request
 creators and approvers meet governance requirements before changes are applied.
 
+:::note
+When Terraform governance is enabled, operational requests such as access rotation must
+be performed in the [Aiven Console](https://console.aiven.io/). These actions are not
+available through Terraform. To learn how to rotate access credentials,
+see [Rotate credentials](/docs/products/kafka/howto/rotate-credentials).
+:::
+
 ### Workflow steps:
 
 1. Define governance policies using Aiven Terraform Provider:

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -909,6 +909,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'products/kafka/howto/enable-governance',
                     'products/kafka/howto/claim-topic',
+                    'products/kafka/howto/terraform-governance-approvals',
                     {
                       type: 'category',
                       label: 'Manage topic requests',
@@ -920,7 +921,7 @@ const sidebars: SidebarsConfig = {
                         'products/kafka/howto/request-access-topic',
                         'products/kafka/howto/approvals',
                         'products/kafka/howto/group-requests',
-                        'products/kafka/howto/terraform-governance-approvals',
+
                         'products/kafka/howto/rotate-credentials',
                       ],
                     },


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
