### PR TITLE
update: change links from dev center to TF examples

### DIFF
--- a/docs/products/cassandra/concepts/cross-cluster-replication.md
+++ b/docs/products/cassandra/concepts/cross-cluster-replication.md
@@ -183,5 +183,4 @@ in the Apache Cassandra documentation.
 
 -   [OpenSearch® cross-cluster replication](/docs/products/opensearch/concepts/cross-cluster-replication-opensearch)
 -   [Set up cross-cluster replication for OpenSearch](/docs/products/opensearch/howto/setup-cross-cluster-replication-opensearch)
--   [Enabling cross-cluster replication for Apache Kafka® via
-    Terraform](https://aiven.io/developer/kafka-mirrormaker-crosscluster).
+-   [Enabling cross-cluster replication for Apache Kafka® via Terraform](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/kafka/kafka_mirrormaker).

--- a/docs/products/cassandra/howto/disable-cross-cluster-replication.md
+++ b/docs/products/cassandra/howto/disable-cross-cluster-replication.md
@@ -140,4 +140,4 @@ curl --request DELETE \
 -   [OpenSearch® cross-cluster replication](/docs/products/opensearch/concepts/cross-cluster-replication-opensearch)
 -   [Set up cross-cluster replication for OpenSearch](/docs/products/opensearch/howto/setup-cross-cluster-replication-opensearch)
 -   [Enabling cross-cluster replication for Apache Kafka® via
-    Terraform](https://aiven.io/developer/kafka-mirrormaker-crosscluster).
+    Terraform](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/kafka/kafka_mirrormaker).

--- a/docs/products/cassandra/howto/enable-cross-cluster-replication.md
+++ b/docs/products/cassandra/howto/enable-cross-cluster-replication.md
@@ -332,4 +332,4 @@ curl --request POST                                                   \
 -   [OpenSearch® cross-cluster replication](/docs/products/opensearch/concepts/cross-cluster-replication-opensearch)
 -   [Set up cross-cluster replication for OpenSearch](/docs/products/opensearch/howto/setup-cross-cluster-replication-opensearch)
 -   [Cross-cluster replication for Apache Kafka® with
-    Terraform](https://aiven.io/developer/kafka-mirrormaker-crosscluster)
+    Terraform](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/kafka/kafka_mirrormaker)

--- a/docs/products/cassandra/howto/manage-cross-cluster-replication.md
+++ b/docs/products/cassandra/howto/manage-cross-cluster-replication.md
@@ -250,4 +250,4 @@ in the Apache Cassandra documentation.
 -   [OpenSearch® cross-cluster replication](/docs/products/opensearch/concepts/cross-cluster-replication-opensearch)
 -   [Set up cross-cluster replication for OpenSearch](/docs/products/opensearch/howto/setup-cross-cluster-replication-opensearch)
 -   [Enabling cross-cluster replication for Apache Kafka® via
-    Terraform](https://aiven.io/developer/kafka-mirrormaker-crosscluster).
+    Terraform](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/kafka/kafka_mirrormaker).

--- a/docs/products/clickhouse/howto/list-integrations.md
+++ b/docs/products/clickhouse/howto/list-integrations.md
@@ -4,8 +4,9 @@ title: Integrate your Aiven for ClickHouse® service
 
 This section provides instructions on how to integrate your Aiven for
 ClickHouse® service with other services or external databases. If you'd
-like to use Terraform for this purpose, see integration recipes in
-[Aiven Terraform Cookbook](https://aiven.io/developer/terraform).
+like to use Terraform for this purpose, see integration examples in
+Aiven Terraform Provider's
+[GitHub repository](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/clickhouse).
 
 import DocCardList from '@theme/DocCardList';
 

--- a/docs/products/clickhouse/howto/manage-users-roles.md
+++ b/docs/products/clickhouse/howto/manage-users-roles.md
@@ -234,5 +234,5 @@ Console](https://console.aiven.io/).
 
 You can also manage user roles and access using the
 [Aiven Provider for Terraform](/docs/tools/terraform).
-Try Aiven Terraform Provider Cookbook recipe
-[Manage user privileges for Aiven for ClickHouse® services using Terraform](https://aiven.io/developer/manage-user-privileges-clickhouse-terraform).
+Learn how to manage multiple grants while avoiding conflicts with the
+[ClickHouse grants example](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/clickhouse/grants).

--- a/docs/products/kafka/karapace/get-started.md
+++ b/docs/products/kafka/karapace/get-started.md
@@ -23,8 +23,7 @@ To use Karapace, enable **Karapace Schema registry** and **REST APIs** on your A
 -   For information on how to manage Kafka schema registry ACL resources
     on Terraform, see
     [Manage resources via Terraform](/docs/products/kafka/karapace/howto/manage-schema-registry-authorization).
--   For more information on how to setup Karapace with Aiven for Apache
+-   For more information on how to set up Karapace with Aiven for Apache
     Kafka® using [Aiven Terraform
-    Provider](https://registry.terraform.io/providers/aiven/aiven/latest/docs),
-    see [Apache Kafka® with Karapace Schema
-    Registry](https://aiven.io/developer/apache-kafka-karapace).
+    Provider](https://registry.terraform.io/providers/aiven/aiven/latest/docs), see
+    [the `aiven_kafka` resource documentation](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/kafka).

--- a/docs/products/kafka/karapace/howto/enable-karapace.md
+++ b/docs/products/kafka/karapace/howto/enable-karapace.md
@@ -31,4 +31,4 @@ APIs on your service.
 
 To set up Karapace with Aiven for Apache Kafka®
 using [Aiven Terraform Provider](https://registry.terraform.io/providers/aiven/aiven/latest/docs),
-see [Apache Kafka® with Karapace Schema Registry](https://aiven.io/developer/apache-kafka-karapace).
+see [the `aiven_kafka` resource documentation](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/kafka).

--- a/docs/tools/terraform.md
+++ b/docs/tools/terraform.md
@@ -36,7 +36,7 @@ The following example file is also available in the
 
 - Follow an [example to set up your own organization](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/get-started)
   with a user group and permissions.
-- Try one of the other [examples](https://aiven.io/developer/terraform)
+- Try one of the other [examples](https://github.com/aiven/terraform-provider-aiven/tree/main/examples)
   to learn how to create a service or integration using the Aiven Terraform Provider.
 - Get details about all the available resources and data sources in the
   [Aiven Provider for Terraform documentation](https://registry.terraform.io/providers/aiven/aiven/latest/docs).


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
