### PR TITLE
feat: OVHcloud US provider and regions

### DIFF
--- a/static/includes/clouds-list.md
+++ b/static/includes/clouds-list.md
@@ -638,6 +638,30 @@ import LimitedBadge from "@site/src/components/Badges/LimitedBadge";
 </tbody>
 </table>
 
+## OVHcloud US
+
+<table>
+  <thead>
+  <tr>
+    <th>Region</th>
+    <th>Cloud</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>North America</td>
+    <td>avn-ovhus-us-east-va-1</td>
+    <td>North America, United States: Virginia</td>
+  </tr>
+  <tr>
+    <td>North America</td>
+    <td>avn-ovhus-us-west-or-1</td>
+    <td>North America, United States: Oregon</td>
+  </tr>
+</tbody>
+</table>
+
 ## UpCloud
 
 <table>


### PR DESCRIPTION
[JIRA](https://aiven.atlassian.net/browse/OPD-414)

[PREVIEW](https://opd-414-docs-add-ovh-us-clou.aiven-docs.pages.dev/docs/platform/reference/list_of_clouds#ovhcloud-us)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
