### PR TITLE
update: Clarify Kafka ACL wildcard matching behavior

### DIFF
--- a/docs/products/kafka/concepts/acl.md
+++ b/docs/products/kafka/concepts/acl.md
@@ -94,8 +94,9 @@ configure separate ACL entries for consumer group access.
   ```
 
   Grants `tester` read access to topics such as `topic-1` and `topic-A`. The `?` matches
-  exactly one character, so it does not match `topic-10`. To match `topic-10`,
-  use `topic-*` (zero or more characters) or `topic-??` (exactly two characters).
+  exactly one character. For example, it does not match `topic-10`. To match `topic-10`,
+  use `topic-*` (zero or more characters), `topic-??` (two characters),
+  or `topic-?0`.
 
 ## Kafka-native ACL capabilities
 


### PR DESCRIPTION
## Describe your changes

- Clarify that ? matches exactly one character
- Add examples like topic-? matching topic-1, topic-A, etc.

[FLEET-5865](https://aiven.atlassian.net/browse/FLEET-5865)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.


[FLEET-5865]: https://aiven.atlassian.net/browse/FLEET-5865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ