### PR TITLE
fix: command for displaying PG migration status

### DIFF
--- a/docs/products/mysql/howto/migrate-from-external-mysql.md
+++ b/docs/products/mysql/howto/migrate-from-external-mysql.md
@@ -92,7 +92,7 @@ You can use the following variables in the code samples provided:
     [Aiven CLI command](/docs/tools/cli/service-cli#avn-cli-service-migration-status):
 
     ```bash
-    avn --show-http service migration-status --project PROJECT_NAME DEST_NAME
+    avn service migration-status --project PROJECT_NAME DEST_SERVICE_NAME
     ```
 
 While the migration process is ongoing, the `migration_detail.status`

--- a/docs/products/postgresql/howto/migrate-aiven-db-migrate.md
+++ b/docs/products/postgresql/howto/migrate-aiven-db-migrate.md
@@ -55,7 +55,7 @@ following:
     [Aiven CLI](/docs/tools/cli) substituting the
     parameters accordingly:
 
-    ```
+    ```bash
     avn service create --project PROJECT_NAME -t pg -p DEST_PG_PLAN DEST_PG_NAME
     ```
 
@@ -135,8 +135,7 @@ You can see the migration status using the
 following call:
 
 ```bash
-avn --project PROJECT_NAME --show-http service migration-status \
-    DEST_PG_NAME
+avn service migration-status --project PROJECT_NAME SERVICE_NAME
 ```
 
 :::note
@@ -214,8 +213,7 @@ Don't stop the migration process while it is `running` state since both
 the logical replication and `pg-dump`/`pg-restore` methods are copying
 data from the source to the destination cluster.
 
-Once migration is completed successfully, unused replication slots
-should be removed.
+Once the migration is completed successfully, remove unused replication slots.
 :::
 
 The migration using `aiven-db-migrate` can also be


### PR DESCRIPTION
[JIRA](https://aiven.atlassian.net/browse/BF-3460)

[PREVIEW](https://bf-3460-docs-fix-pg-migratio.aiven-docs.pages.dev/docs/products/postgresql/howto/migrate-aiven-db-migrate#display-the-migration-status-using-the-aiven-cli)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
