### PR TITLE
update: version 9.x compatibility note for Stream Reactor

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink.md
@@ -123,20 +123,20 @@ Parameters:
   `schema.registry.url` and related credentials.
 
 :::note
-The `key.converter` and `value.converter` fields define how Kafka messages are parsed
-and must be included in the configuration.
+The `key.converter` and `value.converter` fields define how Kafka messages
+are parsed and must be included in the configuration.
 
 When using Avro as the source format, set the following:
 
-- `value.converter.schema.registry.url`: Use the Aiven for Apache Kafka schema registry
-  URL in the format `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT`. Retrieve these
-  values from the [prerequisite step](/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink#connect_cassandra_lenses_sink_prereq).
+- `value.converter.schema.registry.url`: Use the Aiven for Apache Kafka schema
+  registry URL in the format `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT`.
 - `value.converter.basic.auth.credentials.source`: Set to `USER_INFO`, which means
   authentication is done using a username and password.
 - `value.converter.schema.registry.basic.auth.user.info`: Provide the schema registry
-  credentials in the format `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`. These
-  values should also be retrieved in the [prerequisite step](/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink#connect_cassandra_lenses_sink_prereq).
+  credentials in the format `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`.
 
+You can retrieve these values from the
+[prerequisite step](/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink#connect_cassandra_lenses_sink_prereq).
 :::
 
 ## Create the connector

--- a/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink.md
@@ -1,9 +1,14 @@
 ---
-title: Create a stream reactor sink connector from Apache Kafka® to Apache Cassandra®
+title: Create a Stream Reactor sink connector from Apache Kafka® to Apache Cassandra®
 ---
 
-**The Apache Cassandra® stream reactor sink connector** enables you to move data from **an Aiven for Apache Kafka® cluster** to **a Apache Cassandra® database**.
-The Lenses.io implementation enables you to write [KCQL transformations](https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sinks/cassandrasinkconnector/) on the topic data before sending it to the Cassandra database.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import Note from "@site/static/includes/streamreactor-compatibility-note.md"
+
+The Apache Cassandra® Stream Reactor sink connector enables you to move data from an Aiven for Apache Kafka® cluster to a Apache Cassandra® database.
+It uses [KCQL transformations](https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sinks/cassandrasinkconnector/) to filter and map topic data before sending it to Cassandra.
 
 :::note
 See the full set of available parameters and configuration
@@ -11,95 +16,75 @@ options in the [connector's
 documentation](https://docs.lenses.io/connectors/sink/cassandra).
 :::
 
+<Note/>
+
 ## Prerequisites {#connect_cassandra_lenses_sink_prereq}
 
-- An Aiven for Apache
-  Kafka service
-  [with Kafka Connect enabled](enable-connect) or a
+- An Aiven for Apache Kafka service
+  [with Apache Kafka Connect enabled](enable-connect) or a
   [dedicated Aiven for Apache Kafka Connect cluster](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
 
-- Collect the following information about the
-  target Cassandra database upfront:
+- Gather the following information for the target Cassandra database:
 
-  -   `CASSANDRA_HOSTNAME`: The Cassandra hostname
-  -   `CASSANDRA_PORT`: The Cassandra port
-  -   `CASSANDRA_USERNAME`: The Cassandra username
-  -   `CASSANDRA_PASSWORD`: The Cassandra password
-  -   `CASSANDRA_SSL`: The Cassandra SSL setting, can be `true`, `false`
-      or `default`
-  -   `CASSANDRA_KEYSTORE`: The path to the Keystore containing the CA
-      certificate, used when connection is secured via SSL
-  -   `CASSANDRA_KEYSTORE_PASSWORD`: The Keystore password, used when
-      connection is secured via SSL
+  - `CASSANDRA_HOSTNAME`: The Cassandra hostname.
+  - `CASSANDRA_PORT`: The Cassandra port.
+  - `CASSANDRA_USERNAME`: The Cassandra username.
+  - `CASSANDRA_PASSWORD`: The Cassandra password.
+  - `CASSANDRA_SSL`: Set to `true`, `false`, or `default`, depending on your SSL setup.
+  - `CASSANDRA_KEYSTORE`: The path to the keystore containing the CA certificate,
+    used for SSL connections.
+  - `CASSANDRA_KEYSTORE_PASSWORD`: The password for the keystore.
 
-  :::note
-  If you're using Aiven for Apache Cassandra, you can use the following
-  keystore values
+    :::note
 
-  -   `CASSANDRA_TRUSTSTORE`: `/run/aiven/keys/public.truststore.jks`
-  -   `CASSANDRA_TRUSTSTORE_PASSWORD`: `password`
-  :::
+    If you are using Aiven for Apache Cassandra, use the following values:
+    - `CASSANDRA_TRUSTSTORE`: `/run/aiven/keys/public.truststore.jks`
+    - `CASSANDRA_TRUSTSTORE_PASSWORD`: `password`
+    :::
+  - `CASSANDRA_KEYSPACE`: The Cassandra keyspace to use to sink the data
 
-  -   `CASSANDRA_KEYSPACE`: The Cassandra keyspace to use to sink the data
+    :::warning
+    The Cassandra keyspace and destination table need to be created before
+    starting the connector, otherwise the connector task will fail.
+    :::
+  - `TOPIC_LIST`: A comma-separated list of Kafka topics to sink.
 
-  :::warning
-  The Cassandra keyspace and destination table need to be created before
-  starting the connector, otherwise the connector task will fail.
-  :::
+  - `KCQL_TRANSFORMATION`: A KCQL statement to map topic fields to table columns.
+    Use the following format:
 
-  -   `TOPIC_LIST`: The list of topics to sink divided by comma
+    ```sql
+    INSERT INTO CASSANDRA_TABLE
+    SELECT LIST_OF_FIELDS
+    FROM APACHE_KAFKA_TOPIC
+    ```
 
-  -   `KCQL_TRANSFORMATION`: The KCQL syntax to parse the topic data,
-      should be in the format:
+    :::warning
+    Create the Cassandra keyspace and destination table (`CASSANDRA_TABLE`) before
+    starting the connector. The connector fails to start if they do not exist.
+    :::
 
-      ```
-      INSERT INTO CASSANDRA_TABLE
-      SELECT LIST_OF_FIELDS
-      FROM APACHE_KAFKA_TOPIC
-      ```
+  - `APACHE_KAFKA_HOST`: The Apache Kafka host. Required only when using Avro as the
+    data format.
+  - `SCHEMA_REGISTRY_PORT`: The schema registry port. Required only when using Avro.
+  - `SCHEMA_REGISTRY_USER`: The schema registry username. Required only when using Avro.
+  - `SCHEMA_REGISTRY_PASSWORD`: The schema registry password. Required only when using
+    Avro.
 
-  :::warning
-  The Cassandra destination table `CASSANDRA_TABLE` needs to be created
-  before starting the connector, otherwise the connector task will fail.
-  :::
+    :::note
+    If you are using Aiven for Cassandra and Aiven for Apache Kafka, get all required
+    connection details, including schema registry information, from the
+    **Connection information** section on the <ConsoleLabel name="overview"/> page.
 
-  -   `APACHE_KAFKA_HOST`: The hostname of the Apache Kafka service, only
-      needed when using Avro as data format
-  -   `SCHEMA_REGISTRY_PORT`: The Apache Kafka's schema registry port,
-      only needed when using Avro as data format
-  -   `SCHEMA_REGISTRY_USER`: The Apache Kafka's schema registry
-      username, only needed when using Avro as data format
-  -   `SCHEMA_REGISTRY_PASSWORD`: The Apache Kafka's schema registry user
-      password, only needed when using Avro as data format
+    As of version 3.0, Aiven for Apache Kafka uses Karapace as the schema registry and
+    no longer supports the Confluent Schema Registry.
+    :::
 
-  :::note
-  If you're using Aiven for Cassandra and Aiven for Apache Kafka, the
-  above details are available in the [Aiven
-  console](https://console.aiven.io/) service *Overview tab* or via the
-  dedicated `avn service get` command with the
-  [Aiven CLI](/docs/tools/cli/service-cli#avn_service_get).
+   For a complete list of supported parameters and configuration options, see the
+   [connector's documentation](https://docs.lenses.io/connectors/sink/cassandra).
 
-  The `SCHEMA_REGISTRY` related parameters are available in the Aiven for
-  Apache Kafka® service page, *Overview* tab, and *Schema Registry* subtab
+## Create a connector configuration file
 
-  As of version 3.0, Aiven for Apache Kafka no longer supports Confluent
-  Schema Registry. For more information, read [the article describing the
-  replacement, Karapace](https://help.aiven.io/en/articles/5651983)
-  :::
-
-## Setup an Apache Cassandra sink connector with Aiven Console
-
-The following example demonstrates how to setup an Apache Cassandra sink
-connector for Apache Kafka using the [Aiven
-Console](https://console.aiven.io/).
-
-### Define a Kafka Connect configuration file
-
-Define the connector configurations in a file (we'll refer to it with
-the name `cassandra_sink.json`) with the following content, creating a
-file is not strictly necessary but allows to have all the information in
-one place before copy/pasting them in the [Aiven
-Console](https://console.aiven.io/):
+Create a file named `cassandra_sink.json` and add the following configuration:
 
 ```json
 {
@@ -126,91 +111,83 @@ Console](https://console.aiven.io/):
 }
 ```
 
-The configuration file contains the following entries:
+Parameters:
 
--   `name`: the connector name, replace `CONNECTOR_NAME` with the name
-    to use for the connector.
--   `connect.cassandra.*`: sink parameters collected in the
-    [prerequisite](/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink#connect_cassandra_lenses_sink_prereq) phase.
--   `key.converter` and `value.converter`: defines the messages data
-    format in the Apache Kafka topic. The
-    `io.confluent.connect.avro.AvroConverter` converter translates
-    messages from the Avro format. To retrieve the messages schema we
-    use Aiven's [Karapace schema
-    registry](https://github.com/aiven/karapace) as specified by the
-    `schema.registry.url` parameter and related credentials.
+- `name`: The connector name. Replace `CONNECTOR_NAME` with your desired name.
+- `connect.cassandra.*`: Cassandra connection parameters collected in the
+  [prerequisite step](/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink#connect_cassandra_lenses_sink_prereq).
+- `key.converter` and `value.converter`: d Define the message data format in the
+  Kafka topic. This example uses `io.confluent.connect.avro.AvroConverter` to translate
+  messages in Avro format. The schema is retrieved from Aiven's
+  [Karapace schema registry](https://github.com/aiven/karapace) using the
+  `schema.registry.url` and related credentials.
 
 :::note
-The `key.converter` and `value.converter` sections define how the topic
-messages will be parsed and needs to be included in the connector
-configuration.
+The `key.converter` and `value.converter` fields define how Kafka messages are parsed
+and must be included in the configuration.
 
-When using Avro as source data format, set the following parameters:
+When using Avro as the source format, set the following:
 
--   `value.converter.schema.registry.url`: pointing to the Aiven for
-    Apache Kafka schema registry URL in the form of
-    `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT` with the
-    `APACHE_KAFKA_HOST` and `SCHEMA_REGISTRY_PORT` parameters
-    [retrieved in the previous step](/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink#connect_cassandra_lenses_sink_prereq).
--   `value.converter.basic.auth.credentials.source`: to the value
-    `USER_INFO`, since you're going to login to the schema registry
-    using username and password.
--   `value.converter.schema.registry.basic.auth.user.info`: passing the
-    required schema registry credentials in the form of
-    `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD` with the
-    `SCHEMA_REGISTRY_USER` and `SCHEMA_REGISTRY_PASSWORD` parameters
-    [retrieved in the previous step](/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink#connect_cassandra_lenses_sink_prereq).
+- `value.converter.schema.registry.url`: Use the Aiven for Apache Kafka schema registry
+  URL in the format `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT`. Retrieve these
+  values from the [prerequisite step](/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink#connect_cassandra_lenses_sink_prereq).
+- `value.converter.basic.auth.credentials.source`: Set to `USER_INFO`, which means
+  authentication is done using a username and password.
+- `value.converter.schema.registry.basic.auth.user.info`: Provide the schema registry
+  credentials in the format `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`. These
+  values should also be retrieved in the [prerequisite step](/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink#connect_cassandra_lenses_sink_prereq).
+
 :::
 
-### Create a Kafka Connect connector with the Aiven Console
+## Create the connector
 
-To create an Apache Kafka Connect connector:
+<Tabs groupId="setup-method">
+<TabItem value="console" label="Console" default>
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/) and select
-    the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
-    service where the connector needs to be defined.
 
-2.  Select **Connectors** from the left sidebar.
+1. Access the [Aiven Console](https://console.aiven.io/).
+1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
+1. Click <ConsoleLabel name="Connectors"/>.
+1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
+   If not, click **Enable connector on this service**.
 
-3.  Select **Create New Connector**, which is enabled only for
-    services
-    [with Kafka Connect enabled](enable-connect).
+   Alternatively, to enable connectors:
 
-4.  Select **Stream Reactor Cassandra Sink**.
+   1. Click <ConsoleLabel name="Service settings"/> in the sidebar.
+   1. In the **Service management** section, click
+      <ConsoleLabel name="Actions"/> > **Enable Kafka connect**.
 
-5.  In the **Common** tab, locate the **Connector configuration** text
-    box and select on **Edit**.
+1. In the sink connectors list, select **Amazon S3 source connector**, and click
+   **Get started**.
+1. On the **Stream Reactor Cassandra Sink** page, go to the **Common** tab.
+1. Locate the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
+1. Paste the configuration from your `cassandra_sink.json` file into the text box.
+1. Click **Create connector**.
+1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Confirm that data appears in the Cassandra target table.
 
-6.  Paste the connector configuration (stored in the
-    `cassandra_sink.json` file) in the form.
+</TabItem>
+<TabItem value="cli" label="CLI">
 
-7.  Select **Apply**.
+To create the connector using the
+[Aiven CLI](/docs/tools/cli/service/connector#avn_service_connector_create), run:
 
-    :::note
-    The Aiven Console parses the configuration file and fills the
-    relevant UI fields. You can review the UI fields across the various
-    tab and change them if necessary. The changes will be reflected in
-    JSON format in the **Connector configuration** text box.
-    :::
+```bash
+avn service connector create SERVICE_NAME @cassandra_sink.json
+```
 
-8.  After all the settings are correctly configured, select **Create
-    connector**.
+Replace:
 
-9.  Verify the connector status under the **Connectors** screen.
+- `SERVICE_NAME`: Your Kafka or Kafka Connect service name.
+- `@cassandra_sink.json`: Path to your configuration file.
 
-10. Verify the presence of the data in the target Cassandra service.
+</TabItem>
+</Tabs>
 
-:::note
-You can also create connectors using the
-[Aiven CLI command](/docs/tools/cli/service/connector#avn_service_connector_create).
-:::
+## Sink topic data to Cassandra
 
-## Example: Create a Cassandra sink connector
-<!-- vale off -->
-If you have a topic named `students` containing the following data that
-you want to move to a Cassandra table called `students_tbl` in the
-keyspace `students_keyspace`:
-<!-- vale on -->
+The following example shows how to sink data from a Kafka topic to a Cassandra table. If
+your Kafka topic `students` contains the following data:
 
 ```json
 {"id":1, "name":"carlo", "age": 77}
@@ -219,43 +196,41 @@ keyspace `students_keyspace`:
 {"id":2, "name":"lucy", "age": 21}
 ```
 
-You can sink the `students` topic to Cassandra with the following
-connector configuration, after replacing the placeholders for
-`CASSANDRA_HOST`, `CASSANDRA_PORT`, `CASSANDRA_USERNAME`,
-`CASSANDRA_PASSWORD`, `CASSANDRA_KEYSTORE`,
-`CASSANDRA_KEYSTORE_PASSWORD`, `CASSANDRA_TRUSTSTORE`,
-`CASSANDRA_TRUSTSTORE_PASSWORD`, `CASSANDRA_KEYSPACE`.
+To write this data to the `students_tbl` table in the `students_keyspace` keyspace,
+use the following connector configuration:
 
 ```json
 {
-    "name": "my-cassandra-sink",
-    "connector.class": "com.datamountaineer.streamreactor.connect.cassandra.sink.CassandraSinkConnector",
-    "topics": "TOPIC_LIST",
-    "connect.cassandra.host": "CASSANDRA_HOSTNAME",
-    "connect.cassandra.port": "CASSANDRA_PORT",
-    "connect.cassandra.username": "CASSANDRA_USERNAME",
-    "connect.cassandra.password": "CASSANDRA_PASSWORD",
-    "connect.cassandra.ssl.enabled": "CASSANDRA_SSL",
-    "connect.cassandra.trust.store.path": "CASSANDRA_TRUSTSTORE",
-    "connect.cassandra.trust.store.password": "CASSANDRA_TRUSTSTORE_PASSWORD",
-    "connect.cassandra.key.space": "students_keyspace",
-    "topics": "students",
-    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
-    "value.converter.schemas.enable": "false",
-    "connect.cassandra.kcql": "INSERT INTO students_tbl SELECT id, name, age FROM students"
+  "name": "my-cassandra-sink",
+  "connector.class": "com.datamountaineer.streamreactor.connect.cassandra.sink.CassandraSinkConnector",
+  "topics": "students",
+  "connect.cassandra.host": "CASSANDRA_HOSTNAME",
+  "connect.cassandra.port": "CASSANDRA_PORT",
+  "connect.cassandra.username": "CASSANDRA_USERNAME",
+  "connect.cassandra.password": "CASSANDRA_PASSWORD",
+  "connect.cassandra.ssl.enabled": "CASSANDRA_SSL",
+  "connect.cassandra.trust.store.path": "CASSANDRA_TRUSTSTORE",
+  "connect.cassandra.trust.store.password": "CASSANDRA_TRUSTSTORE_PASSWORD",
+  "connect.cassandra.key.space": "students_keyspace",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter.schemas.enable": "false",
+  "connect.cassandra.kcql": "INSERT INTO students_tbl SELECT id, name, age FROM students"
 }
+
 ```
 
-The configuration file contains the following peculiarities:
+Replace all placeholder values (such as `CASSANDRA_HOSTNAME`, `CASSANDRA_PORT`,
+and `CASSANDRA_USERNAME`) with your actual Cassandra connection details.
 
--   `"topics": "students"`: setting the topic to sink
--   `"connect.cassandra"`: the connection parameters placeholders
--   `"value.converter": "org.apache.kafka.connect.json.JsonConverter"`
-    and `"value.converter.schemas.enable": "false"`: the topic value is
-    in JSON format without a schema
--   `"connect.cassandra.kcql": "INSERT INTO students_tbl SELECT id, name, age FROM students"`:
-    the connector logic is to insert every topic message as new entry in
-    the table.
+This configuration does the following:
 
-Once the connector is created successfully, you should see the data in
-the target Cassandra database.
+- `"topics": "students"`: Specifies the Kafka topic to sink.
+- Connection settings (`connect.cassandra.*`)**: Provide the Cassandra host, port,
+  credentials, SSL settings, and truststore paths.
+- `"value.converter"` and `"value.converter.schemas.enable"`: Set the message format.
+  The topic uses raw JSON without a schema.
+- `"connect.cassandra.kcql"`: Defines the insert logic. Each Kafka message is written
+  as a new row in the `students_tbl` Cassandra table.
+
+After creating the connector, check the Cassandra database to verify that the data has
+been written.

--- a/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-source.md
+++ b/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-source.md
@@ -1,110 +1,80 @@
 ---
-title: Create a stream reactor source connector from Apache Cassandra® to Apache Kafka®
+title: Create a Stream Reactor source connector from Apache Cassandra® to Apache Kafka®
 ---
 
-**The Apache Cassandra® stream reactor source connector** enables you to move data from **a Apache Cassandra® database** to **an Aiven for Apache Kafka® cluster**.
-The Lenses.io implementation enables you to write
-[KCQL
-transformations](https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sources/cassandrasourceconnector/)
-on the topic data before sending it to the Apache Kafka cluster.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import Note from "@site/static/includes/streamreactor-compatibility-note.md"
 
-:::note
-See the full set of available parameters and configuration
-options in the [connector's
-documentation](https://docs.lenses.io/connectors/source/cassandra).
-:::
+The Apache Cassandra® Stream Reactor source connector enables you to move data from an Apache Cassandra® database to an Aiven for Apache Kafka® cluster.
+It supports
+[KCQL transformations](https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sources/cassandrasourceconnector/)
+to parse and filter Cassandra table data before sending it to Kafka.
+
+<Note/>
 
 ## Prerequisites {#connect_cassandra_lenses_source_prereq}
 
-To setup a Apache Cassandra source connector, you need an Aiven for
-Apache Kafka service
-[with Kafka Connect enabled](enable-connect) or a
-[dedicated Aiven for Apache Kafka Connect cluster](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
+- An Aiven for Apache Kafka service
+  [with Apache Kafka Connect enabled](enable-connect) or a
+  [dedicated Aiven for Apache Kafka Connect cluster](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
 
-Also collect the following information about the
-target Cassandra database upfront:
+- Gather the following information for the source Cassandra database:
 
--   `CASSANDRA_HOSTNAME`: The Cassandra hostname
--   `CASSANDRA_PORT`: The Cassandra port
--   `CASSANDRA_USERNAME`: The Cassandra username
--   `CASSANDRA_PASSWORD`: The Cassandra password
--   `CASSANDRA_SSL`: The Cassandra SSL setting, can be `true`, `false`
-    or `default`
--   `CASSANDRA_KEYSTORE`: The path to the Keystore containing the CA
-    certificate, used when connection is secured via SSL
--   `CASSANDRA_KEYSTORE_PASSWORD`: The Keystore password, used when
-    connection is secured via SSL
+  - `CASSANDRA_HOSTNAME`: The Cassandra hostname.
+  - `CASSANDRA_PORT`: The Cassandra port.
+  - `CASSANDRA_USERNAME`: The Cassandra username.
+  - `CASSANDRA_PASSWORD`: The Cassandra password.
+  - `CASSANDRA_SSL`: Set to `true`, `false`, or `default`, depending on your SSL setup.
+  - `CASSANDRA_KEYSTORE`: The path to the keystore containing the CA certificate,
+    used for SSL connections.
+  - `CASSANDRA_KEYSTORE_PASSWORD`: The password for the keystore.
 
-:::note
-If you're using Aiven for Apache Cassandra, you can use the following
-keystore values
+    :::note
 
--   `CASSANDRA_TRUSTSTORE`: `/run/aiven/keys/public.truststore.jks`
--   `CASSANDRA_TRUSTSTORE_PASSWORD`: `password`
-:::
+    If you are using Aiven for Apache Cassandra, use the following values:
+    - `CASSANDRA_TRUSTSTORE`: `/run/aiven/keys/public.truststore.jks`
+    - `CASSANDRA_TRUSTSTORE_PASSWORD`: `password`
+    :::
+  - `CASSANDRA_KEYSPACE`: The Cassandra keyspace to source the data from.
+  - `KCQL_TRANSFORMATION`: A KCQL statement to map table fields to Kafka topics. Use the following format:
 
--   `CASSANDRA_KEYSPACE`: The Cassandra keyspace to use to source the
-    data from
-
--   `KCQL_TRANSFORMATION`: The KCQL syntax to parse the topic data,
-    should be in the format:
-
-    ```
+    ```sql
     INSERT INTO APACHE_KAFKA_TOPIC
     SELECT LIST_OF_FIELDS
     FROM CASSANDRA_TABLE
     [PK CASSANDRA_TABLE_COLUMN]
-    [INCREMENTAL_MODE=MODE]
+    [INCREMENTALMODE=MODE]
     ```
 
     :::warning
-    By default the connector acts in **bulk mode**, extracting all the
-    rows from the Cassandra table on a polling interval and pushing them
-    to the Apache Kafka topic. You can however define **incremental
-    options** by defining the [incremental mode and primary
-    key](https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sources/cassandrasourceconnector/).
+    By default, the connector runs in **bulk mode** and polls all rows in the table periodically.
+    To source data incrementally, use the `PK` and `INCREMENTALMODE` parameters.
+    See [KCQL syntax for Cassandra Source](https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sources/cassandrasourceconnector/)
+    for details.
     :::
 
--   `APACHE_KAFKA_HOST`: The hostname of the Apache Kafka service, only
-    needed when using Avro as data format
+  - `APACHE_KAFKA_HOST`: The Apache Kafka host. Required only when using Avro as the data format.
+  - `SCHEMA_REGISTRY_PORT`: The schema registry port. Required only when using Avro.
+  - `SCHEMA_REGISTRY_USER`: The schema registry username. Required only when using Avro.
+  - `SCHEMA_REGISTRY_PASSWORD`: The schema registry password. Required only when using Avro.
 
--   `SCHEMA_REGISTRY_PORT`: The Apache Kafka's schema registry port,
-    only needed when using Avro as data format
+    :::note
+    If you are using Aiven for Cassandra and Aiven for Apache Kafka, get all required
+    connection details, including schema registry information, from the
+    **Connection information** section on the <ConsoleLabel name="overview"/> page.
 
--   `SCHEMA_REGISTRY_USER`: The Apache Kafka's schema registry
-    username, only needed when using Avro as data format
+    As of version 3.0, Aiven for Apache Kafka uses Karapace as the schema registry and
+    no longer supports the Confluent Schema Registry.
+    :::
 
--   `SCHEMA_REGISTRY_PASSWORD`: The Apache Kafka's schema registry user
-    password, only needed when using Avro as data format
+For a complete list of supported parameters and configuration options, see the
+[connector's documentation](https://docs.lenses.io/connectors/source/cassandra).
 
-:::note
-If you're using Aiven for Cassandra and Aiven for Apache Kafka, the
-above details are available in the [Aiven
-console](https://console.aiven.io/) service *Overview tab* or via the
-dedicated `avn service get` command with the
-[Aiven CLI](/docs/tools/cli/service-cli#avn_service_get).
+## Create a connector configuration file
 
-The `SCHEMA_REGISTRY` related parameters are available in the Aiven for
-Apache Kafka® service page, *Overview* tab, and *Schema Registry* subtab
-
-As of version 3.0, Aiven for Apache Kafka no longer supports Confluent
-Schema Registry. For more information, read [the article describing the
-replacement, Karapace](https://help.aiven.io/en/articles/5651983)
-:::
-
-## Setup an Apache Cassandra source connector with Aiven Console
-
-The following example demonstrates how to setup an Apache Cassandra
-source connector for Apache Kafka using the [Aiven
-Console](https://console.aiven.io/).
-
-### Define a Kafka Connect configuration file
-
-Define the connector configurations in a file (we'll refer to it with
-the name `cassandra_source.json`) with the following content, creating a
-file is not strictly necessary but allows to have all the information in
-one place before copy/pasting them in the [Aiven
-Console](https://console.aiven.io/):
+Create a file named `cassandra_source.json` and add the following configuration:
 
 ```json
 {
@@ -130,134 +100,128 @@ Console](https://console.aiven.io/):
 }
 ```
 
-The configuration file contains the following entries:
+Parameters:
 
--   `name`: the connector name, replace `CONNECTOR_NAME` with the name
-    to give to the connector.
--   `connect.cassandra.*`: source parameters collected in the
-    [prerequisite](/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-source#connect_cassandra_lenses_source_prereq) phase.
--   `key.converter` and `value.converter`: defines the messages data
-    format in the Apache Kafka topic. The
-    `io.confluent.connect.avro.AvroConverter` converter translates
-    messages from the Avro format. To retrieve the messages schema we
-    use Aiven's [Karapace schema
-    registry](https://github.com/aiven/karapace) as specified by the
-    `schema.registry.url` parameter and related credentials.
+- `name`: The connector name. Replace `CONNECTOR_NAME` with your desired name.
+- `connect.cassandra.*`: Cassandra connection parameters collected in the
+  [prerequisite step](#connect_cassandra_lenses_source_prereq).
+- `key.converter` and `value.converter`: Define the message data format. This example uses
+  `AvroConverter`. The schema is retrieved from Aiven’s
+  [Karapace schema registry](https://github.com/aiven/karapace).
 
 :::note
-The `key.converter` and `value.converter` sections define how the topic
-messages will be parsed and needs to be included in the connector
-configuration.
+The `key.converter` and `value.converter` fields define how Kafka messages are parsed
+and must be included in the configuration.
 
-When using Avro as source data format, set following
-parameters:
+When using Avro as the output format, set the following fields:
 
--   `value.converter.schema.registry.url`: pointing to the Aiven for
-    Apache Kafka schema registry URL in the form of
-    `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT` with the
-    `APACHE_KAFKA_HOST` and `SCHEMA_REGISTRY_PORT` parameters
-    [retrieved in the previous step](/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-source#connect_cassandra_lenses_source_prereq).
--   `value.converter.basic.auth.credentials.source`: to the value
-    `USER_INFO`, since you're going to login to the schema registry
-    using username and password.
--   `value.converter.schema.registry.basic.auth.user.info`: passing the
-    required schema registry credentials in the form of
-    `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD` with the
-    `SCHEMA_REGISTRY_USER` and `SCHEMA_REGISTRY_PASSWORD` parameters
-    [retrieved in the previous step](/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-source#connect_cassandra_lenses_source_prereq).
+- `value.converter.schema.registry.url`: Use the Aiven for Apache Kafka schema registry URL
+  in the format `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT`. Retrieve these values
+  from the
+  [prerequisite step](#connect_cassandra_lenses_source_prereq).
+- `value.converter.basic.auth.credentials.source`: Set to `USER_INFO` to use username
+  and password authentication.
+- `value.converter.schema.registry.basic.auth.user.info`: Provide the credentials in the format
+  `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`. Retrieve these values from the
+  [prerequisite step](#connect_cassandra_lenses_source_prereq).
+
 :::
 
-### Create a Kafka Connect connector with the Aiven Console
+## Create the connector
 
-To create a Kafka Connect connector:
+<Tabs groupId="setup-method">
+<TabItem value="console" label="Console" default>
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/) and select
-    the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
-    service where the connector needs to be defined.
+1. Access the [Aiven Console](https://console.aiven.io/).
+1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
+1. Click <ConsoleLabel name="Connectors"/>.
+1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
+   If not, click **Enable connector on this service**.
 
-2.  Select **Connectors** from the left sidebar.
+   Alternatively, to enable connectors:
 
-3.  Select **Create New Connector**.
+   1. Click <ConsoleLabel name="Service settings"/> in the sidebar.
+   1. In the **Service management** section, click
+      <ConsoleLabel name="Actions"/> > **Enable Kafka connect**.
 
-    :::note
-    It enabled only for services [with Kafka Connect enabled](enable-connect).
-    :::
+1. In the source connectors list, select **Stream Reactor Cassandra Source**, and click
+   **Get started**.
+1. On the **Stream Reactor Cassandra Source** page, go to the **Common** tab.
+1. Locate the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
+1. Paste the configuration from your `cassandra_source.json` file into the text box.
+1. Click **Create connector**.
+1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Confirm that data appears in the target Kafka topic.
 
-4.  Select **Stream Reactor Cassandra Source**.
+</TabItem>
+<TabItem value="cli" label="CLI">
 
-5.  In the **Common** tab, locate the **Connector configuration** text
-    box and select on **Edit**.
+To create the connector using the
+[Aiven CLI](/docs/tools/cli/service/connector#avn_service_connector_create), run:
 
-6.  Paste the connector configuration (stored in the
-    `cassandra_source.json` file) in the form.
+```bash
+avn service connector create SERVICE_NAME @cassandra_source.json
+```
 
-7.  Select **Apply**.
+Replace:
 
-    :::note
-    The Aiven Console parses the configuration file and fills the
-    relevant UI fields. You can review the UI fields across the various
-    tab and change them if necessary. The changes will be reflected in
-    JSON format in the **Connector configuration** text box.
-    :::
+- `SERVICE_NAME`: Your Kafka or Kafka Connect service name.
+- `@cassandra_source.json`: Path to your configuration file.
 
-8.  After all the settings are correctly configured, select **Create new
-    connector**.
+</TabItem>
+</Tabs>
 
-9.  Verify the connector status under the **Connectors** screen.
+## Source Cassandra data to a Kafka topic
 
-10. Verify the presence of the data in the target Cassandra service.
+The following example shows how to source data from a Cassandra table to a Kafka topic.
 
-You can also create connectors using the
-[Aiven CLI command](/docs/tools/cli/service/connector#avn_service_connector_create).
+If your Cassandra table `students` in the `students_keyspace` keyspace contains the
+following data:
 
-## Example: Create a Cassandra source connector
+| id | name  | age | timestamp_added |
+|----|-------|-----|-----------------|
+| 1  | carlo | 77  | 1719838880      |
+| 2  | lucy  | 55  | 1719839999      |
 
-<!-- vale off -->
-If you have a Cassandra table named `students` in the
-`students_keyspace` keyspace, with four columns (`id`, `name`, `age` and
-`timestamp_added`) and you want to load incrementally an Apache Kafka
-topic called `students_topic`, you can use the following connector
-configuration, after replacing the placeholders for `CASSANDRA_HOST`,
-`CASSANDRA_PORT`, `CASSANDRA_USERNAME`, `CASSANDRA_PASSWORD`,
-`CASSANDRA_KEYSTORE`, `CASSANDRA_KEYSTORE_PASSWORD`,
-`CASSANDRA_TRUSTSTORE`, `CASSANDRA_TRUSTSTORE_PASSWORD`,
-`CASSANDRA_KEYSPACE`:
+To write this data incrementally to a Kafka topic named `students_topic`, use the
+following connector configuration:
 
 ```json
 {
-    "name": "my-cassandra-source",
-    "connector.class": "com.datamountaineer.streamreactor.connect.cassandra.source.CassandraSinkConnector",
-    "topics": "TOPIC_LIST",
-    "connect.cassandra.host": "CASSANDRA_HOSTNAME",
-    "connect.cassandra.port": "CASSANDRA_PORT",
-    "connect.cassandra.username": "CASSANDRA_USERNAME",
-    "connect.cassandra.password": "CASSANDRA_PASSWORD",
-    "connect.cassandra.ssl.enabled": "CASSANDRA_SSL",
-    "connect.cassandra.trust.store.path": "CASSANDRA_TRUSTSTORE",
-    "connect.cassandra.trust.store.password": "CASSANDRA_TRUSTSTORE_PASSWORD",
-    "connect.cassandra.key.space": "students_keyspace",
-    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
-    "connect.cassandra.kcql": "INSERT INTO students_topic SELECT id, name, age, timestamp_added FROM students PK timestamp_added INCREMENTALMODE=TIMESTAMP"
+  "name": "my-cassandra-source",
+  "connector.class": "com.datamountaineer.streamreactor.connect.cassandra.source.CassandraSourceConnector",
+  "connect.cassandra.host": "CASSANDRA_HOSTNAME",
+  "connect.cassandra.port": "CASSANDRA_PORT",
+  "connect.cassandra.username": "CASSANDRA_USERNAME",
+  "connect.cassandra.password": "CASSANDRA_PASSWORD",
+  "connect.cassandra.ssl.enabled": "CASSANDRA_SSL",
+  "connect.cassandra.trust.store.path": "CASSANDRA_TRUSTSTORE",
+  "connect.cassandra.trust.store.password": "CASSANDRA_TRUSTSTORE_PASSWORD",
+  "connect.cassandra.key.space": "students_keyspace",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter.schemas.enable": "false",
+  "connect.cassandra.kcql": "INSERT INTO students_topic SELECT id, name, age, timestamp_added FROM students PK timestamp_added INCREMENTALMODE=TIMESTAMP"
 }
 ```
 
-The configuration file contains the following peculiarities:
+Replace all placeholder values (such as `CASSANDRA_HOSTNAME`, `CASSANDRA_PORT`,
+and `CASSANDRA_USERNAME`) with your actual Cassandra connection details.
 
--   `"topics": "students"`: setting the topic to source
--   `"connect.cassandra"`: the connection parameters placeholders
--   `"value.converter": "org.apache.kafka.connect.json.JsonConverter"`:
-    the topic will be populated in JSON format
--   `"connect.cassandra.kcql": "INSERT INTO students_topic SELECT id, name, age, timestamp_added FROM students PK timestamp_added INCREMENTALMODE=TIMESTAMP"`:
-    the connector logic is to insert every row in a new topic message
-    and use the column `timestamp_added` to check for new rows compared
-    to the previous poll.
+This configuration does the following:
 
-Once the connector is created successfully, you should see one message
-per row in the Cassandra table appearing in the target Apache Kafka
-`students_topic` topic.
+- `connect.cassandra.kcql`: Defines how Cassandra data is mapped to the Kafka topic.
+  This example uses the `timestamp_added` column for incremental polling.
+
+- `value.converter` and `value.converter.schemas.enable`: Set the message format.
+  This example uses raw JSON without a schema.
+
+- Connection settings (`connect.cassandra.*`): Provide the Cassandra host, port,
+  credentials, SSL settings, and truststore paths.
+
+After creating the connector, check the Kafka topic to verify that the data has been written.
 
 :::tip
-If your Aiven for Apache Kafka instance doesn't have the
-[automatic creation of topic enabled](/docs/products/kafka/howto/create-topics-automatically), you might need to create the `students_topic` topic upfront
-before starting the connector
+If your Aiven for Apache Kafka instance does not have
+[automatic topic creation enabled](/docs/products/kafka/howto/create-topics-automatically),
+create the `students_topic` manually before starting the connector.
 :::

--- a/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-source.md
+++ b/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-source.md
@@ -178,6 +178,8 @@ The following example shows how to source data from a Cassandra table to a Kafka
 If your Cassandra table `students` in the `students_keyspace` keyspace contains the
 following data:
 
+<!-- vale off -->
+
 | id | name  | age | timestamp_added |
 |----|-------|-----|-----------------|
 | 1  | carlo | 77  | 1719838880      |
@@ -211,10 +213,8 @@ This configuration does the following:
 
 - `connect.cassandra.kcql`: Defines how Cassandra data is mapped to the Kafka topic.
   This example uses the `timestamp_added` column for incremental polling.
-
 - `value.converter` and `value.converter.schemas.enable`: Set the message format.
   This example uses raw JSON without a schema.
-
 - Connection settings (`connect.cassandra.*`): Provide the Cassandra host, port,
   credentials, SSL settings, and truststore paths.
 

--- a/docs/products/kafka/kafka-connect/howto/influx-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/influx-sink.md
@@ -98,14 +98,14 @@ Include these fields in the connector configuration.
 If you use Avro as the message format, set the following parameters:
 
 - `value.converter.schema.registry.url`: The Aiven for Apache Kafka schema registry
-  URL, in the format `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT`. Get these values from the
-  [prerequisite step](/docs/products/kafka/kafka-connect/howto/influx-sink#connect_influx_lenses_sink_prereq).
+  URL, in the format `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT`.
 - `value.converter.basic.auth.credentials.source`: Set to `USER_INFO` to enable
   authentication with a username and password.
 - `value.converter.schema.registry.basic.auth.user.info`: The schema registry
   credentials, in the format `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`.
-  Get these values from the
-  [prerequisite step](/docs/products/kafka/kafka-connect/howto/influx-sink#connect_influx_lenses_sink_prereq).
+
+You can get these values from the
+[prerequisite step](/docs/products/kafka/kafka-connect/howto/influx-sink#connect_influx_lenses_sink_prereq).
 :::
 
 ## Create the connector

--- a/docs/products/kafka/kafka-connect/howto/influx-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/influx-sink.md
@@ -2,236 +2,197 @@
 title: Create a sink connector from Apache Kafka® to InfluxDB®
 ---
 
-The InfluxDB® sink connector enables you to move data from an Aiven for
-Apache Kafka® cluster to an InfluxDB instance for further processing and
-analysis.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import Note from "@site/static/includes/streamreactor-compatibility-note.md"
 
-:::note
-See the full set of available parameters and configuration
-options in the [connector's
-documentation](https://docs.lenses.io/connectors/sink/influx).
-:::
+The InfluxDB® Stream Reactor sink connector enables you to move data from an Aiven for Apache Kafka® cluster to an InfluxDB® instance.
+It uses [KCQL transformations](https://docs.lenses.io/connectors/sink/influx) to
+filter and map topic data before writing it to InfluxDB.
+
+<Note/>
 
 ## Prerequisites {#connect_influx_lenses_sink_prereq}
 
-To setup a InfluxDB sink connector, you need an Aiven for Apache Kafka
-service [with Kafka Connect enabled](enable-connect) or a
+- An Aiven for Apache Kafka service
+[with Apache Kafka Connect enabled](enable-connect) or a
 [dedicated Aiven for Apache Kafka Connect cluster](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
 
-Also collect the following information about the
-target InfluxDB database upfront:
+- Gather the following information for the target InfluxDB database:
 
--   `INFLUXDB_USERNAME`: The database username to connect
+- `INFLUXDB_HOST`: The InfluxDB hostname.
+- `INFLUXDB_PORT`: The InfluxDB port.
+- `INFLUXDB_DATABASE_NAME`: The InfluxDB database name.
+- `INFLUXDB_USERNAME`: The InfluxDB username.
+- `INFLUXDB_PASSWORD`: The InfluxDB password.
+- `TOPIC_LIST`: A comma-separated list of Kafka topics to sink.
+- `KCQL_TRANSFORMATION`: A KCQL statement to map topic fields to InfluxDB measurements.
+  Use the following format:
 
--   `INFLUXDB_PASSWORD`: The password for the username selected
+  ```sql
+  INSERT INTO MEASUREMENT_NAME
+  SELECT LIST_OF_FIELDS
+  FROM APACHE_KAFKA_TOPIC
+  ```
 
--   `INFLUXDB_HOST`: the InfluxDB hostname
+- `APACHE_KAFKA_HOST`: The Apache Kafka host. Required only when using Avro as the
+  data format.
+- `SCHEMA_REGISTRY_PORT`: The schema registry port. Required only when using Avro.
+- `SCHEMA_REGISTRY_USER`: The schema registry username. Required only when using Avro.
+- `SCHEMA_REGISTRY_PASSWORD`: The schema registry password. Required only when using Avro.
 
--   `INFLUXDB_PORT`: the InfluxDB port
+  :::note
+  If you are using Aiven for InfluxDB and Aiven for Apache Kafka, get all required
+  connection details, including schema registry information, from the
+  **Connection information** section on the <ConsoleLabel name="overview"/> page.
 
--   `INFLUXDB_DATABASE_NAME`: The name of the InfluxDB database
+  As of version 3.0, Aiven for Apache Kafka uses Karapace as the schema registry and
+  no longer supports the Confluent Schema Registry.
+  :::
 
--   `TOPIC_LIST`: The list of topics to sink divided by comma
+For a complete list of supported parameters and configuration options, see the
+[connector's documentation](https://docs.lenses.io/latest/connectors/kafka-connectors/sinks/influxdb).
 
--   `KCQL_TRANSFORMATION`: The KCQL syntax to parse the topic data,
-    should be in the format
+## Create a connector configuration file
 
-    ```
-    INSERT
-    INTO INFLUXDB_TABLe_NAME
-    SELECT LIST_OF_FIELDS
-    FROM APACHE_KAFKA_TOPIC
-    ```
-
--   `APACHE_KAFKA_HOST`: The hostname of the Apache Kafka service, only
-    needed when using Avro as data format
-
--   `SCHEMA_REGISTRY_PORT`: The Apache Kafka's schema registry port,
-    only needed when using Avro as data format
-
--   `SCHEMA_REGISTRY_USER`: The Apache Kafka's schema registry
-    username, only needed when using Avro as data format
-
--   `SCHEMA_REGISTRY_PASSWORD`: The Apache Kafka's schema registry user
-    password, only needed when using Avro as data format
-
-:::note
-The Apache Kafka and InfluxDB details are available in the [Aiven
-console](https://console.aiven.io/) service *Overview tab* or via the
-dedicated `avn service get` command with the
-[Aiven CLI](/docs/tools/cli/service-cli#avn_service_get).
-
-The `SCHEMA_REGISTRY` related parameters are available in the Aiven for
-Apache Kafka® service page, *Overview* tab, and *Schema Registry* subtab
-
-As of version 3.0, Aiven for Apache Kafka no longer supports Confluent
-Schema Registry. For more information, read [the article describing the
-replacement, Karapace](https://help.aiven.io/en/articles/5651983)
-:::
-
-## Setup a InfluxDB sink connector with Aiven Console
-
-The following example demonstrates how to setup a InfluxDB sink
-connector for Apache Kafka using the [Aiven
-Console](https://console.aiven.io/).
-
-### Define a Kafka Connect configuration file
-
-Define the connector configurations in a file (we'll refer to it with
-the name `influxdb_sink.json`) with the following content, creating a
-file is not strictly necessary but allows to have all the information in
-one place before copy/pasting them in the [Aiven
-Console](https://console.aiven.io/):
+Create a file named `influxdb_sink.json` and add the following configuration:
 
 ```json
 {
-    "name":"CONNECTOR_NAME",
-    "connector.class": "com.datamountaineer.streamreactor.connect.influx.InfluxSinkConnector",
-    "topics": "TOPIC_LIST",
-    "connect.influx.url": "https://INFLUXDB_HOST:INFLUXDB_PORT",
-    "connect.influx.db": "INFLUXDB_DATABASE_NAME",
-    "connect.influx.username": "INFLUXDB_USERNAME",
-    "connect.influx.password": "INFLUXDB_PASSWORD",
-    "connect.influx.kcql": "KCQL_TRANSFORMATION",
-    "key.converter": "io.confluent.connect.avro.AvroConverter",
-    "key.converter.schema.registry.url": "https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT",
-    "key.converter.basic.auth.credentials.source": "USER_INFO",
-    "key.converter.schema.registry.basic.auth.user.info": "SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD",
-    "value.converter": "io.confluent.connect.avro.AvroConverter",
-    "value.converter.schema.registry.url": "https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT",
-    "value.converter.basic.auth.credentials.source": "USER_INFO",
-    "value.converter.schema.registry.basic.auth.user.info": "SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD"
+  "name": "CONNECTOR_NAME",
+  "connector.class": "com.datamountaineer.streamreactor.connect.influx.InfluxSinkConnector",
+  "topics": "TOPIC_LIST",
+  "connect.influx.url": "https://INFLUXDB_HOST:INFLUXDB_PORT",
+  "connect.influx.db": "INFLUXDB_DATABASE_NAME",
+  "connect.influx.username": "INFLUXDB_USERNAME",
+  "connect.influx.password": "INFLUXDB_PASSWORD",
+  "connect.influx.kcql": "KCQL_TRANSFORMATION",
+  "key.converter": "io.confluent.connect.avro.AvroConverter",
+  "key.converter.schema.registry.url": "https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT",
+  "key.converter.basic.auth.credentials.source": "USER_INFO",
+  "key.converter.schema.registry.basic.auth.user.info": "SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD",
+  "value.converter": "io.confluent.connect.avro.AvroConverter",
+  "value.converter.schema.registry.url": "https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT",
+  "value.converter.basic.auth.credentials.source": "USER_INFO",
+  "value.converter.schema.registry.basic.auth.user.info": "SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD"
 }
 ```
 
-The configuration file contains the following entries:
+Parameters:
 
--   `name`: the connector name, replace `CONNECTOR_NAME` with the name
-    to give to the connector.
--   `connect.influx.*`: sink parameters collected in the
-    [prerequisite](/docs/products/kafka/kafka-connect/howto/influx-sink#connect_influx_lenses_sink_prereq) phase.
--   `topics`: the comma-separated list of topics to sink
--   `key.converter` and `value.converter`: defines the messages data
-    format in the Apache Kafka topic. The
-    `io.confluent.connect.avro.AvroConverter` converter translates
-    messages from the Avro format. To retrieve the messages schema we
-    use Aiven's [Karapace schema
-    registry](https://github.com/aiven/karapace) as specified by the
-    `schema.registry.url` parameter and related credentials.
+- `name`: The connector name. Replace `CONNECTOR_NAME` with your desired name.
+- `connect.influx.*`: InfluxDB connection parameters collected in the
+  [prerequisite step](/docs/products/kafka/kafka-connect/howto/influx-sink#connect_influx_lenses_sink_prereq).
+- `topics`: A comma-separated list of Kafka topics to sink.
+- `key.converter` and `value.converter`: Define the message data format in the
+  Kafka topic. This example uses `io.confluent.connect.avro.AvroConverter` to translate
+  messages in Avro format. The schema is retrieved from Aiven's
+  [Karapace schema registry](https://github.com/aiven/karapace) using the
+  `schema.registry.url` and related credentials.
 
 :::note
-The `key.converter` and `value.converter` sections define how the topic
-messages will be parsed and needs to be included in the connector
-configuration.
+The `key.converter` and `value.converter` fields define how Kafka messages are parsed.
+Include these fields in the connector configuration.
 
-When using Avro as source data format, set following
-parameters:
+If you use Avro as the message format, set the following parameters:
 
--   `value.converter.schema.registry.url`: pointing to the Aiven for
-    Apache Kafka schema registry URL in the form of
-    `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT` with the
-    `APACHE_KAFKA_HOST` and `SCHEMA_REGISTRY_PORT` parameters
-    [retrieved in the previous step](/docs/products/kafka/kafka-connect/howto/influx-sink#connect_influx_lenses_sink_prereq).
--   `value.converter.basic.auth.credentials.source`: to the value
-    `USER_INFO`, since you're going to login to the schema registry
-    using username and password.
--   `value.converter.schema.registry.basic.auth.user.info`: passing the
-    required schema registry credentials in the form of
-    `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD` with the
-    `SCHEMA_REGISTRY_USER` and `SCHEMA_REGISTRY_PASSWORD` parameters
-    [retrieved in the previous step](/docs/products/kafka/kafka-connect/howto/influx-sink#connect_influx_lenses_sink_prereq).
+- `value.converter.schema.registry.url`: The Aiven for Apache Kafka schema registry
+  URL, in the format `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT`. Get these values from the
+  [prerequisite step](/docs/products/kafka/kafka-connect/howto/influx-sink#connect_influx_lenses_sink_prereq).
+- `value.converter.basic.auth.credentials.source`: Set to `USER_INFO` to enable
+  authentication with a username and password.
+- `value.converter.schema.registry.basic.auth.user.info`: The schema registry
+  credentials, in the format `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`.
+  Get these values from the
+  [prerequisite step](/docs/products/kafka/kafka-connect/howto/influx-sink#connect_influx_lenses_sink_prereq).
 :::
 
-### Create a Kafka Connect connector with the Aiven Console
+## Create the connector
 
-To create an Apache Kafka Connect connector:
+<Tabs groupId="setup-method">
+<TabItem value="console" label="Console" default>
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/) and select
-    the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
-    service where the connector needs to be defined.
+1. Access the [Aiven Console](https://console.aiven.io/).
+1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
+1. Click <ConsoleLabel name="Connectors"/>.
+1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
+   If not, click **Enable connector on this service**.
 
-2.  Select **Connectors** from the left sidebar.
+   Alternatively, to enable connectors:
 
-3.  Select **Create New Connector**, it is enabled only for
-    services
-    [with Kafka Connect enabled](enable-connect).
+   1. Click <ConsoleLabel name="Service settings"/> in the sidebar.
+   1. In the **Service management** section, click
+      <ConsoleLabel name="Actions"/> > **Enable Kafka connect**.
 
-4.  Select **Stream Reactor InfluxDB Sink**.
+1. In the sink connectors list, select **Stream Reactor InfluxDB Sink**, and
+   click **Get started**.
+1. On the **Stream Reactor InfluxDB Sink** page, go to the **Common** tab.
+1. Locate the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
+1. Paste the configuration from your `influxdb_sink.json` file into the text box.
+1. Click **Create connector**.
+1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Confirm that data is written to the InfluxDB target database.
 
-5.  In the **Common** tab, locate the **Connector configuration** text
-    box and select on **Edit**.
+</TabItem>
+<TabItem value="cli" label="CLI">
 
-6.  Paste the connector configuration (stored in the
-    `influxdb_sink.json` file) in the form.
+To create the connector using the
+[Aiven CLI](/docs/tools/cli/service/connector#avn_service_connector_create), run:
 
-7.  Select **Apply**.
-
-    :::note
-    The Aiven Console parses the configuration file and fills the
-    relevant UI fields. You can review the UI fields across the various
-    tab and change them if necessary. The changes will be reflected in
-    JSON format in the **Connector configuration** text box.
-    :::
-
-8.  After all the settings are correctly configured, select **Create
-    connector**.
-
-9.  Verify the connector status under the **Connectors** screen.
-
-10. Verify the presence of the data in the target InfluxDB service, the
-    table name is equal to the Apache Kafka topic name.
-
-:::note
-You can also create connectors using the
-[Aiven CLI command](/docs/tools/cli/service/connector#avn_service_connector_create).
-:::
-
-## Example: Create a InfluxDB sink connector
-
-If you have a topic named `measurements` containing the following data
-in AVRO format to move to InfluxDB:
-
-```
-{
-    "ts":"2022-10-24T13:09:43.406000Z"
-    "device_name": "mydevice1",
-    "measurement": 17
-}
+```bash
+avn service connector create SERVICE_NAME @influxdb_sink.json
 ```
 
-You can sink the `measurements` topic to InfluxDB with the following
-connector configuration, after replacing the placeholders for
-`INFLUXDB_HOST`, `INFLUXDB_PORT`, `INFLUXDB_DB_NAME`,
-`INFLUXDB_USERNAME`, `INFLUXDB_PASSWORD` and schema registry:
+Replace:
+
+- `SERVICE_NAME`: Your Kafka or Kafka Connect service name.
+- `@influxdb_sink.json`: Path to your configuration file.
+
+</TabItem>
+</Tabs>
+
+## Sink topic data to InfluxDB
+
+The following example shows how to sink data from a Kafka topic to an InfluxDB measurement.
+If your Kafka topic `measurements` contains the following data:
 
 ```json
 {
-    "name": "my-influxdb-sink",
-    "connector.class": "com.datamountaineer.streamreactor.connect.influx.InfluxSinkConnector",
-    "topics": "measurements",
-    "connect.influx.url": "https://INFLUXDB_HOST:INFLUXDB_PORT",
-    "connect.influx.db": "INFLUXDB_DATABASE_NAME",
-    "connect.influx.username": "INFLUXDB_USERNAME",
-    "connect.influx.password": "INFLUXDB_PASSWORD",
-    "connect.influx.kcql": "insert into measurements select ts, device_name, measurement from measurements",
-    "key.converter": "io.confluent.connect.avro.AvroConverter",
-    "key.converter.schema.registry.url": "https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT",
-    "key.converter.basic.auth.credentials.source": "USER_INFO",
-    "key.converter.schema.registry.basic.auth.user.info": "SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD"
-    "value.converter": "io.confluent.connect.avro.AvroConverter",
-    "value.converter.schema.registry.url": "https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT",
-    "value.converter.basic.auth.credentials.source": "USER_INFO",
-    "value.converter.schema.registry.basic.auth.user.info": "SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD"
+"ts": "2022-10-24T13:09:43.406000Z",
+"device_name": "mydevice1",
+"measurement": 17
 }
 ```
 
-The configuration file contains the following peculiarities:
+To write this data to InfluxDB, use the following connector configuration:
 
--   `"topics": "measurements"`: setting the topic to sink
--   `"connect.influx.kcql": "select into measurements select ts, device_name, measurement from measurements"`:
-    the connector logic is to insert every topic message as new document
-    into a table called `measurements`.
+```json
+{
+"name": "my-influxdb-sink",
+"connector.class": "com.datamountaineer.streamreactor.connect.influx.InfluxSinkConnector",
+"topics": "measurements",
+"connect.influx.url": "https://INFLUXDB_HOST:INFLUXDB_PORT",
+"connect.influx.db": "INFLUXDB_DATABASE_NAME",
+"connect.influx.username": "INFLUXDB_USERNAME",
+"connect.influx.password": "INFLUXDB_PASSWORD",
+"connect.influx.kcql": "INSERT INTO measurements SELECT ts, device_name, measurement FROM measurements",
+"value.converter": "org.apache.kafka.connect.json.JsonConverter",
+"value.converter.schemas.enable": "false"
+}
+```
 
-Once the connector is created successfully, you should see a table named
-`measurements` in the InfluxDB database referenced by the
-`INFLUXDB_DB_NAME` placeholder with the record in it.
+Replace all placeholder values (such as `INFLUXDB_HOST`, `INFLUXDB_PORT`,
+and `INFLUXDB_PASSWORD`) with your actual InfluxDB connection details.
+
+This configuration does the following:
+
+- `"topics": "measurements"`: Specifies the Kafka topic to sink.
+- Connection settings (`connect.influx.*`): Provide the InfluxDB connection details.
+- `"value.converter"` and `"value.converter.schemas.enable"`: Set the message format.
+  The topic uses raw JSON without a schema.
+- `"connect.influx.kcql"`: Defines the insert logic. Each Kafka message is written as a
+  row in the `measurements` table.
+
+After creating the connector, verify the presence of the data in the target InfluxDB database.
+The measurement name matches the Kafka topic (`measurements`).

--- a/docs/products/kafka/kafka-connect/howto/mongodb-sink-lenses.md
+++ b/docs/products/kafka/kafka-connect/howto/mongodb-sink-lenses.md
@@ -242,7 +242,7 @@ If the Kafka topic `students` contains the following records:
 {"name": "carlo", "age": 77}
 {"name": "lucy", "age": 55}
 {"name": "carlo", "age": 33}
-````
+```
 
 Use the following connector configuration to insert each record into a MongoDB
 collection named `studentscol`:

--- a/docs/products/kafka/kafka-connect/howto/mongodb-sink-lenses.md
+++ b/docs/products/kafka/kafka-connect/howto/mongodb-sink-lenses.md
@@ -2,82 +2,120 @@
 title: Create a sink connector by Lenses.io from Apache Kafka® to MongoDB
 ---
 
-The MongoDB sink connector enables you to move data from an Aiven for Apache Kafka® cluster to a MongoDB database.
-The Lenses.io implementation enables you to write [KCQL
-transformations](https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sinks/mongosinkconnector/)
-on the topic data before sending it to the MongoDB database.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import Note from "@site/static/includes/streamreactor-compatibility-note.md"
+
+The MongoDB Stream Reactor sink connector enables you to move data from an Aiven for Apache Kafka cluster to a MongoDB database.
+It uses [KCQL transformations](https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sinks/mongosinkconnector/)
+to filter and map topic data before sending it to MongoDB.
 
 :::note
-Aiven offers two distinct MongoDB sink connectors, each one having
-different implementation and parameters:
+Aiven supports two different MongoDB sink connectors. Each has a separate
+implementation and configuration options:
 
--   The standard [MongoDB sink connector by
-    MongoDB](https://docs.mongodb.com/kafka-connector/current/)
--   The [MongoDB sink connector by
-    Lenses.io](https://docs.lenses.io/connectors/sink/mongo)
+- [MongoDB sink connector by MongoDB](https://docs.mongodb.com/kafka-connector/current/)
+- [MongoDB sink connector by Lenses.io](https://docs.lenses.io/connectors/sink/mongo)
 
-This document refers to the MongoDB sink connector by Lenses.io, you can
-browse the MongoDB implementation in the
-[related document](mongodb-sink-mongo)
-
-See the full set of available parameters and configuration
-options in the [connector's
-documentation](https://docs.lenses.io/connectors/sink/mongo).
+This document covers the connector by Lenses.io. For the MongoDB connector by
+MongoDB, see the [related document](mongodb-sink-mongo).
 :::
+
+<Note/>
 
 ## Prerequisites {#connect_mongodb_lenses_sink_prereq}
 
-To setup a MongoDB sink connector, you need an Aiven for Apache Kafka
-service [with Kafka Connect enabled](enable-connect) or a
-[dedicated Aiven for Apache Kafka Connect cluster](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
+- An Aiven for Apache Kafka service
+  [with Apache Kafka Connect enabled](enable-connect) or a
+  [dedicated Aiven for Apache Kafka Connect cluster](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
 
-Also collect the following information about the
-target MongoDB database upfront:
+- Gather the following information for the target MongoDB database:
 
--   `MONGODB_USERNAME`: The database username to connect
+  - `MONGODB_USERNAME`: The MongoDB username.
+  - `MONGODB_PASSWORD`: The MongoDB password.
+  - `MONGODB_HOST`: The MongoDB hostname.
+  - `MONGODB_PORT`: The MongoDB port.
+  - `MONGODB_DATABASE_NAME`: The target MongoDB database name.
+  - `TOPIC_LIST`: A comma-separated list of Kafka topics to sink.
+  - `KCQL_TRANSFORMATION`: A KCQL statement to map topic data to MongoDB collections.
+    Use the following format:
 
--   `MONGODB_PASSWORD`: The password for the username selected
+    ```sql
+    INSERT | UPSERT INTO MONGODB_COLLECTION
+    SELECT LIST_OF_FIELDS
+    FROM APACHE_KAFKA_TOPIC
+    ```
 
--   `MONGODB_HOST`: the MongoDB hostname
+  - `APACHE_KAFKA_HOST`: The Apache Kafka host. Required only when using Avro.
+  - `SCHEMA_REGISTRY_PORT`: The schema registry port. Required only when using Avro.
+  - `SCHEMA_REGISTRY_USER`: The schema registry username. Required only when using Avro.
+  - `SCHEMA_REGISTRY_PASSWORD`: The schema registry password. Required only when using
+    Avro.
 
--   `MONGODB_PORT`: the MongoDB port
+    :::note
+    If you are using Aiven for MongoDB and Aiven for Apache Kafka, get all required
+    connection details, including schema registry information, from the
+    **Connection information** section on the <ConsoleLabel name="overview"/> page.
 
--   `MONGODB_DATABASE_NAME`: The name of the MongoDB database
+    As of version 3.0, Aiven for Apache Kafka uses Karapace as the schema registry and
+    no longer supports the Confluent Schema Registry.
+    :::
 
--   `TOPIC_LIST`: The list of topics to sink divided by comma
+For a complete list of supported parameters and configuration options, see the
+[connector's documentation](https://docs.lenses.io/connectors/sink/mongo).
 
--   `KCQL_TRANSFORMATION`: The KCQL syntax to parse the topic data,
-    should be in the format:
+## Create a connector configuration file
 
-        INSERT | UPSERT
-        INTO MONGODB_COLLECTION_NAME
-        SELECT LIST_OF_FIELDS
-        FROM APACHE_KAFKA_TOPIC
+Create a file named `mongodb_sink.json` and add the following configuration:
 
--   `APACHE_KAFKA_HOST`: The hostname of the Apache Kafka service, only
-    needed when using Avro as data format
+```json
+{
+  "name": "CONNECTOR_NAME",
+  "connector.class": "com.datamountaineer.streamreactor.connect.mongodb.sink.MongoSinkConnector",
+  "topics": "TOPIC_LIST",
+  "connect.mongo.connection": "mongodb://MONGODB_USERNAME:MONGODB_PASSWORD@MONGODB_HOST:MONGODB_PORT",
+  "connect.mongo.db": "MONGODB_DATABASE_NAME",
+  "connect.mongo.kcql": "KCQL_TRANSFORMATION",
+  "key.converter": "io.confluent.connect.avro.AvroConverter",
+  "key.converter.schema.registry.url": "https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT",
+  "key.converter.basic.auth.credentials.source": "USER_INFO",
+  "key.converter.schema.registry.basic.auth.user.info": "SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD",
+  "value.converter": "io.confluent.connect.avro.AvroConverter",
+  "value.converter.schema.registry.url": "https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT",
+  "value.converter.basic.auth.credentials.source": "USER_INFO",
+  "value.converter.schema.registry.basic.auth.user.info": "SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD"
+}
+```
 
--   `SCHEMA_REGISTRY_PORT`: The Apache Kafka's schema registry port,
-    only needed when using Avro as data format
+Parameters:
 
--   `SCHEMA_REGISTRY_USER`: The Apache Kafka's schema registry
-    username, only needed when using Avro as data format
-
--   `SCHEMA_REGISTRY_PASSWORD`: The Apache Kafka's schema registry user
-    password, only needed when using Avro as data format
+- `name`: The connector name. Replace `CONNECTOR_NAME` with your desired name.
+- `connect.mongo.*`: MongoDB connection parameters collected in the
+   [prerequisite step](/docs/products/kafka/kafka-connect/howto/mongodb-sink-lenses#connect_mongodb_lenses_sink_prereq).
+- `key.converter` and `value.converter`: Define the message data format in the Kafka topic.
+  This example uses `io.confluent.connect.avro.AvroConverter` to translate messages
+  in Avro format.
+  The schema is retrieved from Aiven's [Karapace schema registry](https://github.com/aiven/karapace)
+  using the `schema.registry.url` and related credentials.
 
 :::note
-The Apache Kafka related details are available in the [Aiven
-console](https://console.aiven.io/) service *Overview tab* or via the
-dedicated `avn service get` command with the
-[Aiven CLI](/docs/tools/cli/service-cli#avn_service_get).
+The `key.converter` and `value.converter` fields define how Kafka messages are parsed
+and must be included in the configuration.
 
-The `SCHEMA_REGISTRY` related parameters are available in the Aiven for
-Apache Kafka® service page, *Overview* tab, and *Schema Registry* subtab
+When using Avro as the source format, set the following:
 
-As of version 3.0, Aiven for Apache Kafka no longer supports Confluent
-Schema Registry. For more information, read [the article describing the
-replacement, Karapace](https://help.aiven.io/en/articles/5651983)
+- `value.converter.schema.registry.url`: Use the Aiven for Apache Kafka schema registry
+  URL in the format `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT`.
+  Retrieve these values from the
+  [prerequisite step](/docs/products/kafka/kafka-connect/howto/mongodb-sink-lenses#connect_mongodb_lenses_sink_prereq).
+- `value.converter.basic.auth.credentials.source`: Set to `USER_INFO`, which means
+  authentication is done using a username and password.
+- `value.converter.schema.registry.basic.auth.user.info`: Provide the schema registry
+  credentials in the format `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`.
+  These values should also be retrieved from the
+  [prerequisite step](/docs/products/kafka/kafka-connect/howto/mongodb-sink-lenses#connect_mongodb_lenses_sink_prereq).
+
 :::
 
 ## Setup a MongoDB sink connector with Aiven Console
@@ -149,146 +187,131 @@ parameters:
     [retrieved in the previous step](/docs/products/kafka/kafka-connect/howto/mongodb-sink-lenses#connect_mongodb_lenses_sink_prereq).
 :::
 
-### Create a Kafka Connect connector with the Aiven Console
+## Create the connector
 
-To create an Apache Kafka Connect connector:
+<Tabs groupId="setup-method">
+<TabItem value="console" label="Console" default>
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/) and select
-    the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
-    service where the connector needs to be defined.
+1. Go to the [Aiven Console](https://console.aiven.io/).
+1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
+1. Click <ConsoleLabel name="Connectors"/>.
+1. Click **Create connector** if Kafka Connect is enabled on the service.
+   If not, click **Enable connector on this service**.
 
-2.  Select **Connectors** from the left sidebar.
+   To enable connectors:
 
-3.  Select **Create New Connector**.
+   1. Click <ConsoleLabel name="Service settings"/> in the sidebar.
+   1. In the **Service management** section, click
+      <ConsoleLabel name="Actions"/> > **Enable Kafka Connect**.
 
-    :::note
-    It is enabled only for services [with Kafka Connect enabled](enable-connect).
-    :::
+1. From the list of sink connectors, select **Stream Reactor MongoDB Sink** and click **Get started**.
+1. On the **Common** tab, go to the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
+1. Paste the contents of your `mongodb_sink.json` configuration file into the text box.
+1. Click **Create connector**.
+1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Confirm that data appears in the target MongoDB collection.
+   The collection name corresponds to the Kafka topic name defined in the KCQL statement.
 
-4.  Select **Stream Reactor MongoDB Sink**.
+</TabItem>
+<TabItem value="cli" label="CLI">
 
-5.  In the **Common** tab, locate the **Connector configuration** text
-    box and select on **Edit**.
+To create the connector using the
+[Aiven CLI](/docs/tools/cli/service/connector#avn_service_connector_create), run:
 
-6.  Paste the connector configuration (stored in the `mongodb_sink.json`
-    file) in the form.
-
-7.  Select **Apply**.
-
-    :::note
-    The Aiven Console parses the configuration file and fills the
-    relevant UI fields. You can review the UI fields across the various
-    tab and change them if necessary. The changes will be reflected in
-    JSON format in the **Connector configuration** text box.
-    :::
-
-8.  After all the settings are correctly configured, select **Create
-    connector**.
-
-9.  Verify the connector status under the **Connectors** screen.
-
-10. Verify the presence of the data in the target MongoDB service, the
-    index name is equal to the Apache Kafka topic name.
-
-:::note
-You can also create connectors using the
-[Aiven CLI command](/docs/tools/cli/service/connector#avn_service_connector_create).
-:::
-
-## Example: Create a MongoDB sink connector in insert mode
-
-If you have a topic named `students` containing the following data that
-to be moved to MongoDB:
-
-```json
-{"name":"carlo", "age": 77}
-{"name":"lucy", "age": 55}
-{"name":"carlo", "age": 33}
+```bash
+avn service connector create SERVICE_NAME @mongodb_sink.json
 ```
 
-You can sink the `students` topic to MongoDB with the following
-connector configuration, after replacing the placeholders for
-`MONGODB_HOST`, `MONGODB_PORT`, `MONGODB_DB_NAME`, `MONGODB_USERNAME`
-and `MONGODB_PASSWORD`:
+Replace:
+
+- `SERVICE_NAME`: Your Kafka or Kafka Connect service name.
+- `@mongodb_sink.json`: Path to your configuration file.
+
+</TabItem>
+</Tabs>
+
+## Sink topic data to MongoDB
+
+The following examples show how to sink data from a Kafka topic to a MongoDB collection.
+
+### Insert mode
+
+If the Kafka topic `students` contains the following records:
+
+```json
+{"name": "carlo", "age": 77}
+{"name": "lucy", "age": 55}
+{"name": "carlo", "age": 33}
+````
+
+Use the following connector configuration to insert each record into a MongoDB
+collection named `studentscol`:
 
 ```json
 {
-    "name": "my-mongodb-sink",
-    "connector.class": "com.datamountaineer.streamreactor.connect.mongodb.sink.MongoSinkConnector",
-    "connect.mongo.connection": "mongodb://MONGODB_USERNAME:MONGODB_PASSWORD@MONGODB_HOST:MONGODB_PORT",
-    "connect.mongo.db": "MONGODB_DB_NAME",
-    "topics": "students",
-    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
-    "value.converter.schemas.enable": "false",
-    "connect.mongo.kcql": "INSERT into studentscol SELECT * FROM students"
+  "name": "my-mongodb-sink",
+  "connector.class": "com.datamountaineer.streamreactor.connect.mongodb.sink.MongoSinkConnector",
+  "connect.mongo.connection": "mongodb://MONGODB_USERNAME:MONGODB_PASSWORD@MONGODB_HOST:MONGODB_PORT",
+  "connect.mongo.db": "MONGODB_DB_NAME",
+  "topics": "students",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter.schemas.enable": "false",
+  "connect.mongo.kcql": "INSERT INTO studentscol SELECT * FROM students"
 }
 ```
 
-The configuration file contains the following peculiarities:
+Replace all placeholders (such as `MONGODB_HOST`, `MONGODB_DB_NAME`, and
+`MONGODB_USERNAME`) with your actual MongoDB connection details.
 
--   `"topics": "students"`: setting the topic to sink
--   `"database": "MONGODB_DB_NAME"`: the database used is the one
-    referenced by the placeholder `MONGODB_DB_NAME`
--   `"value.converter": "org.apache.kafka.connect.json.JsonConverter"`
-    and `"value.converter.schemas.enable": "false"`: the topic value is
-    in JSON format without a schema
--   `"connect.mongo.kcql": "INSERT into studentscol SELECT * FROM students"`:
-    the connector logic is to insert every topic message as new document
-    into a collection called `studentscol`.
+This configuration does the following:
 
-Once the connector is created successfully, you should see a collection
-named `studentscol` in the MongoDB database referenced by the
-`MONGODB_DB_NAME` placeholder with three documents in it.
+- `"topics": "students"`: Specifies the Kafka topic to sink.
+- Connection settings (`connect.mongo.*`): Provide the MongoDB host, port, credentials,
+  and database name.
+- `"value.converter"` and `"value.converter.schemas.enable"`: Set the message format.
+  The topic uses raw JSON without a schema.
+- `"connect.mongo.kcql"`: Defines the insert logic. Each Kafka message is written as a
+  new document in the `studentscol` MongoDB collection.
 
-## Example: Create a MongoDB sink connector in upsert mode
+After creating the connector, check the MongoDB collection to verify that the data
+has been inserted. You should see three documents in the `studentscol` collection.
 
-If you have a topic named `students` containing the following data
-to be moved to MongoDB, but having one document per person `name`
-in the following messages:
+### Upsert mode
+
+To ensure only one document per unique name is stored, use upsert mode. If
+the `students` topic contains:
 
 ```json
-{"name":"carlo", "age": 77}
-{"name":"lucy", "age": 55}
-{"name":"carlo", "age": 33}
+{"name": "carlo", "age": 77}
+{"name": "lucy", "age": 55}
+{"name": "carlo", "age": 33}
 ```
 
-You can sink the `students` topic to MongoDB with the following
-connector configuration, after replacing the placeholders for
-`MONGODB_HOST`, `MONGODB_PORT`, `MONGODB_DB_NAME`, `MONGODB_USERNAME`
-and `MONGODB_PASSWORD`:
+Use the following connector configuration:
 
 ```json
 {
-    "name": "my-mongodb-sink",
-    "connector.class": "com.datamountaineer.streamreactor.connect.mongodb.sink.MongoSinkConnector",
-    "connect.mongo.connection": "mongodb://MONGODB_USERNAME:MONGODB_PASSWORD@MONGODB_HOST:MONGODB_PORT",
-    "connect.mongo.db": "MONGODB_DB_NAME",
-    "topics": "students",
-    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
-    "value.converter.schemas.enable": "false",
-    "connect.mongo.kcql": "UPSERT into studentscol SELECT * FROM students PK name"
+  "name": "my-mongodb-sink",
+  "connector.class": "com.datamountaineer.streamreactor.connect.mongodb.sink.MongoSinkConnector",
+  "connect.mongo.connection": "mongodb://MONGODB_USERNAME:MONGODB_PASSWORD@MONGODB_HOST:MONGODB_PORT",
+  "connect.mongo.db": "MONGODB_DB_NAME",
+  "topics": "students",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter.schemas.enable": "false",
+  "connect.mongo.kcql": "UPSERT INTO studentscol SELECT * FROM students PK name"
 }
 ```
 
-The configuration file contains the following peculiarities:
+This configuration performs the following:
 
--   `"topics": "students"`: setting the topic to sink
--   `"database": "MONGODB_DB_NAME"`: the database used is the one
-    referenced by the placeholder `MONGODB_DB_NAME`
--   `"value.converter": "org.apache.kafka.connect.json.JsonConverter"`
-    and `"value.converter.schemas.enable": "false"`: the topic value is
-    in JSON format without a schema
--   `"connect.mongo.kcql": "UPSERT into studentscol SELECT * FROM students PK name"`:
-    the connector logic is to upsert every topic message as new document
-    into a collection called `studentscol`, the primary key is set to
-    the `name` field (`PK name`).
+- Uses the same connection and converter settings as the insert mode example.
+- `"connect.mongo.kcql"`: Uses `UPSERT` logic with `PK name` to update the document
+  based on the `name` field.
 
-Once the connector is created successfully, you should see a collection
-named `studentscol` in the MongoDB database referenced by the
-`MONGODB_DB_NAME` placeholder. The collection should contain two
-documents since the name `carlo` was present two times:
+After the connector runs, the `studentscol` collection contains two documents,
+because the record with `"name": "carlo"` is upserted:
 
-```
-{"name":"lucy", age: 55}
-{"name":"carlo", age: 33}
+```json
+{"name": "lucy", "age": 55}
+{"name": "carlo", "age": 33}
 ```

--- a/docs/products/kafka/kafka-connect/howto/mqtt-source-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/mqtt-source-connector.md
@@ -152,7 +152,7 @@ This configuration does the following:
 - `connect.mqtt.kcql`: Routes messages from the MQTT topic `devices/status` to the
   Kafka topic `device_status`.
 - `connect.mqtt.service.quality`: Uses QoS level `1` for at-least-once delivery.
-- `key.converter` and `value.converter`**: Set the message format to JSON.
+- `key.converter` and `value.converter`: Set the message format to JSON.
 - `connect.mqtt.*`: Supplies the MQTT connection details.
 
 After the connector is running, check the `device_status` Kafka topic to confirm that

--- a/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink.md
@@ -1,5 +1,5 @@
 ---
-title: Create a stream reactor sink connector from Apache Kafka® to Redis®*
+title: Create a Stream Reactor sink connector from Apache Kafka® to Redis®*
 ---
 
 import Tabs from '@theme/Tabs';
@@ -86,7 +86,7 @@ Parameters:
 
 - `name`: The connector name. Replace `CONNECTOR_NAME` with your desired name.
 - `connect.redis.*`: Redis connection parameters collected in the
-  [prerequisite step](/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink#connect_redis_lenses_sink_prereq).
+  [prerequisite step](#connect_redis_lenses_sink_prereq).
 - `key.converter` and `value.converter`: Define the message data format in the
   Kafka topic. This example uses `io.confluent.connect.avro.AvroConverter` to translate
   messages in Avro format. The schema is retrieved from Aiven's
@@ -100,15 +100,14 @@ and must be included in the configuration.
 When using Avro as the source format, set the following:
 
 - `value.converter.schema.registry.url`: Use the Aiven for Apache Kafka schema registry
-  URL in the format `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT`. Retrieve these
-  values from the [prerequisite step](/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink#connect_redis_lenses_sink_prereq).
+  URL in the format `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT`.
 - `value.converter.basic.auth.credentials.source`: Set to `USER_INFO`, which means
   authentication is done using a username and password.
 - `value.converter.schema.registry.basic.auth.user.info`: Provide the schema registry
-  credentials in the format `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`. These
-  values should also be retrieved in the
-  [prerequisite step](/docs/products/kafka/kafka-connect/howto/edis-streamreactor-sink#connect_redis_lenses_sink_prereq).
+  credentials in the format `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`.
 
+You can retrieve these values from the
+[prerequisite step](#connect_redis_lenses_sink_prereq).
 :::
 
 ## Create the connector

--- a/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink.md
@@ -2,242 +2,208 @@
 title: Create a stream reactor sink connector from Apache Kafka® to Redis®*
 ---
 
-**The Redis stream reactor sink connector** enables you to move data from **an Aiven for Apache Kafka® cluster** to **a Redis®\* database**.
-The Lenses.io implementation enables you to write [KCQL
-transformations](https://docs.lenses.io/connectors/sink/redis) on
-the topic data before sending it to the Redis database.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import Note from "@site/static/includes/streamreactor-compatibility-note.md"
+
+The Redis®\* Stream Reactor sink connector enables you to move data from an Aiven for Apache Kafka® cluster to a Redis®\* database.
+It uses [KCQL transformations](https://docs.lenses.io/connectors/sink/redis) to filter
+and map topic data before sending it to Redis.
+
 
 :::important
-A known issue with the `GEOADD` command in version 4.2.0 of the Redis
-stream reactor sink connector may cause exceptions during initialization
-under specific configurations. For more information, see the [GitHub
-issue](https://github.com/lensesio/stream-reactor/issues/990).
+In version 4.2.0 of the Redis Stream Reactor sink connector, a known issue with the
+`GEOADD` command may cause exceptions during initialization under specific configurations.
+
+For more information, see the
+[GitHub issue](https://github.com/lensesio/stream-reactor/issues/990).
 :::
 
-:::note
-See the full set of available parameters and configuration
-options in the [connector's
-documentation](https://docs.lenses.io/connectors/sink/redis).
-:::
+<Note/>
 
 ## Prerequisites {#connect_redis_lenses_sink_prereq}
 
-To setup a Redis sink connector, you need an Aiven for Apache Kafka
-service [with Kafka Connect enabled](enable-connect) or a
-[dedicated Aiven for Apache Kafka Connect cluster](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
+- An Aiven for Apache Kafka service
+  [with Apache Kafka Connect enabled](enable-connect) or a
+  [dedicated Aiven for Apache Kafka Connect cluster](/docs/products/kafka/kafka-connect/get-started#apache_kafka_connect_dedicated_cluster).
+- Gather the following information for the target Redis database:
 
-Also collect the following information about the
-target Redis database upfront:
+  - `REDIS_HOSTNAME`: The Redis hostname.
+  - `REDIS_PORT`: The Redis port.
+  - `REDIS_PASSWORD`: The Redis password.
+  - `REDIS_SSL`: Set to `true` or `false`, depending on your SSL setup.
+  - `TOPIC_LIST`: A comma-separated list of Kafka topics to sink.
+  - `KCQL_TRANSFORMATION`: A KCQL statement to map topic fields to Redis cache entries. Use the following format:
 
--   `REDIS_HOSTNAME`: The Redis hostname
+    ```sql
+    INSERT INTO REDIS_CACHE
+    SELECT LIST_OF_FIELDS
+    FROM APACHE_KAFKA_TOPIC
+    ```
 
--   `REDIS_PORT`: The Redis port
-
--   `REDIS_PASSWORD`: The Redis password
-
--   `REDIS_SSL`: The Redis SSL setting, should be `true` or `false`
-
--   `TOPIC_LIST`: The list of topics to sink divided by comma
-
--   `KCQL_TRANSFORMATION`: The KCQL syntax to parse the topic data,
-    should be in the format:
-
-        [INSERT INTO REDIS_CACHE]
-        SELECT LIST_OF_FIELDS
-        FROM APACHE_KAFKA_TOPIC
-
--   `APACHE_KAFKA_HOST`: The hostname of the Apache Kafka service, only
-    needed when using Avro as data format
-
--   `SCHEMA_REGISTRY_PORT`: The Apache Kafka's schema registry port,
-    only needed when using Avro as data format
-
--   `SCHEMA_REGISTRY_USER`: The Apache Kafka's schema registry
-    username, only needed when using Avro as data format
-
--   `SCHEMA_REGISTRY_PASSWORD`: The Apache Kafka's schema registry user
-    password, only needed when using Avro as data format
+  - `APACHE_KAFKA_HOST`: The Apache Kafka host. Required only when using Avro as the
+    data format.
+  - `SCHEMA_REGISTRY_PORT`: The schema registry port. Required only when using Avro.
+  - `SCHEMA_REGISTRY_USER`: The schema registry username. Required only when using Avro.
+  - `SCHEMA_REGISTRY_PASSWORD`: The schema registry password. Required only when using Avro.
 
 :::note
-If you're using Aiven for Caching and Aiven for Apache Kafka, the above
-details are available in the [Aiven console](https://console.aiven.io/)
-service *Overview tab* or via the dedicated `avn service get` command
-with the [Aiven CLI](/docs/tools/cli/service-cli#avn_service_get).
+If you are using Aiven for Caching and Aiven for Apache Kafka, get all required
+connection details, including schema registry information, from the
+**Connection information** section on the <ConsoleLabel name="overview"/> page.
 
-The `SCHEMA_REGISTRY` related parameters are available in the Aiven for
-Apache Kafka® service page, *Overview* tab, and *Schema Registry* subtab
-
-As of version 3.0, Aiven for Apache Kafka no longer supports Confluent
-Schema Registry. For more information, read [the article describing the
-replacement, Karapace](https://help.aiven.io/en/articles/5651983)
+As of version 3.0, Aiven for Apache Kafka uses Karapace as the schema registry and
+no longer supports the Confluent Schema Registry.
 :::
 
-## Setup a Redis sink connector with Aiven Console
+## Create a connector configuration file
 
-The following example demonstrates how to setup a Redis sink connector
-for Apache Kafka using the [Aiven Console](https://console.aiven.io/).
-
-### Define a Kafka Connect configuration file
-
-Define the connector configurations in a file (we'll refer to it with
-the name `redis_sink.json`) with the following content, creating a file
-is not strictly necessary but allows to have all the information in one
-place before copy/pasting them in the [Aiven
-Console](https://console.aiven.io/):
+Create a file named `redis_sink.json` and add the following configuration:
 
 ```json
 {
-    "name":"CONNECTOR_NAME",
-    "connector.class": "com.datamountaineer.streamreactor.connect.redis.sink.RedisSinkConnector",
-    "topics": "TOPIC_LIST",
-    "connect.redis.host": "REDIS_HOSTNAME",
-    "connect.redis.port": "REDIS_PORT",
-    "connect.redis.password": "REDIS_PASSWORD",
-    "connect.redis.ssl.enabled": "REDIS_SSL",
-    "connect.redis.kcql": "KCQL_TRANSFORMATION",
-    "key.converter": "io.confluent.connect.avro.AvroConverter",
-    "key.converter.schema.registry.url": "https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT",
-    "key.converter.basic.auth.credentials.source": "USER_INFO",
-    "key.converter.schema.registry.basic.auth.user.info": "SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD",
-    "value.converter": "io.confluent.connect.avro.AvroConverter",
-    "value.converter.schema.registry.url": "https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT",
-    "value.converter.basic.auth.credentials.source": "USER_INFO",
-    "value.converter.schema.registry.basic.auth.user.info": "SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD"
+  "name": "CONNECTOR_NAME",
+  "connector.class": "com.datamountaineer.streamreactor.connect.redis.sink.RedisSinkConnector",
+  "topics": "TOPIC_LIST",
+  "connect.redis.host": "REDIS_HOSTNAME",
+  "connect.redis.port": "REDIS_PORT",
+  "connect.redis.password": "REDIS_PASSWORD",
+  "connect.redis.ssl.enabled": "REDIS_SSL",
+  "connect.redis.kcql": "KCQL_TRANSFORMATION",
+  "key.converter": "io.confluent.connect.avro.AvroConverter",
+  "key.converter.schema.registry.url": "https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT",
+  "key.converter.basic.auth.credentials.source": "USER_INFO",
+  "key.converter.schema.registry.basic.auth.user.info": "SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD",
+  "value.converter": "io.confluent.connect.avro.AvroConverter",
+  "value.converter.schema.registry.url": "https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT",
+  "value.converter.basic.auth.credentials.source": "USER_INFO",
+  "value.converter.schema.registry.basic.auth.user.info": "SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD"
 }
 ```
 
-The configuration file contains the following entries:
+Parameters:
 
--   `name`: the connector name, replace `CONNECTOR_NAME` with the name
-    to use for the connector.
--   `connect.redis.*`: sink parameters collected in the
-    [prerequisite](/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink#connect_redis_lenses_sink_prereq) phase.
--   `key.converter` and `value.converter`: defines the messages data
-    format in the Apache Kafka topic. The
-    `io.confluent.connect.avro.AvroConverter` converter translates
-    messages from the Avro format. To retrieve the messages schema we
-    use Aiven's [Karapace schema
-    registry](https://github.com/aiven/karapace) as specified by the
-    `schema.registry.url` parameter and related credentials.
+- `name`: The connector name. Replace `CONNECTOR_NAME` with your desired name.
+- `connect.redis.*`: Redis connection parameters collected in the
+  [prerequisite step](/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink#connect_redis_lenses_sink_prereq).
+- `key.converter` and `value.converter`: Define the message data format in the
+  Kafka topic. This example uses `io.confluent.connect.avro.AvroConverter` to translate
+  messages in Avro format. The schema is retrieved from Aiven's
+  [Karapace schema registry](https://github.com/aiven/karapace) using the
+  `schema.registry.url` and related credentials.
 
 :::note
-The `key.converter` and `value.converter` sections define how the topic
-messages will be parsed and needs to be included in the connector
-configuration.
+The `key.converter` and `value.converter` fields define how Kafka messages are parsed
+and must be included in the configuration.
 
-When using Avro as source data format, to set following
-parameters
+When using Avro as the source format, set the following:
 
--   `value.converter.schema.registry.url`: pointing to the Aiven for
-    Apache Kafka schema registry URL in the form of
-    `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT` with the
-    `APACHE_KAFKA_HOST` and `SCHEMA_REGISTRY_PORT` parameters
-    [retrieved in the previous step](/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink#connect_redis_lenses_sink_prereq).
--   `value.converter.basic.auth.credentials.source`: to the value
-    `USER_INFO`, since you're going to login to the schema registry
-    using username and password.
--   `value.converter.schema.registry.basic.auth.user.info`: passing the
-    required schema registry credentials in the form of
-    `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD` with the
-    `SCHEMA_REGISTRY_USER` and `SCHEMA_REGISTRY_PASSWORD` parameters
-    [retrieved in the previous step](/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink#connect_redis_lenses_sink_prereq).
+- `value.converter.schema.registry.url`: Use the Aiven for Apache Kafka schema registry
+  URL in the format `https://APACHE_KAFKA_HOST:SCHEMA_REGISTRY_PORT`. Retrieve these
+  values from the [prerequisite step](/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink#connect_redis_lenses_sink_prereq).
+- `value.converter.basic.auth.credentials.source`: Set to `USER_INFO`, which means
+  authentication is done using a username and password.
+- `value.converter.schema.registry.basic.auth.user.info`: Provide the schema registry
+  credentials in the format `SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`. These
+  values should also be retrieved in the
+  [prerequisite step](/docs/products/kafka/kafka-connect/howto/edis-streamreactor-sink#connect_redis_lenses_sink_prereq).
+
 :::
 
-### Create a Kafka Connect connector with the Aiven Console
+## Create the connector
 
-To create an Apache Kafka Connect connector:
+<Tabs groupId="setup-method">
+<TabItem value="console" label="Console" default>
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/) and select
-    the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
-    service where the connector needs to be defined.
 
-2.  Select **Connectors** from the left sidebar.
+1. Access the [Aiven Console](https://console.aiven.io/).
+1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
+1. Click <ConsoleLabel name="Connectors"/>.
+1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
+   If not, click **Enable connector on this service**.
 
-3.  Select **Create New Connector**, this is enabled only for
-    services
-    [with Kafka Connect enabled](enable-connect).
+   Alternatively, to enable connectors:
 
-4.  Select **Stream Reactor Redis Sink**.
+   1. Click <ConsoleLabel name="Service settings"/> in the sidebar.
+   1. In the **Service management** section, click
+      <ConsoleLabel name="Actions"/> > **Enable Kafka connect**.
 
-5.  In the **Common** tab, locate the **Connector configuration** text
-    box and select on **Edit**.
+1. In the sink connectors list, select **Redis Sink Connector**, and click **Get started**.
+1. On the **Stream Reactor Redis Sink** page, go to the **Common** tab.
+1. Locate the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
+1. Paste the configuration from your `redis_sink.json` file into the text box.
+1. Click **Create connector**.
+1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Confirm that data is written to the Redis target database.
+</TabItem>
+<TabItem value="cli" label="Aiven CLI">
 
-6.  Paste the connector configuration (stored in the `redis_sink.json`
-    file) in the form.
+To create the connector using the
+[Aiven CLI](/docs/tools/cli/service/connector#avn_service_connector_create), run:
 
-7.  Select **Apply**.
-
-    :::note
-    The Aiven Console parses the configuration file and fills the
-    relevant UI fields. You can review the UI fields across the various
-    tab and change them if necessary. The changes will be reflected in
-    JSON format in the **Connector configuration** text box.
-    :::
-
-8.  After all the settings are correctly configured, select **Create
-    connector**.
-
-9.  Verify the connector status under the **Connectors** screen.
-
-10. Verify the presence of the data in the target Redis service.
-
-:::note
-You can also create connectors using the
-[Aiven CLI command](/docs/tools/cli/service/connector#avn_service_connector_create).
-:::
-
-## Example: Create a Redis sink connector
-
-If you have a topic named `students` containing the following data that
-to move to Redis:
-
+```bash
+avn service connector create SERVICE_NAME @redis_sink.json
 ```
+
+Replace:
+
+* `SERVICE_NAME`: Your Kafka or Kafka Connect service name.
+* `@redis_sink.json`: Path to your configuration file.
+
+</TabItem>
+</Tabs>
+
+## Sink topic data to Redis
+
+The following example shows how to sink data from a Kafka topic to a Redis database.
+If your Kafka topic `students` contains the following data:
+
+```json
 {"id":1, "name":"carlo", "age": 77}
 {"id":2, "name":"lucy", "age": 55}
 {"id":3, "name":"carlo", "age": 33}
 {"id":2, "name":"lucy", "age": 21}
 ```
 
-You can sink the `students` topic to Redis with the following connector
-configuration, after replacing the placeholders for `REDIS_HOST`,
-`REDIS_PORT`, `REDIS_DB_NAME`, `REDIS_USERNAME` and `REDIS_PASSWORD`:
+To write this data to Redis, use the following connector configuration:
 
 ```json
 {
-    "name": "my-redis-sink",
-    "connector.class": "com.datamountaineer.streamreactor.connect.redis.sink.RedisSinkConnector",
-    "connect.redis.host": "REDIS_HOSTNAME",
-    "connect.redis.port": "REDIS_PORT",
-    "connect.redis.password": "REDIS_PASSWORD",
-    "connect.redis.ssl.enabled": "REDIS_SSL",
-    "topics": "students",
-    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
-    "value.converter.schemas.enable": "false",
-    "connect.redis.kcql": "INSERT INTO students- SELECT * FROM students PK id"
+  "name": "my-redis-sink",
+  "connector.class": "com.datamountaineer.streamreactor.connect.redis.sink.RedisSinkConnector",
+  "connect.redis.host": "REDIS_HOSTNAME",
+  "connect.redis.port": "REDIS_PORT",
+  "connect.redis.password": "REDIS_PASSWORD",
+  "connect.redis.ssl.enabled": "REDIS_SSL",
+  "topics": "students",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter.schemas.enable": "false",
+  "connect.redis.kcql": "INSERT INTO students- SELECT * FROM students PK id"
 }
 ```
 
-The configuration file contains the following peculiarities:
+Replace all placeholder values (such as `REDIS_HOSTNAME`, `REDIS_PORT`, and `REDIS_PASSWORD`)
+with your actual Redis connection details.
 
--   `"topics": "students"`: setting the topic to sink
--   `"connect.redis"`: the connection parameters placeholders
--   `"value.converter": "org.apache.kafka.connect.json.JsonConverter"`
-    and `"value.converter.schemas.enable": "false"`: the topic value is
-    in JSON format without a schema
--   `"connect.redis.kcql": "INSERT INTO students- SELECT * FROM students PK id"`:
-    the connector logic is to insert every topic message as new entry in
-    Redis, using the `id` field as key prefixed with `students-`
-    (configured in the `INSERT INTO` statement).
+This configuration does the following:
 
-Once the connector is created successfully, you should see the following
-three entries in the target Redis database.
+- `"topics": "students"`: Specifies the Kafka topic to sink.
+- Connection settings (`connect.redis.*`): Provide the Redis host, port, password, and
+  SSL setting.
+- `"value.converter"` and `"value.converter.schemas.enable"`: Set the message format.
+  The topic uses raw JSON without a schema.
+- `"connect.redis.kcql"`: Defines the insert logic. Each Kafka message is written
+  as a key-value pair in Redis. The key is built from the `id` field and prefixed
+  with `students-`.
 
-```
+After creating the connector, check your Redis database. You should see the following entries:
+
+```text
 1. "students-1" containing "{\"name\":\"carlo\",\"id\":1,\"age\":77}"
 2. "students-2" containing "{\"name\":\"lucy\",\"id\":2,\"age\":21}"
 3. "students-3" containing "{\"name\":\"carlo\",\"id\":3,\"age\":33}"
 ```
 
-There are only three keys in Redis since there were two messages in the
-topic sharing the `"id": 2`, and the connector will overwrite entries
-sharing the same key.
+Only three keys are present because two Kafka messages shared the same `"id": 2`.
+Redis overwrites entries that use the same key.

--- a/static/includes/streamreactor-compatibility-note.md
+++ b/static/includes/streamreactor-compatibility-note.md
@@ -1,0 +1,22 @@
+:::caution
+
+**Version compatibility**
+
+Stream Reactor version 9.0.2 includes class and package name changes introduced in
+version 6.0.0 by Lenses. These changes standardize connector class names and converter
+package names.
+
+Version 9.x is not compatible with version 4.2.0. To continue using version 4.2.0,
+[set the connector version](/docs/products/kafka/kafka-connect/howto/manage-connector-versions#set-version)
+before upgrading.
+
+If you are upgrading from version 4.2.0, you must recreate the connector using the
+updated class name. For example:
+
+```json
+"connector.class": "io.lenses.streamreactor.connect.<connector_path>.<ConnectorClassName>"
+```
+
+For details about the changes, see the
+[Stream Reactor release notes](https://docs.lenses.io/stream-reactor/docs/releases/).
+:::


### PR DESCRIPTION
## Describe your changes

Stream Reactor has been updated to version 9.0.2, which introduces standardized class and package names. This makes it incompatible with version 4.2.0 previously used on Aiven.

- Added a version compatibility snippet to affected pages
- Improved structure and flow to align with the documentation style guide

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
