### PR TITLE
fix: Fix spacing after period

### DIFF
--- a/static/includes/config-pg.md
+++ b/static/includes/config-pg.md
@@ -365,7 +365,7 @@ import Link from '@docusaurus/Link'
       <td>
         <div className="param"><p className="name"><Link id="pg_stat_monitor_enable"/><Link to="#pg_stat_monitor_enable"><strong>pg_stat_monitor_enable</strong></Link></p><p><code className="type">boolean</code></p></div>
         <p className="title">Enable pg_stat_monitor extension if available for the current cluster</p>
-        <div className="description"><p>Enable the pg_stat_monitor extension. Enabling this extension will cause the cluster to be restarted.When this extension is enabled, pg_stat_statements results for utility commands are unreliable</p></div>
+        <div className="description"><p>Enable the pg_stat_monitor extension. Enabling this extension will cause the cluster to be restarted. When this extension is enabled, pg_stat_statements results for utility commands are unreliable</p></div>
         <table className="service-param-children">
           <tbody>
           </tbody>


### PR DESCRIPTION
Corrected improper spacing after a period by changing ".When" to ". When" to improve readability.

## Describe your changes
I only added a space after a period. No other change was made.

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
