### PR TITLE
update: Redirect new connector requests to Aiven Ideas

### DIFF
--- a/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.md
+++ b/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.md
@@ -58,7 +58,7 @@ target technology. The available sink connectors include:
 - [Stream Reactor Redis®\*](https://docs.lenses.io/5.1/connectors/sinks/redissinkconnector/)
 - [S3 IAM Assume Role](/docs/products/kafka/kafka-connect/howto/s3-iam-assume-role)
 
-## Requesting new connectors
+## Request new connectors
 
 To request a new connector,
 [submit an idea through the Aiven Ideas portal](https://ideas.aiven.io/). Aiven regularly
@@ -71,9 +71,9 @@ Aiven evaluates new Apache Kafka Connect connectors based on the following crite
 - Active repository maintenance
 
 :::tip
-If the connector is not on the pre-approved list, mention which
-Aiven for Apache Kafka service to use it with. This helps us better understand your
-use case.
+If the connector is not on the pre-approved list, include the name of the
+Aiven for Apache Kafka service you plan to use it with. This helps us better
+understand your use case.
 :::
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
## Describe your changes

Redirect users from support to Aiven Ideas to request new Kafka connectors. 

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
