### PR TITLE
update: remove dev center from redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -232,13 +232,13 @@
 /tools/terraform/reference/cookbook/kafka-connect-terraform-recipe    /docs/tools/terraform/get-started
 /tools/terraform/reference/troubleshooting                            /docs/tools/terraform
 /tools/terraform/reference/troubleshooting/private-access-error       /docs/tools/terraform
+/tutorials/anomaly-detection                                          /docs
 
 #
 # Redirect to external resources
 #
-/tutorials/anomaly-detection                                          https://aiven.io/developer
-/tools/terraform/reference/cookbook/kafka-flink-integration-recipe    https://aiven.io/developer/apache-kafka-to-opensearch-terraform
-/tools/terraform/reference/cookbook/multicloud-postgresql-recipe      https://aiven.io/developer/multicloud-postgresql-terraform
+/tools/terraform/reference/cookbook/kafka-flink-integration-recipe    https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/examples
+/tools/terraform/reference/cookbook/multicloud-postgresql-recipe      https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/examples
 /tools/terraform/howto/config-postgresql-provider          https://registry.terraform.io/providers/aiven/aiven/latest/guides/use-pg-provider-for-config
 /tools/terraform/howto/promote-to-master-pg-rr             https://registry.terraform.io/providers/aiven/aiven/latest/guides/manage-read-replicas
 /tools/terraform/howto/update-deprecated-resources         https://registry.terraform.io/providers/aiven/aiven/latest/guides/update-deprecated-resources


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
