### PR TITLE
fix: broken mysql restore command

### DIFF
--- a/docs/products/mysql/howto/migrate-database-mysqldump.md
+++ b/docs/products/mysql/howto/migrate-database-mysqldump.md
@@ -104,7 +104,7 @@ Run the following command to load your saved data into your Aiven for
 MySQL database:
 
 ```shell
-mysqldump \
+mysql \
 -p DEFAULTDB -P TARGET_DB_PORT \
 -h TARGET_DB_HOST \
 -u TARGET_DB_USER \


### PR DESCRIPTION
## Describe your changes

When restoring a MySQL dump file, I think you're supposed to use the `mysql` tool itself, not `mysqldump` - [source](https://dba.stackexchange.com/questions/94552/mysqldump-doesnt-restore-database-why-not)

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
