### PR TITLE
feat: redirect support legacy url

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -245,6 +245,15 @@
 /valkey                                                               https://aiven.io/docs/products/valkey
 
 #
+# Redirects for legacy urls
+#
+/index.html                                                https://aiven.io/docs
+/docs/*                                                    https://aiven.io/docs/:splat
+/*/index.html                                              https://aiven.io/docs/:splat
+/*.html                                                    https://aiven.io/docs/:splat
+/*/                                                        https://aiven.io/docs/:splat
+
+#
 # Keep splats at the end
 #
 /platform/howto/byoc/create-custom-cloud/*                 https://aiven.io/docs/platform/howto/byoc/create-cloud/:splat


### PR DESCRIPTION
## Describe your changes
Migrate the legacy docs url redirect logic from NGINX reverse proxy on the aiven host level to docs's level using the couldflare redirect file.

## Preview
Tested in staging with the same redirect logic

1. remove ending `.html`
`/index.html -> https://aiven.io/docs` 
eg: https://avnsmarketingtest.net/docs/index.html -> https://aiven.io/docs

2. remove double `/docs/docs`
`/docs/* -> https://aiven.io/docs/:splat`
eg: https://avnsmarketingtest.net/docs/docs/get-started -> https://aiven.io/docs/get-started

3. nested url, remove ending `index.html`
`/*/index.html -> https://aiven.io/docs/:splat`
eg: https://avnsmarketingtest.net/docs/get-started/index.html -> https://aiven.io/docs/get-started

4. remove ending `.html`
`/*.html ->  https://aiven.io/docs/:splat`
eg: https://avnsmarketingtest.net/docs/get-started.html -> https://aiven.io/docs/get-started

5. remove trailing slash `/`
`/*/ -> https://aiven.io/docs/:splat`
eg: https://aiven.io/docs/get-started/ -> https://aiven.io/docs/get-started

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
