### PR TITLE
update: clarify claim must be a string

### DIFF
--- a/docs/products/kafka/howto/enable-oidc.md
+++ b/docs/products/kafka/howto/enable-oidc.md
@@ -108,6 +108,12 @@ Set the following OIDC parameters:
     `sasl.oauthbearer.sub.claim.name`.
   - **Value**: Enter `sub` or the specific claim name provided
     by your OIDC provider if different.
+
+    :::note
+    The claim must be a string. Claims that contain arrays, such as `groups`, are not
+    supported.
+    :::
+
 - Optional: `kafka.sasl_oauthbearer_expected_issuer`
   - **Description**: Specifies the JWT's issuer for the broker to
     verify. Corresponds to the Apache Kafka parameter


### PR DESCRIPTION
## Describe your changes
The value of `kafka.sasl_oauthbearer_sub_claim_name` must be a single string claim (e.g., `sub` or `oid`) as defined by the OIDC provider.


## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
