### PR TITLE
fix: incorrect variable in howto example

### DIFF
--- a/static/code/products/valkey/connect.py
+++ b/static/code/products/valkey/connect.py
@@ -1,7 +1,7 @@
 import valkey
 
 def main():
-    valkey_uri = 'VALKEY_URI'  # Replace 'VALKEY_URI' with your actual Valkey service URI
+    valkey_uri = 'VALKEY_SERVICE_URI'  # Replace 'VALKEY_SERVICE_URI' with your actual Valkey service URI
     valkey_client = valkey.from_url(valkey_uri)
 
     valkey_client.set('key', 'hello world')

--- a/static/code/products/valkey/connect.py
+++ b/static/code/products/valkey/connect.py
@@ -1,8 +1,8 @@
 import valkey
 
 def main():
-    valkey_uri = 'SERVICE_URI'  # Replace 'VALKEY_URI' with your actual Valkey service URI
-    valkey_client = valkey.from_url(service_uri)
+    valkey_uri = 'VALKEY_URI'  # Replace 'VALKEY_URI' with your actual Valkey service URI
+    valkey_client = valkey.from_url(valkey_uri)
 
     valkey_client.set('key', 'hello world')
     key = valkey_client.get('key').decode('utf-8')


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
