### PR TITLE
update: remove EA tag for KRaft docs

### DIFF
--- a/docs/platform/reference/eol-for-major-versions.md
+++ b/docs/platform/reference/eol-for-major-versions.md
@@ -102,7 +102,7 @@ to manage metadata and controllers, replacing ZooKeeper. Migration to Apache Kaf
 from earlier versions is not yet supported. For details and current limitations, see:
 
 - [KRaft in Apache Kafka®](/docs/products/kafka/concepts/kraft-mode)
-- [Transitioning to KRaft](/docs/products/kafka/concepts/upgrade-procedure#transitioning-to-kraft-)
+- [Transitioning to KRaft](/docs/products/kafka/concepts/upgrade-procedure#transitioning-to-kraft)
 
 To support this transition, Aiven has extended support for Apache Kafka 3.8 by one year.
 :::

--- a/docs/platform/reference/eol-for-major-versions.md
+++ b/docs/platform/reference/eol-for-major-versions.md
@@ -94,7 +94,7 @@ after they are made available on the Aiven platform.
 | 3.6     | 2024-10-18 | 2024-09-01                       | 2023-10-18                      |
 | 3.7     | 2025-04-17 | 2025-01-17                       | 2024-04-17                      |
 | 3.8     | 2026-09-03 | 2026-06-03                       | 2024-09-06                      |
-| 3.9 (EA) | 2027-03-03 | 2026-12-03                      | 2025-03-20                      |
+| 3.9  | 2027-03-03 | 2026-12-03                      | 2025-03-20                      |
 
 :::note
 Starting with Apache Kafka 3.9, Aiven for Apache Kafka uses KRaft (Kafka Raft)

--- a/docs/products/kafka/concepts/kraft-mode.md
+++ b/docs/products/kafka/concepts/kraft-mode.md
@@ -62,7 +62,7 @@ ZooKeeper is not supported.
 - The migration is triggered when you upgrade your service to Apache Kafka 3.9 using the
   Aiven Console.
 - The migration runs during your configured
-  [maintenance window](/docs/platform/howto/maintenance-window), like other major
+  [maintenance window](/docs/platform/concepts/maintenance-window), like other major
   version upgrades.
 - During the upgrade, the service status changes to **Rebuilding**.
 - AAiven transfers your service’s metadata from ZooKeeper to KRaft and updates the

--- a/docs/products/kafka/concepts/kraft-mode.md
+++ b/docs/products/kafka/concepts/kraft-mode.md
@@ -65,9 +65,9 @@ ZooKeeper is not supported.
   [maintenance window](/docs/platform/concepts/maintenance-window), like other major
   version upgrades.
 - During the upgrade, the service status changes to **Rebuilding**.
-- AAiven transfers your service’s metadata from ZooKeeper to KRaft and updates the
+- Aiven transfers your service’s metadata from ZooKeeper to KRaft and updates the
   cluster to use KRaft mode.
-- When the migration finishes, the service status returns to **Running**, and the
+- When the migration completes, the service status returns to **Running**, and the
   service operates in KRaft mode.
 
 ### Before you migrate

--- a/docs/products/kafka/concepts/kraft-mode.md
+++ b/docs/products/kafka/concepts/kraft-mode.md
@@ -48,6 +48,35 @@ KRaft introduces two key roles within an Aiven for Apache Kafka service:
 Separating these roles improves metadata management efficiency without affecting broker
 performance.
 
+## Migration from ZooKeeper to KRaft
+
+Migration from ZooKeeper to KRaft is not yet available for existing
+Aiven for Apache Kafka services. Aiven will notify you when your service becomes eligible.
+
+The migration is included in the upgrade to Apache Kafka 3.9. It is fully automated and
+does not require any manual steps. After the migration is complete, reverting to
+ZooKeeper is not supported.
+
+### How the migration works
+
+- The migration is triggered when you upgrade your service to Apache Kafka 3.9 using the
+  Aiven Console.
+- The migration runs during your configured
+  [maintenance window](/docs/platform/howto/maintenance-window), like other major
+  version upgrades.
+- During the upgrade, the service status changes to **Rebuilding**.
+- AAiven transfers your service’s metadata from ZooKeeper to KRaft and updates the
+  cluster to use KRaft mode.
+- When the migration finishes, the service status returns to **Running**, and the
+  service operates in KRaft mode.
+
+### Before you migrate
+
+- **Service version**: To upgrade to Apache Kafka 4.0 or later, your service must first
+  migrate to KRaft by upgrading to Kafka 3.9.
+- **Service plan**: If your service is on the **Startup-2** plan, you must upgrade
+  to **Startup-4** or higher during the same maintenance window as the version upgrade.
+
 ## Impact of KRaft
 
 ### Compatibility and impact

--- a/docs/products/kafka/concepts/kraft-mode.md
+++ b/docs/products/kafka/concepts/kraft-mode.md
@@ -1,7 +1,6 @@
 ---
 title: KRaft in Aiven for Apache Kafka®
 sidebar_label: KRaft
-early: true
 ---
 
 import RelatedPages from "@site/src/components/RelatedPages";

--- a/docs/products/kafka/concepts/kraft-mode.md
+++ b/docs/products/kafka/concepts/kraft-mode.md
@@ -68,4 +68,4 @@ removed metrics, see [KRaft and metrics changes](/docs/products/kafka/reference/
 
 <RelatedPages/>
 
-[Transitioning to KRaft](/docs/products/kafka/concepts/upgrade-procedure#transitioning-to-kraft-)
+[Transitioning to KRaft](/docs/products/kafka/concepts/upgrade-procedure#transitioning-to-kraft)

--- a/docs/products/kafka/concepts/upgrade-procedure.md
+++ b/docs/products/kafka/concepts/upgrade-procedure.md
@@ -117,7 +117,7 @@ In critical situations, Aiven's operations team can temporarily add extra storag
 the old nodes.
 :::
 
-## Transitioning to KRaft <EarlyBadge/>
+## Transitioning to KRaft
 
 With the release of Apache Kafka® 3.9, Aiven introduces support for Apache Kafka Raft
 (KRaft), the new consensus protocol for Kafka metadata management. This enhancement
@@ -129,6 +129,9 @@ Apache Kafka 3.9 includes all features from Apache Kafka 3.8, but some controlle
 are no longer available due to the transition to KRaft mode. For details,
 see [Apache Kafka controller metrics](/docs/products/kafka/reference/kafka-metrics-prometheus#kraft-mode-and-metrics-changes).
 ACL permissions and governance behaviors remain unchanged.
+
+For a detailed overview of how KRaft mode works and how it differs from ZooKeeper-based
+metadata management, see [KRaft in Aiven for Apache Kafka®](/docs/products/kafka/concepts/kraft-mode).
 
 ### Availability and migration
 

--- a/docs/products/kafka/concepts/upgrade-procedure.md
+++ b/docs/products/kafka/concepts/upgrade-procedure.md
@@ -147,7 +147,11 @@ metadata management, see [KRaft in Aiven for Apache Kafka®](/docs/products/kafk
 
 - Migration for existing services, which involves upgrading from Apache Kafka 3.x to 3.9,
   is not yet available.
-- Aiven will provide a migration path once it is ready.
+- The migration will be included in a future upgrade to Apache Kafka 3.9 and
+  performed automatically by Aiven.
+- Aiven will notify you when your service becomes eligible for migration. For details,
+  see [Migration from ZooKeeper to KRaft](/docs/products/kafka/concepts/kraft-mode#migration-from-zookeeper-to-kraft).
+
 - To support this transition, Aiven has extended support for Apache Kafka 3.8 by one
   year, allowing sufficient time for planning and migration.
 


### PR DESCRIPTION
## Describe your changes

Removed Early Access (EA) tag from KRaft-related documentation.

[HH-5372](https://aiven.atlassian.net/browse/HH-5372)


## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.


[HH-5372]: https://aiven.atlassian.net/browse/HH-5372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ