### PR TITLE
Fix: link to LA for Exoscale new provider and regions

### DIFF
--- a/static/includes/clouds-list.md
+++ b/static/includes/clouds-list.md
@@ -779,3 +779,38 @@ information or access, contact your account team.
   </tr>
 </tbody>
 </table>
+
+## Exoscale <LimitedBadge/>
+
+:::important
+Exoscale is supported on the Aiven Platform as a
+[limited availability feature](/docs/platform/concepts/beta_services) for Aiven for
+PostgreSQL® only. For more information or access, contact your account team.
+:::
+
+<table>
+  <thead>
+  <tr>
+    <th>Region</th>
+    <th>Zone</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>Europe</td>
+    <td>AT-VIE-1</td>
+    <td>Austria, Vienna</td>
+  </tr>
+  <tr>
+    <td>Europe</td>
+    <td>DE-FRA-1</td>
+    <td>Germany, Frankfurt</td>
+  </tr>
+  <tr>
+    <td>Europe</td>
+    <td>DE-MUC-1</td>
+    <td>Germany, Munich</td>
+  </tr>
+</tbody>
+</table>

--- a/static/includes/clouds-list.md
+++ b/static/includes/clouds-list.md
@@ -704,8 +704,8 @@ import LimitedBadge from "@site/src/components/non-swizzled/Badges/LimitedBadge"
 
 :::important
 Oracle Cloud Infrastructure (OCI) is supported on the Aiven Platform as a
-[limited availability feature](/docs/platform/concepts/beta_services). For more
-information or access, contact your account team.
+[limited availability feature](/docs/platform/concepts/service-and-feature-releases#limited-availability-).
+For more information or access, contact your account team.
 :::
 
 <table>
@@ -784,8 +784,8 @@ information or access, contact your account team.
 
 :::important
 Exoscale is supported on the Aiven Platform as a
-[limited availability feature](/docs/platform/concepts/beta_services) for Aiven for
-PostgreSQL® only. For more information or access, contact your account team.
+[limited availability feature](/docs/platform/concepts/service-and-feature-releases#limited-availability-)
+for Aiven for PostgreSQL® only. For more information or access, contact your account team.
 :::
 
 <table>


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
