### PR TITLE
update: free trials cannot be manually ended

### DIFF
--- a/docs/platform/concepts/free-trial.md
+++ b/docs/platform/concepts/free-trial.md
@@ -27,6 +27,7 @@ There are some limitations:
     [billing group](/docs/platform/howto/use-billing-groups). You cannot transfer them to
     another billing group.
 -   You can't create new services if your remaining credits would be spent too quickly.
+-   You can't end a free trial yourself before the end of the trial period.
 <!-- vale on -->
 
 Services are automatically powered down after the trial ends or your credits run out. To


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
