### PR TITLE
update: PG read-only replica configured programmatically with startup plans only

### DIFF
--- a/docs/products/postgresql/howto/create-read-replica.md
+++ b/docs/products/postgresql/howto/create-read-replica.md
@@ -9,8 +9,8 @@ import ConsoleLabel from "@site/src/components/ConsoleIcons";
 
 Use Aiven for PostgreSQL® read-only replicas to reduce the load on the primary server and optimize query response times across different geographical locations.
 
-You can run read-only queries against Aiven for PostgreSQL read-only replicas. Such
-replicas can be hosted in different regions or with different cloud providers.
+You can run read-only queries against Aiven for PostgreSQL read-only replicas. These 
+replicas can be hosted in different regions or on different cloud providers.
 
 :::note
 If your service is running a `business-*` or `premium-*` plan, you have


### PR DESCRIPTION
https://aiven.atlassian.net/browse/DOC-1475

[PREVIEW](https://doc-1475-create-read-replica.aiven-docs.pages.dev/docs/products/postgresql/howto/create-read-replica)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
