### PR TITLE
fix: HTTPS page has internal links to HTTP

### DIFF
--- a/.vscode/aiven.code-snippets
+++ b/.vscode/aiven.code-snippets
@@ -141,13 +141,13 @@
     "scope": "markdown",
     "prefix": ["enable", "feature", "contact", "sales"],
     "body": [
-      "To enable this feature, contact the [sales team](http://aiven.io/contact)."
+      "To enable this feature, contact the [sales team](https://aiven.io/contact)."
     ]
   },
   "Contact sales": {
     "scope": "markdown",
     "prefix": ["contact", "sales"],
-    "body": ["contact the [sales team](http://aiven.io/contact)"]
+    "body": ["contact the [sales team](https://aiven.io/contact)"]
   },
   "Contact support": {
     "scope": "markdown",

--- a/docs/platform/concepts/enhanced-compliance-env.md
+++ b/docs/platform/concepts/enhanced-compliance-env.md
@@ -79,7 +79,7 @@ Insurance Portability and Accountability Act (HIPAA) and the Payment
 Card Industry Data Security Standard (PCI DSS) compliances.
 
 If you require compliance beyond these compliances, contact the
-[sales team](http://aiven.io/contact) so we can better understand your specific needs.
+[sales team](https://aiven.io/contact) so we can better understand your specific needs.
 
 Additionally, we offer an alternative deployment option. See
 [Bring Your Own Cloud (BYOC)](/docs/platform/concepts/byoc).
@@ -89,7 +89,7 @@ Additionally, we offer an alternative deployment option. See
 Migrations to Aiven are a standard procedure, but migrating
 to an ECE can add complexity.
 
-To migrate a new service to an ECE, contact [the sales team](http://aiven.io/contact)
+To migrate a new service to an ECE, contact [the sales team](https://aiven.io/contact)
 to request help.
 
 To migrate an existing Aiven service to an ECE, the Aiven network team creates a VPN

--- a/docs/platform/concepts/service-and-feature-releases.md
+++ b/docs/platform/concepts/service-and-feature-releases.md
@@ -25,7 +25,7 @@ The limited availability stage is an initial release of a
 new feature or service that you can try out by invitation only.
 
 To try a service or feature in this stage, contact the
-[sales team](http://aiven.io/contact).
+[sales team](https://aiven.io/contact).
 
 ### Early availability <EarlyBadge/>
 

--- a/docs/platform/howto/custom-plans.md
+++ b/docs/platform/howto/custom-plans.md
@@ -32,7 +32,7 @@ For example, available memory and CPU configurations may depend on
 restrictions imposed by the cloud provider and the instance types
 available in the region.
 
-Contact the [sales team](http://aiven.io/contact) for a quote and the
+Contact the [sales team](https://aiven.io/contact) for a quote and the
 availability of a custom plan.
 
 ## Custom plan request

--- a/docs/platform/howto/list-marketplace-payments.md
+++ b/docs/platform/howto/list-marketplace-payments.md
@@ -23,7 +23,7 @@ Aiven makes its services available through various Marketplaces. If you already 
    1. From your **new Aiven organization** with the AWS Marketplace
       subscription, retrieve the Aiven organization name.
 
-1. Send the information by email to the [sales team](http://aiven.io/contact)
+1. Send the information by email to the [sales team](https://aiven.io/contact)
 
 </TabItem>
 <TabItem value="azure" label="Azure Marketplace">
@@ -39,7 +39,7 @@ Aiven makes its services available through various Marketplaces. If you already 
    1. From your **new Aiven organization** with the Azure Marketplace
       subscription, retrieve the Aiven organization name.
 
-1. Send the information by email to the [sales team](http://aiven.io/contact).
+1. Send the information by email to the [sales team](https://aiven.io/contact).
 
 </TabItem>
 <TabItem value="google" label="Google Cloud Marketplace">
@@ -56,7 +56,7 @@ Aiven makes its services available through various Marketplaces. If you already 
       subscription, retrieve the Aiven organization name, as shown in the
       [Aiven GCP console](https://console.gcp.aiven.io/).
 
-1. Send the information by email to the [sales team](http://aiven.io/contact).
+1. Send the information by email to the [sales team](https://aiven.io/contact).
 
 </TabItem>
 </Tabs>

--- a/docs/products/cassandra/howto/enable-cross-cluster-replication.md
+++ b/docs/products/cassandra/howto/enable-cross-cluster-replication.md
@@ -34,7 +34,7 @@ To enable CCR, you can use the following tools:
 ## Prerequisites
 
 -   This is a [limited availability feature](/docs/platform/concepts/service-and-feature-releases#limited-availability-). To try
-    it out, contact the [sales team](http://aiven.io/contact).
+    it out, contact the [sales team](https://aiven.io/contact).
 -   Aiven account
 -   Depending on the method you choose to use for enabling CCR
     -   Access to [Aiven Console](https://console.aiven.io/)

--- a/docs/products/cassandra/howto/list-cross-cluster-replication.md
+++ b/docs/products/cassandra/howto/list-cross-cluster-replication.md
@@ -5,7 +5,7 @@ limited: true
 
 :::important
 This feature is in [limited availability](/docs/platform/concepts/service-and-feature-releases#limited-availability-).
-Contact the [sales team](http://aiven.io/contact) to enable it.
+Contact the [sales team](https://aiven.io/contact) to enable it.
 :::
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/products/cassandra/howto/manage-cross-cluster-replication.md
+++ b/docs/products/cassandra/howto/manage-cross-cluster-replication.md
@@ -10,7 +10,7 @@ Learn how to update Apache Cassandra® services that has cross-cluster replicati
 ## Prerequisites
 
 This feature is in [limited availability](/docs/platform/concepts/service-and-feature-releases#limited-availability-).
-Contact the [sales team](http://aiven.io/contact)
+Contact the [sales team](https://aiven.io/contact)
 
 ### Aiven-wise
 

--- a/docs/products/flink/howto/create-flink-applications.md
+++ b/docs/products/flink/howto/create-flink-applications.md
@@ -14,7 +14,7 @@ for custom job execution.
 :::important
 Custom JARs for Aiven for Apache Flink is a
 [limited availability feature](/docs/platform/concepts/service-and-feature-releases#limited-availability-). If you're interested in trying out this feature, contact
-the [sales team](http://aiven.io/contact).
+the [sales team](https://aiven.io/contact).
 :::
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/products/flink/howto/create-jar-application.md
+++ b/docs/products/flink/howto/create-jar-application.md
@@ -11,7 +11,7 @@ Aiven for Apache Flink® enables you to upload and deploy [custom code as a JAR 
 
 - Custom JARs for Aiven for Apache Flink is a **limited availability** feature.
   To try this feature, request access by contacting the
-  [sales team](http://aiven.io/contact).
+  [sales team](https://aiven.io/contact).
 - Create an Aiven for Apache Flink service and click **Upload and deploy custom JARs**
   to enable custom JARs during service creation.
 

--- a/docs/products/kafka/howto/enable-governance.md
+++ b/docs/products/kafka/howto/enable-governance.md
@@ -32,7 +32,7 @@ can manually select which services to govern through the Apache Kafka governance
 ## Prerequisites
 
 - This is a [limited availability feature](/docs/platform/concepts/service-and-feature-releases). To try
-  it out, contact the [sales team](http://aiven.io/contact).
+  it out, contact the [sales team](https://aiven.io/contact).
 - Ensure you have either
   [super admin role](/docs/platform/howto/manage-permissions#make-users-super-admin)
   or [organization admin role](/docs/platform/concepts/permissions#organization-roles)

--- a/docs/products/kafka/howto/enabled-consumer-lag-predictor.md
+++ b/docs/products/kafka/howto/enabled-consumer-lag-predictor.md
@@ -22,7 +22,7 @@ Before you start, ensure you have the following:
 -   Necessary permissions to modify service configurations.
 -   The consumer lag predictor for Aiven for Apache Kafka® is a
     **limited availability** feature and requires activation on your Aiven account.
-    Contact the [sales team](http://aiven.io/contact) to request activation.
+    Contact the [sales team](https://aiven.io/contact) to request activation.
 
 ## Enable and configure the consumer lag predictor
 
@@ -77,7 +77,7 @@ To enable the consumer lag predictor for your Aiven for Apache Kafka service usi
 [Aiven CLI](/docs/tools/cli):
 
 1. Ensure the consumer lag predictor feature is activated for your account by contacting
-   the [sales team](http://aiven.io/contact). The consumer lag predictor is a limited availability
+   the [sales team](https://aiven.io/contact). The consumer lag predictor is a limited availability
    feature and needs to be activated for your account.
 
 1. Get the project information:


### PR DESCRIPTION
## Describe your changes
Based on Ahref, SEO audit fixing issue with HTTPS page has internal links to HTTP

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
