### PR TITLE
fix: typo on tokens page

### DIFF
--- a/docs/platform/concepts/authentication-tokens.md
+++ b/docs/platform/concepts/authentication-tokens.md
@@ -18,7 +18,7 @@ To keep your personal and application tokens secure:
 
 - Set a session duration to limit the impact of exposure
 - Refrain from letting users share tokens
-- Rotation your tokens regularly
+- Rotate your tokens regularly
 - Restrict usage to trusted networks by specifying an allowed IP address range
 - Use application users for non-human users and follow
   [security best practices](/docs/platform/concepts/application-users) for their tokens


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
