### PR TITLE
update: Remove EA tag

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/iceberg-sink-connector.md
@@ -1,7 +1,6 @@
 ---
 title: Create an Iceberg sink connector for Aiven for Apache Kafka®
 sidebar_label: Iceberg sink connector
-early: true
 ---
 
 import RelatedPages from "@site/src/components/RelatedPages";


### PR DESCRIPTION
## Describe your changes
Removed EA tag for Iceberg sink connector


## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
