### PR TITLE
fix: removed schema management from governance overview

### DIFF
--- a/docs/products/kafka/concepts/governance-overview.md
+++ b/docs/products/kafka/concepts/governance-overview.md
@@ -52,9 +52,6 @@ functionalities are incrementally added as development continues.
 - **Improved catalog:** Enhance the topic catalog to make it easier for teams to find
   and manage topics across the organization.
 
-- **Schema management:** Compare schema versions in the topic catalog to help
-  maintain data quality and compatibility.
-
 - **Access control:** Implement role-based access control (RBAC) for fine-grained
   permissions to ensure only authorized users can access sensitive data. Enable
   organization-wide visibility for Apache Kafka topics, allowing teams to discover


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
