### PR TITLE
feat: restore pride logo swap automation

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -4,6 +4,9 @@ import type * as Preset from '@docusaurus/preset-classic';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 
+const currentMonth = new Date().getMonth();
+const isJune = currentMonth === 5;
+
 const config: Config = {
   // Testing faster build
   future: {
@@ -112,8 +115,8 @@ const config: Config = {
       title: 'aiven',
       logo: {
         alt: 'Aiven docs',
-        src: 'images/logo.svg',
-        srcDark: 'images/logoDark.svg',
+        src: isJune ? 'images/logo-pride.svg' : 'images/logo.svg',
+        srcDark: isJune ? 'images/logoDark-pride.svg' : 'images/logoDark.svg',
       },
       items: [
         {


### PR DESCRIPTION
Reverts aiven/aiven-docs#868
The initial decision of not having logo swap has sparked lots of interest internally - [thread](https://aiven-io.slack.com/archives/C010WDFJSA3/p1748553081699399?thread_ts=1748281699.695049&cid=C010WDFJSA3) and Oskari has firmly said we should change our logo at least.

<img width="766" alt="Screenshot 2025-05-30 at 10 22 07" src="https://github.com/user-attachments/assets/031c6e79-a17a-4aaf-9fcb-0c14a418c7c8" />
