### PR TITLE
fix: pg anonymizer supported from pg 15

### DIFF
--- a/docs/products/postgresql/reference/list-of-extensions.md
+++ b/docs/products/postgresql/reference/list-of-extensions.md
@@ -196,7 +196,7 @@ installed with a few exceptions.
     Show tuple-level statistics.
 -   [postgresql_anonymizer](https://postgresql-anonymizer.readthedocs.io/en/latest/).
     Mask or replace personally identifiable information (PII) or commercially sensitive
-    data from a PostgreSQL database.
+    data from a PostgreSQL database. `PG15 and newer`
 
     :::important
     This is an experimental release of `postgresql_anonymizer`. The extension’s behavior


### PR DESCRIPTION
https://aiven.atlassian.net/browse/BF-3310

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
