### PR TITLE
fix: service creation date

### DIFF
--- a/docs/platform/reference/eol-for-major-versions.md
+++ b/docs/platform/reference/eol-for-major-versions.md
@@ -94,7 +94,7 @@ after they are made available on the Aiven platform.
 | 3.6     | 2024-10-18 | 2024-09-01                       | 2023-10-18                      |
 | 3.7     | 2025-04-17 | 2025-01-17                       | 2024-04-17                      |
 | 3.8     | 2026-09-03 | 2026-06-03                       | 2024-09-06                      |
-| 3.9 (EA) | 2027-03-03 | 2026-12-03                      | 2024-03-20                      |
+| 3.9 (EA) | 2027-03-03 | 2026-12-03                      | 2025-03-20                      |
 
 :::note
 Starting with Apache Kafka 3.9, Aiven for Apache Kafka uses KRaft (Kafka Raft)


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
