### PR TITLE
update: previous version backups not available after a major version upgrade

### DIFF
--- a/docs/products/postgresql/howto/upgrade.md
+++ b/docs/products/postgresql/howto/upgrade.md
@@ -71,8 +71,9 @@ To upgrade a PostgreSQL service:
     Upon clicking **Upgrade**:
     - The system applies the upgrade **immediately**.
     - The PostgreSQL instance can't be restored to the previous version.
-    - Backups cannot be used for procedures such as Point In Time Recovery since they were
-      created with an earlier version of PostgreSQL.
+    - Backups created with an earlier version are no longer visible in the Aiven Console
+      and cannot be used for operations such as Point In Time Recovery (PiTR). You can
+      only use backups created after the major version upgrade for such purposes.
     :::
 
 1.  Select **Upgrade**.

--- a/docs/products/postgresql/howto/upgrade.md
+++ b/docs/products/postgresql/howto/upgrade.md
@@ -71,7 +71,7 @@ To upgrade a PostgreSQL service:
     Upon clicking **Upgrade**:
     - The system applies the upgrade **immediately**.
     - The PostgreSQL instance can't be restored to the previous version.
-    - Backups created with an earlier version are no longer visible in the Aiven Console
+    - Backups created with an earlier major version are no longer visible in the Aiven Console
       and cannot be used for operations such as Point In Time Recovery (PiTR). You can
       only use backups created after the major version upgrade for such purposes.
     :::


### PR DESCRIPTION
https://aiven.atlassian.net/browse/BF-3375 

[PREVIEW](https://bf-3375-doc-backups-after-ma.aiven-docs.pages.dev/docs/products/postgresql/howto/upgrade#upgrade-to-a-major-version)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
