### PR TITLE
feat: support warnings in the generated advanced config pages

### DIFF
--- a/scripts/service_type_parser.js
+++ b/scripts/service_type_parser.js
@@ -16,6 +16,7 @@ handlebars.registerHelper('parameterDetailsHelper', function (options) {
   var minimum = options.hash.minimum;
   var maximum = options.hash.maximum;
   var def = options.hash.def;
+  var restart_warning = options.hash.restart_warning;
   var fullname = parent + '.' + name;
   var fullnameid = fullname.replace('.', '_');
 
@@ -39,11 +40,14 @@ handlebars.registerHelper('parameterDetailsHelper', function (options) {
 
   html += '<p><code className="type">' + type + '</code></p>';
   html += '</div>';
-  if (minimum || maximum || def) {
+  if (minimum || maximum || def || restart_warning) {
     const constraints = [];
     if (minimum) constraints.push('<li>min: <code>' + minimum + '</code></li>');
     if (maximum) constraints.push('<li>max: <code>' + maximum + '</code></li>');
     if (def) constraints.push('<li>default: <code>' + def + '</code></li>');
+    if (restart_warning) {
+      constraints.push('<li><span class="badge badge--warning">Service restart</span></li>');
+    }
 
     html +=
       '<div className="constraints"><ul>' +
@@ -117,7 +121,7 @@ import Link from '@docusaurus/Link'
   {{~#each user_config_schema.properties}}
     <tr>
       <td>
-        {{parameterDetailsHelper name=@key type=type minimum=minimum maximum=maximum def=default}}
+        {{parameterDetailsHelper name=@key type=type minimum=minimum maximum=maximum def=default restart_warning=x-aiven-change-requires-restart}}
         {{#if title~}}<p className="title">{{title}}</p>{{~/if}}
         {{#if description~}}<div className="description"><p>{{description}}</p></div>{{~/if}}
         <table className="service-param-children">
@@ -125,7 +129,7 @@ import Link from '@docusaurus/Link'
           {{#each properties}}
           <tr>
             <td>
-              {{parameterDetailsHelper name=@key parent=@../key type=type minimum=minimum maximum=maximum def=default}}
+              {{parameterDetailsHelper name=@key parent=@../key type=type minimum=minimum maximum=maximum def=default restart_warning=x-aiven-change-requires-restart}}
               {{#if title~}}<p className="title">{{title}}</p>{{~/if}}
               {{#if description~}}<div className="description"><p>{{description}}</p></div>{{~/if}}
             </td>


### PR DESCRIPTION
## Describe your changes

With a new flag added to the API we can generate a better-looking warning rather than relying on the plain text in the description.

### Results

<details><summary>With the custom CSS `.property-warning`:</summary>
<p>

![image](https://github.com/user-attachments/assets/b83c8643-e3ba-4182-85a2-896e74839503)

**The changes for this alternative are no longer in the PR**

</p>
</details> 

<details><summary>With the standard CSS `.brand .brand--warning`:</summary>
<p>


![image](https://github.com/user-attachments/assets/f8fb7d67-44f8-486c-9b75-d5863c81c221)

It would look different from the badges in our own code, e.g. [here](https://aiven.io/docs/platform/reference/list_of_clouds#oracle-cloud-infrastructure-):

![image](https://github.com/user-attachments/assets/4fae65a3-06c3-435f-9831-b1246ac1fb28)

I couldn't figure out how to reuse the code from our own component in the generated code:

https://github.com/aiven/aiven-docs/blob/d10e2dc0bfcc88f82a2d24a5aee55be1bfbbe1da/src/components/Badges/LimitedBadge/index.tsx

</p>
</details> 


## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
