### PR TITLE
update: docs for Java class generation from Avro, Protobuf, and JSON schemas

### DIFF
--- a/.github/vale/styles/config/vocabularies/Aiven/accept.txt
+++ b/.github/vale/styles/config/vocabularies/Aiven/accept.txt
@@ -258,6 +258,7 @@ PostgreSQL
 Postman
 preformatted
 privatelink
+protoc
 Prometheus
 Protobuf
 Provectus

--- a/.github/vale/styles/config/vocabularies/Aiven/accept.txt
+++ b/.github/vale/styles/config/vocabularies/Aiven/accept.txt
@@ -81,6 +81,7 @@ depends_on
 deserialization
 deserialize
 deserializer
+deserializers
 Dev
 Digitransit
 diskio_io_time

--- a/docs/products/kafka/howto/generate-avro-java-classes.md
+++ b/docs/products/kafka/howto/generate-avro-java-classes.md
@@ -42,18 +42,6 @@ java -jar avro-tools-1.12.0.jar compile schema src/main/resources/user-value.avs
 The generated class is named based on the `name` field in your schema, and it is placed
 in a subdirectory matching the `namespace`.
 
-:::note
-Use the `--package` option to specify the Java package during code generation.
-Kafka serialization depends on the fully
-qualified class name.
-
-For example:
-
-```bash
-jsonschema2pojo --source src/main/resources/users.json --target src/main/java/io/aiven/example --package io.aiven.example
-```
-:::
-
 ## Example schema
 
 ```json

--- a/docs/products/kafka/howto/generate-avro-java-classes.md
+++ b/docs/products/kafka/howto/generate-avro-java-classes.md
@@ -30,9 +30,12 @@ java -jar avro-tools-1.12.0.jar compile schema src/main/resources/user-value.avs
 - Replace `src/main/java/` with your preferred output directory.
 
 The generated class is named based on the `name` field in your schema, and it is placed
-in a subdirectory matching the `namespace`. Do not rename the generated class or change
-its package declaration. Kafka serialization
+in a subdirectory matching the `namespace`.
+
+:::note
+Do not rename the generated class or change its package declaration. Kafka serialization
 depends on the original name and namespace in the schema.
+:::
 
 ## Example schema
 
@@ -56,8 +59,8 @@ src/main/java/io/aiven/example/User.java
 
 ## Add Maven dependencies
 
-Add these dependencies to your `pom.xml` to compile and use the generated classes with
-Avro and Kafka:
+Add these dependencies to your `pom.xml` to compile and use the generated classes for
+Avro serialization and deserialization in Kafka producers and consumers.
 
 ```xml
 <dependencies>
@@ -115,7 +118,8 @@ You can use additional libraries depending on your schema or Avro usage:
 ```
 
 These dependencies are optional. Include them only if your generated classes use
-features like `Optional<T>` fields (Jackson) or `ImmutableList` and `ImmutableSet` types (Guava).
+features like `Optional<T>` fields (Jackson) or `ImmutableList` and `ImmutableSet`
+types (Guava).
 
 <RelatedPages />
 

--- a/docs/products/kafka/howto/generate-avro-java-classes.md
+++ b/docs/products/kafka/howto/generate-avro-java-classes.md
@@ -27,6 +27,11 @@ Generate Java data classes from Avro schema files (`.avsc`) to use with Apache K
 
 Run the following command to generate Java classes from your Avro schema:
 
+:::note
+Use the latest version of `avro-tools` if available.
+You can check for newer releases at [https://avro.apache.org/releases.html](https://avro.apache.org/releases.html).
+:::
+
 ```bash
 java -jar avro-tools-1.12.0.jar compile schema src/main/resources/user-value.avsc src/main/java/
 ```
@@ -38,8 +43,15 @@ The generated class is named based on the `name` field in your schema, and it is
 in a subdirectory matching the `namespace`.
 
 :::note
-Do not rename the generated class or change its package declaration. Kafka serialization
-depends on the original name and namespace in the schema.
+Use the `--package` option to specify the Java package during code generation.
+Kafka serialization depends on the fully
+qualified class name.
+
+For example:
+
+```bash
+jsonschema2pojo --source src/main/resources/users.json --target src/main/java/io/aiven/example --package io.aiven.example
+```
 :::
 
 ## Example schema

--- a/docs/products/kafka/howto/generate-avro-java-classes.md
+++ b/docs/products/kafka/howto/generate-avro-java-classes.md
@@ -23,7 +23,7 @@ Generate Java data classes from Avro schema files (`.avsc`) to use with Apache K
   use `.avro` files. They include both schema and data and are not compatible with `avro-tools`.
   :::
 
-## Generate the Java class
+## Generate the Java classes
 
 Run the following command to generate Java classes from your Avro schema:
 

--- a/docs/products/kafka/howto/generate-avro-java-classes.md
+++ b/docs/products/kafka/howto/generate-avro-java-classes.md
@@ -1,0 +1,122 @@
+---
+title: Generate Java data classes from Avro schemas
+sidebar_label: Avro schema
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Generate Java data classes from Avro schema files (`.avsc`) to use with Apache Kafka® producers and consumers. Use the `avro-tools` JAR to create Java classes that match your schema structure.
+
+## Prerequisites
+
+- An active [Aiven for Apache Kafka® service](/docs/products/kafka/get-started#create-an-aiven-for-apache-kafka-service)
+- [Karapace Schema Registry](/docs/products/kafka/karapace/concepts/schema-registry-authorization)
+  enabled
+- Java (JDK 8 or later)
+- [Apache Maven](https://maven.apache.org/) installed to manage dependencies
+- [`avro-tools`](https://avro.apache.org/releases.html) JAR file downloaded (such
+  as `avro-tools-1.12.0.jar`)
+- An Avro schema file (`.avsc`)
+
+## Generate the Java class
+
+Run the following command to generate Java classes from your Avro schema:
+
+```bash
+java -jar avro-tools-1.12.0.jar compile schema src/main/resources/user-value.avsc src/main/java/
+```
+
+- Replace `user-value.avsc` with your schema file.
+- Replace `src/main/java/` with your preferred output directory.
+
+The generated class is named based on the `name` field in your schema, and it is placed
+in a subdirectory matching the `namespace`. Do not rename the generated class or change
+its package declaration. Kafka serialization
+depends on the original name and namespace in the schema.
+
+## Example schema
+
+```json
+{
+  "type": "record",
+  "name": "User",
+  "namespace": "io.aiven.example",
+  "fields": [
+    { "name": "id", "type": "int" },
+    { "name": "email", "type": "string" }
+  ]
+}
+```
+
+This schema produces the following file:
+
+```plaintext
+src/main/java/io/aiven/example/User.java
+```
+
+## Add Maven dependencies
+
+Add these dependencies to your `pom.xml` to compile and use the generated classes with
+Avro and Kafka:
+
+```xml
+<dependencies>
+  <!-- Apache Kafka client dependency -->
+  <dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>3.8.1</version>
+  </dependency>
+
+  <!-- Confluent dependencies for Avro serialization and Schema Registry -->
+  <dependency>
+    <groupId>io.confluent</groupId>
+    <artifactId>kafka-avro-serializer</artifactId>
+    <version>8.0.0</version>
+  </dependency>
+  <dependency>
+    <groupId>io.confluent</groupId>
+    <artifactId>kafka-schema-registry-client</artifactId>
+    <version>8.0.0</version>
+  </dependency>
+
+  <!-- Apache Avro dependency -->
+  <dependency>
+    <groupId>org.apache.avro</groupId>
+    <artifactId>avro</artifactId>
+    <version>1.12.0</version>
+  </dependency>
+</dependencies>
+```
+
+:::note
+Ensure that the versions of Avro, Kafka, and Confluent dependencies are compatible
+with each other and with your Kafka setup.
+:::
+
+### Optional dependencies
+
+You can use additional libraries depending on your schema or Avro usage:
+
+```xml
+<!-- Jackson support for Java 8 types (used with generated POJOs) -->
+<dependency>
+  <groupId>com.fasterxml.jackson.datatype</groupId>
+  <artifactId>jackson-datatype-jdk8</artifactId>
+  <version>2.19.2</version>
+</dependency>
+
+<!-- Guava support (used in some Avro-related tooling) -->
+<dependency>
+  <groupId>com.google.guava</groupId>
+  <artifactId>guava</artifactId>
+  <version>33.4.8-jre</version>
+</dependency>
+```
+
+These dependencies are optional. Include them only if your generated classes use
+features like `Optional<T>` fields (Jackson) or `ImmutableList` and `ImmutableSet` types (Guava).
+
+<RelatedPages />
+
+[Official Avro Java Getting Started Guide](https://avro.apache.org/docs/1.12.0/getting-started-java/)

--- a/docs/products/kafka/howto/generate-avro-java-classes.md
+++ b/docs/products/kafka/howto/generate-avro-java-classes.md
@@ -16,7 +16,12 @@ Generate Java data classes from Avro schema files (`.avsc`) to use with Apache K
 - [Apache Maven](https://maven.apache.org/) installed to manage dependencies
 - [`avro-tools`](https://avro.apache.org/releases.html) JAR file downloaded (such
   as `avro-tools-1.12.0.jar`)
-- An Avro schema file (`.avsc`)
+- An Avro schema file with a `.avsc` extension
+
+  :::note
+  You can also use `.json` files if they contain a valid Avro schema. Do not
+  use `.avro` files. They include both schema and data and are not compatible with `avro-tools`.
+  :::
 
 ## Generate the Java class
 

--- a/docs/products/kafka/howto/generate-java-classes-from-schemas.md
+++ b/docs/products/kafka/howto/generate-java-classes-from-schemas.md
@@ -35,4 +35,5 @@ See schema-specific instructions:
 - [Generate JSON Schema Java classes with jsonschema2pojo](/docs/products/kafka/howto/generate-json-java-classes)
 
 After generating your classes,
-[use them with Kafka and the schema registry](/docs/products/kafka/howto/schema-registry-java) to produce and consume messages.
+[use them with Kafka and the schema registry](/docs/products/kafka/howto/schema-registry)
+to produce and consume messages.

--- a/docs/products/kafka/howto/generate-java-classes-from-schemas.md
+++ b/docs/products/kafka/howto/generate-java-classes-from-schemas.md
@@ -10,10 +10,12 @@ with the correct data types.
 
 Generate data classes if you:
 
-- Work with schema-based formats such as Avro, Protobuf, or JSON Schema
-- Want strongly typed Kafka producers and consumers
-- Use Karapace as your Schema Registry
-- Prefer Java classes over generic records or raw values
+- Work with schema-based formats such as Avro, Protobuf, or JSON Schema.
+- Want strongly typed Kafka producers and consumers.
+- Use Karapace as your Schema Registry.
+- Prefer Java classes over using generic records or untyped data (such as raw strings
+  or byte arrays).
+- Need to enforce data governance in your Kafka topics.
 
 ## Prerequisites
 

--- a/docs/products/kafka/howto/generate-java-classes-from-schemas.md
+++ b/docs/products/kafka/howto/generate-java-classes-from-schemas.md
@@ -2,11 +2,9 @@
 title: Generate Java classes from schemas
 ---
 
-Generate Java data classes (also known as Plain Old Java Objects, or POJOs) from Avro, Protobuf, or JSON Schema files and use them in Apache Kafka® producers and consumers.
+Generate Java classes from Avro, Protobuf, or JSON Schema files to use with Apache Kafka® and [Karapace Schema Registry](/docs/products/kafka/karapace/concepts/schema-registry-authorization).
 These classes match your schema structure and help serialize and deserialize messages
-with the correct data types when integrating
-with [Karapace, Aiven’s Schema Registry](/docs/products/kafka/karapace/concepts/schema-registry-authorization).
-
+with the correct data types.
 
 ## When to generate data classes
 

--- a/docs/products/kafka/howto/generate-java-classes-from-schemas.md
+++ b/docs/products/kafka/howto/generate-java-classes-from-schemas.md
@@ -13,8 +13,8 @@ Generate data classes if you:
 - Work with schema-based formats such as Avro, Protobuf, or JSON Schema.
 - Want strongly typed Kafka producers and consumers.
 - Use Karapace as your Schema Registry.
-- Prefer Java classes over using generic records or untyped data (such as raw strings
-  or byte arrays).
+- Prefer Java classes over using generic records or data without a defined schema
+  (such as raw strings or byte arrays).
 - Need to enforce data governance in your Kafka topics.
 
 ## Prerequisites

--- a/docs/products/kafka/howto/generate-java-classes-from-schemas.md
+++ b/docs/products/kafka/howto/generate-java-classes-from-schemas.md
@@ -1,0 +1,40 @@
+---
+title: Generate Java classes from schemas
+---
+
+Generate Java data classes (also known as Plain Old Java Objects, or POJOs) from Avro, Protobuf, or JSON Schema files and use them in Apache Kafka® producers and consumers.
+These classes match your schema structure and help serialize and deserialize messages
+with the correct data types when integrating
+with [Karapace, Aiven’s Schema Registry](/docs/products/kafka/karapace/concepts/schema-registry-authorization).
+
+
+## When to generate data classes
+
+Generate data classes if you:
+
+- Work with schema-based formats such as Avro, Protobuf, or JSON Schema
+- Want strongly typed Kafka producers and consumers
+- Use Karapace as your Schema Registry
+- Prefer Java classes over generic records or raw values
+
+## Prerequisites
+
+- An active [Aiven for Apache Kafka® service](/docs/products/kafka/get-started)
+- [Karapace Schema Registry enabled](/docs/products/kafka/karapace/howto/enable-karapace)
+- Java (JDK 8 or later)
+- [Apache Maven](https://maven.apache.org/) installed
+- A schema file in one of these formats:
+  - Avro (`.avsc`)
+  - Protobuf (`.proto`)
+  - JSON Schema (`.json`)
+
+## Next steps
+
+See schema-specific instructions:
+
+- [Generate Avro Java classes with avro-tools](/docs/products/kafka/howto/generate-avro-java-classes)
+- [Generate Protobuf Java classes with protoc](/docs/products/kafka/howto/generate-protobuf-java-classes)
+- [Generate JSON Schema Java classes with jsonschema2pojo](/docs/products/kafka/howto/generate-json-java-classes)
+
+After generating your classes,
+[use them with Kafka and the schema registry](/docs/products/kafka/howto/schema-registry-java) to produce and consume messages.

--- a/docs/products/kafka/howto/generate-json-java-classes.md
+++ b/docs/products/kafka/howto/generate-json-java-classes.md
@@ -17,7 +17,7 @@ Generate Java data classes from JSON Schema (`.json`) files for use in Apache Ka
 - [`jsonschema2pojo`](https://github.com/joelittlejohn/jsonschema2pojo) installed
 - A JSON Schema file (`.json`)
 
-## Generate the Java class
+## Generate the Java classes
 
 Generate Java classes from your JSON schema file using the `jsonschema2pojo` CLI:
 

--- a/docs/products/kafka/howto/generate-json-java-classes.md
+++ b/docs/products/kafka/howto/generate-json-java-classes.md
@@ -10,7 +10,7 @@ Generate Java data classes from JSON Schema (`.json`) files for use in Apache Ka
 ## Prerequisites
 
 - An active [Aiven for Apache Kafka® service](/docs/products/kafka/get-started#create-an-aiven-for-apache-kafka-service)
-- [Karapace Schema Registry](/docs/products/kafka/karapace/concepts/schema-registry-authorization)
+- [Karapace Schema Registry](/docs/products/kafka/karapace/howto/enable-karapace)
   enabled
 - Java (JDK 8 or later)
 - [Apache Maven](https://maven.apache.org/) installed to manage dependencies

--- a/docs/products/kafka/howto/generate-json-java-classes.md
+++ b/docs/products/kafka/howto/generate-json-java-classes.md
@@ -33,9 +33,11 @@ schema. If `javaType` is not defined, the output directory is based on the schem
 or the folder structure.
 
 :::note
-Do not rename the generated class or change its package declaration. Kafka serialization
-depends on the original name and namespace in the schema.
+If your schema does not define a `javaType` with a package, you may need to update the
+package declaration in the generated Java file so it matches your project's structure.
+Kafka serialization depends on the fully qualified class name.
 :::
+
 
 ## Example schema
 
@@ -55,12 +57,13 @@ depends on the original name and namespace in the schema.
 This schema generates the following Java file:
 
 ```plaintext
-src/main/java/io/aiven/example/User.java
+src/main/java/User.java
 ```
 
 ## Optional: Add Confluent schema annotation
 
-To support additional features in Confluent-compatible deserializers (such as Karapace, Aiven’s Schema Registry), you can add this annotation to your JSON Schema:
+To enable additional features in Confluent’s deserializers (which are compatible
+with schema registries like Karapace), you can add this annotation to your JSON Schema:
 
 ```json
 "@io.confluent.kafka.schemaregistry.annotations.Schema": {

--- a/docs/products/kafka/howto/generate-json-java-classes.md
+++ b/docs/products/kafka/howto/generate-json-java-classes.md
@@ -63,7 +63,9 @@ src/main/java/User.java
 ## Optional: Add Confluent schema annotation
 
 To enable additional features in Confluent’s deserializers (which are compatible
-with schema registries like Karapace), you can add this annotation to your JSON Schema:
+with schema registries like
+[Karapace](/docs/products/kafka/karapace/concepts/schema-registry-authorization)), you
+can add this annotation to your JSON Schema:
 
 ```json
 "@io.confluent.kafka.schemaregistry.annotations.Schema": {
@@ -72,9 +74,8 @@ with schema registries like Karapace), you can add this annotation to your JSON 
 }
 ```
 
-This annotation allows Confluent-compatible deserializers, such
-as [Karapace](/docs/products/kafka/karapace/concepts/schema-registry-authorization),
-to expose runtime methods like `schema()` and `refs()` in the generated Java class.
+This annotation makes runtime methods such as `schema()` and `refs()` available in
+the generated Java classes.
 
 Use this only for advanced use cases that require schema introspection at runtime.
 

--- a/docs/products/kafka/howto/generate-json-java-classes.md
+++ b/docs/products/kafka/howto/generate-json-java-classes.md
@@ -28,7 +28,7 @@ jsonschema2pojo --source src/main/resources/schema.json --target src/main/java/
 - Replace `schema.json` with your schema file.
 - Replace `src/main/java/` with your preferred output directory.
 
-The generated Java class is placed in a subfolder based on the `javaType` field in the
+The generated Java class is placed in a subdirectory based on the `javaType` field in the
 schema. If `javaType` is not defined, the output directory is based on the schema title
 or the folder structure.
 

--- a/docs/products/kafka/howto/generate-json-java-classes.md
+++ b/docs/products/kafka/howto/generate-json-java-classes.md
@@ -1,0 +1,139 @@
+---
+title: Generate Java data classes from JSON schemas
+sidebar_label: JSON schema
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Generate Java data classes from JSON Schema (`.json`) files for use in Apache Kafka® applications. Use the `jsonschema2pojo` CLI tool to generate Java classes that match your schema structure.
+
+## Prerequisites
+
+- An active [Aiven for Apache Kafka® service](/docs/products/kafka/get-started#create-an-aiven-for-apache-kafka-service)
+- [Karapace Schema Registry](/docs/products/kafka/karapace/concepts/schema-registry-authorization)
+  enabled
+- Java (JDK 8 or later)
+- [Apache Maven](https://maven.apache.org/) installed to manage dependencies
+- [`jsonschema2pojo`](https://github.com/joelittlejohn/jsonschema2pojo) installed
+- A JSON Schema file (`.json`)
+
+## Generate the Java class
+
+Generate Java classes from your JSON schema file using the `jsonschema2pojo` CLI:
+
+```bash
+jsonschema2pojo --source src/main/resources/schema.json --target src/main/java/
+```
+
+- Replace `schema.json` with your schema file.
+- Replace `src/main/java/` with your preferred output directory.
+
+The generated Java class is placed in a subfolder based on the `javaType` field in the
+schema. If `javaType` is not defined, the output directory is based on the schema title
+or the folder structure.
+
+Make sure the `package` declaration in the generated Java file matches your
+project’s structure. Kafka serialization depends on consistent class names and packages.
+
+## Example schema
+
+```json
+{
+  "type": "object",
+  "title": "User",
+  "javaType": "io.aiven.example.User",
+  "properties": {
+    "id": { "type": "integer" },
+    "email": { "type": "string" }
+  },
+  "required": ["id", "email"]
+}
+```
+
+This schema generates the following Java file:
+
+```plaintext
+src/main/java/io/aiven/example/User.java
+```
+
+## Optional: Add Confluent schema annotation
+
+To support additional features in Confluent-compatible deserializers (such as Karapace, Aiven’s Schema Registry), you can add this annotation to your JSON Schema:
+
+```json
+"@io.confluent.kafka.schemaregistry.annotations.Schema": {
+  "value": "{...your schema as a string...}",
+  "refs": []
+}
+```
+
+This annotation allows Confluent-compatible deserializers, such
+as [Karapace](/docs/products/kafka/karapace/concepts/schema-registry-authorization),
+to expose runtime methods like `schema()` and `refs()` in the generated Java class.
+
+Use this only for advanced use cases that require schema introspection at runtime.
+
+## Add Maven dependencies
+
+Add these dependencies to your `pom.xml` to compile and use the generated classes with
+JSON Schema and Kafka:
+
+```xml
+<dependencies>
+  <!-- Apache Kafka client dependency -->
+  <dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>3.8.1</version>
+  </dependency>
+
+  <!-- Confluent dependency for JSON Schema serialization -->
+  <dependency>
+    <groupId>io.confluent</groupId>
+    <artifactId>kafka-json-schema-serializer</artifactId>
+    <version>8.0.0</version>
+  </dependency>
+
+  <!-- Core Jackson library for JSON binding -->
+  <dependency>
+    <groupId>com.fasterxml.jackson.core</groupId>
+    <artifactId>jackson-databind</artifactId>
+    <version>2.19.2</version>
+  </dependency>
+</dependencies>
+```
+
+### Optional dependencies
+
+Depending on your schema complexity or tooling, you might also need these:
+
+```xml
+<!-- Jackson support for Java 8 types -->
+<dependency>
+  <groupId>com.fasterxml.jackson.datatype</groupId>
+  <artifactId>jackson-datatype-jdk8</artifactId>
+  <version>2.19.2</version>
+</dependency>
+
+<!-- Jackson support for Java time (JSR-310) -->
+<dependency>
+  <groupId>com.fasterxml.jackson.datatype</groupId>
+  <artifactId>jackson-datatype-jsr310</artifactId>
+  <version>2.19.2</version>
+</dependency>
+
+<!-- JSON Schema validation -->
+<dependency>
+  <groupId>com.github.erosb</groupId>
+  <artifactId>everit-json-schema</artifactId>
+  <version>1.14.6</version>
+</dependency>
+```
+
+These optional dependencies support features like Java 8 types, JSR-310 date/time classes,
+and schema validation. Add them only if your schema or generated class uses these
+features.
+
+<RelatedPages />
+
+[jsonschema2pojo CLI reference](https://github.com/joelittlejohn/jsonschema2pojo/wiki/Getting-Started#the-command-line-interface)

--- a/docs/products/kafka/howto/generate-json-java-classes.md
+++ b/docs/products/kafka/howto/generate-json-java-classes.md
@@ -32,8 +32,10 @@ The generated Java class is placed in a subdirectory based on the `javaType` fie
 schema. If `javaType` is not defined, the output directory is based on the schema title
 or the folder structure.
 
-Make sure the `package` declaration in the generated Java file matches your
-project’s structure. Kafka serialization depends on consistent class names and packages.
+:::note
+Do not rename the generated class or change its package declaration. Kafka serialization
+depends on the original name and namespace in the schema.
+:::
 
 ## Example schema
 
@@ -75,8 +77,8 @@ Use this only for advanced use cases that require schema introspection at runtim
 
 ## Add Maven dependencies
 
-Add these dependencies to your `pom.xml` to compile and use the generated classes with
-JSON Schema and Kafka:
+Add these dependencies to your `pom.xml` to compile and use the generated classes for
+JSON Schema serialization and deserialization in Kafka producers and consumers.
 
 ```xml
 <dependencies>

--- a/docs/products/kafka/howto/generate-json-java-classes.md
+++ b/docs/products/kafka/howto/generate-json-java-classes.md
@@ -28,16 +28,21 @@ jsonschema2pojo --source src/main/resources/schema.json --target src/main/java/
 - Replace `schema.json` with your schema file.
 - Replace `src/main/java/` with your preferred output directory.
 
-The generated Java class is placed in a subdirectory based on the `javaType` field in the
-schema. If `javaType` is not defined, the output directory is based on the schema title
-or the folder structure.
-
 :::note
-If your schema does not define a `javaType` with a package, you may need to update the
-package declaration in the generated Java file so it matches your project's structure.
-Kafka serialization depends on the fully qualified class name.
-:::
+Use the `--package` option to specify the Java package during code generation.
+Kafka serialization depends on the fully
+qualified class name.
 
+For example:
+
+```bash
+jsonschema2pojo \
+  --source src/main/resources/users.json \
+  --target src/main/java/io/aiven/example \
+  --package io.aiven.example
+```
+
+:::
 
 ## Example schema
 
@@ -57,7 +62,7 @@ Kafka serialization depends on the fully qualified class name.
 This schema generates the following Java file:
 
 ```plaintext
-src/main/java/User.java
+src/main/java/io/aiven/example/User.java
 ```
 
 ## Optional: Add Confluent schema annotation

--- a/docs/products/kafka/howto/generate-protobuf-java-classes.md
+++ b/docs/products/kafka/howto/generate-protobuf-java-classes.md
@@ -33,9 +33,10 @@ in your `.proto` file. Ensure the `package` in your `.proto` file matches your i
 Java package structure.
 
 :::note
-If your `.proto` file does not define a `package`, you may need to update the package
-declaration in the generated Java file so it matches your project's structure.
-Kafka serialization depends on the fully qualified class name.
+To control the Java package of the generated classes, add the option `java_package`
+inside your `.proto` file. This cannot be set through the `protoc` compiler command-line
+options. Kafka serialization depends on the fully qualified class name, so
+ensure the `java_package` matches your project structure.
 :::
 
 ## Example schema
@@ -43,7 +44,8 @@ Kafka serialization depends on the fully qualified class name.
 ```protobuf
 syntax = "proto3";
 
-package io.aiven.example;
+package io.aiven.example.protobuf;
+option java_package = "io.aiven.example.protobuf";
 
 message User {
   int32 id = 1;

--- a/docs/products/kafka/howto/generate-protobuf-java-classes.md
+++ b/docs/products/kafka/howto/generate-protobuf-java-classes.md
@@ -30,8 +30,12 @@ protoc -I=. --java_out=src/main/java/ src/main/resources/example.proto
 
 The generated class is placed inside a directory that matches the `package` declaration
 in your `.proto` file. Ensure the `package` in your `.proto` file matches your intended
-Java package structure. Do not rename the generated class or change its package. Kafka
-serialization relies on the original name and package.
+Java package structure.
+
+:::note
+Do not rename the generated class or change its package declaration. Kafka serialization
+depends on the original name and namespace in the schema.
+:::
 
 ## Example schema
 
@@ -54,8 +58,8 @@ src/main/java/io/aiven/example/User.java
 
 ## Add Maven dependencies
 
-Add these dependencies to your `pom.xml` to compile and use the generated classes with
-Protobuf and Kafka:
+Add these dependencies to your `pom.xml` to compile and use the generated classes for
+Protobuf serialization and deserialization in Kafka producers and consumers.
 
 ```xml
 <dependencies>

--- a/docs/products/kafka/howto/generate-protobuf-java-classes.md
+++ b/docs/products/kafka/howto/generate-protobuf-java-classes.md
@@ -56,7 +56,7 @@ message User {
 This schema produces the following file:
 
 ```plaintext
-src/main/java/io/aiven/example/User.java
+src/main/java/io/aiven/example/protobuf/User.java
 ```
 
 ## Add Maven dependencies

--- a/docs/products/kafka/howto/generate-protobuf-java-classes.md
+++ b/docs/products/kafka/howto/generate-protobuf-java-classes.md
@@ -10,7 +10,7 @@ Generate Java data classes from Protocol Buffers (`.proto`) schema files for use
 ## Prerequisites
 
 - An active [Aiven for Apache Kafka® service](/docs/products/kafka/get-started#create-an-aiven-for-apache-kafka-service)
-- [Karapace Schema Registry](/docs/products/kafka/karapace/concepts/schema-registry-authorization)
+- [Karapace Schema Registry](/docs/products/kafka/karapace/howto/enable-karapace)
   enabled
 - Java (JDK 8 or later)
 - [Apache Maven](https://maven.apache.org/) installed to manage dependencies

--- a/docs/products/kafka/howto/generate-protobuf-java-classes.md
+++ b/docs/products/kafka/howto/generate-protobuf-java-classes.md
@@ -33,8 +33,9 @@ in your `.proto` file. Ensure the `package` in your `.proto` file matches your i
 Java package structure.
 
 :::note
-Do not rename the generated class or change its package declaration. Kafka serialization
-depends on the original name and namespace in the schema.
+If your `.proto` file does not define a `package`, you may need to update the package
+declaration in the generated Java file so it matches your project's structure.
+Kafka serialization depends on the fully qualified class name.
 :::
 
 ## Example schema

--- a/docs/products/kafka/howto/generate-protobuf-java-classes.md
+++ b/docs/products/kafka/howto/generate-protobuf-java-classes.md
@@ -1,0 +1,115 @@
+---
+title: Generate Java data classes from Protobuf schemas
+sidebar_label: Protobuf schema
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Generate Java data classes from Protocol Buffers (`.proto`) schema files for use in Apache Kafka® producers and consumers. Use the `protoc` compiler to generate Java classes that match your schema structure.
+
+## Prerequisites
+
+- An active [Aiven for Apache Kafka® service](/docs/products/kafka/get-started#create-an-aiven-for-apache-kafka-service)
+- [Karapace Schema Registry](/docs/products/kafka/karapace/concepts/schema-registry-authorization)
+  enabled
+- Java (JDK 8 or later)
+- [Apache Maven](https://maven.apache.org/) installed to manage dependencies
+- [`protoc`](https://grpc.io/docs/protoc-installation/) compiler installed
+- A Protobuf schema file (`.proto`)
+
+## Generate the Java class
+
+Generate Java classes from your Protobuf schema file using the `protoc` CLI:
+
+```bash
+protoc -I=. --java_out=src/main/java/ src/main/resources/example.proto
+```
+
+- Replace `example.proto` with your Protobuf schema file.
+- Replace `src/main/java/` with your preferred output directory.
+
+The generated class is placed inside a directory that matches the `package` declaration
+in your `.proto` file. Ensure the `package` in your `.proto` file matches your intended
+Java package structure. Do not rename the generated class or change its package. Kafka
+serialization relies on the original name and package.
+
+## Example schema
+
+```protobuf
+syntax = "proto3";
+
+package io.aiven.example;
+
+message User {
+  int32 id = 1;
+  string email = 2;
+}
+```
+
+This schema produces the following file:
+
+```plaintext
+src/main/java/io/aiven/example/User.java
+```
+
+## Add Maven dependencies
+
+Add these dependencies to your `pom.xml` to compile and use the generated classes with
+Protobuf and Kafka:
+
+```xml
+<dependencies>
+  <!-- Apache Kafka client dependency -->
+  <dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>3.8.1</version>
+  </dependency>
+
+  <!-- Confluent dependencies for Protobuf serialization and Schema Registry -->
+  <dependency>
+    <groupId>io.confluent</groupId>
+    <artifactId>kafka-protobuf-serializer</artifactId>
+    <version>8.0.0</version>
+  </dependency>
+  <dependency>
+    <groupId>io.confluent</groupId>
+    <artifactId>kafka-schema-registry-client</artifactId>
+    <version>8.0.0</version>
+  </dependency>
+
+  <!-- Protobuf core library -->
+  <dependency>
+    <groupId>com.google.protobuf</groupId>
+    <artifactId>protobuf-java</artifactId>
+    <version>4.32.0</version>
+  </dependency>
+</dependencies>
+```
+
+### Optional dependencies
+
+You can also use these optional dependencies depending on your use case:
+
+```xml
+<!-- Support for Protobuf well-known types (e.g., Timestamp, Struct) -->
+<dependency>
+  <groupId>io.confluent</groupId>
+  <artifactId>kafka-protobuf-types</artifactId>
+  <version>8.0.0</version>
+</dependency>
+
+<!-- Provider for advanced Protobuf schema features -->
+<dependency>
+  <groupId>io.confluent</groupId>
+  <artifactId>kafka-protobuf-provider</artifactId>
+  <version>8.0.0</version>
+</dependency>
+```
+
+These dependencies are optional. Use them if your schema includes well-known Protobuf
+types or if you use advanced features in Confluent’s Protobuf support.
+
+<RelatedPages />
+
+[Protobuf Compiler Installation](https://grpc.io/docs/protoc-installation/)

--- a/docs/products/kafka/howto/generate-protobuf-java-classes.md
+++ b/docs/products/kafka/howto/generate-protobuf-java-classes.md
@@ -17,7 +17,7 @@ Generate Java data classes from Protocol Buffers (`.proto`) schema files for use
 - [`protoc`](https://grpc.io/docs/protoc-installation/) compiler installed
 - A Protobuf schema file (`.proto`)
 
-## Generate the Java class
+## Generate the Java classes
 
 Generate Java classes from your Protobuf schema file using the `protoc` CLI:
 

--- a/docs/products/kafka/howto/schema-registry.md
+++ b/docs/products/kafka/howto/schema-registry.md
@@ -15,7 +15,7 @@ To produce and consume Avro messages in Java using the schema registry:
 1. Define your schema.
 1. Generate Java classes from the schema.
 1. Add the required dependencies.
-1. Create a keystore and truststore.
+1. Create a keystore and truststore (if required for your security setup).
 1. Configure your Kafka producer and consumer properties.
 
 ## Prerequisites
@@ -92,18 +92,26 @@ To generate Java classes from Avro, Protobuf, or JSON Schema files, see
 
 ### Manual schema compilation
 
-To compile manually, download`avro-tools-1.11.0.jar` from
+To compile manually, download `avro-tools-1.12.0.jar` from
 [https://avro.apache.org/releases.html](https://avro.apache.org/releases.html) or
 fetch it using Maven:
 
-```
-mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get -Dartifact=org.apache.avro:avro-tools:1.11.0:jar -Ddest=avro-tools-1.11.0.jar
+:::note
+If a newer version of `avro-tools` is available, use that instead of `1.12.0`. To find
+the most recent release, see
+[https://avro.apache.org/releases.html](https://avro.apache.org/releases.html).
+:::
+
+```bash
+mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get \
+  -Dartifact=org.apache.avro:avro-tools:1.12.0:jar \
+  -Ddest=avro-tools-1.12.0.jar
 ```
 
 To compile the schema and generate a Java class, run:
 
 ```
-java -jar avro-tools-1.11.0.jar compile schema ClickRecord.avsc .
+java -jar avro-tools-1.12.0.jar compile schema ClickRecord.avsc .
 ```
 
 This generates a Java file named `ClickRecord.java` in a subdirectory that matches

--- a/docs/products/kafka/howto/schema-registry.md
+++ b/docs/products/kafka/howto/schema-registry.md
@@ -27,8 +27,8 @@ registry:
 <TabItem value="console" label="Aiven Console" default>
 
 - Running **Aiven for Apache Kafka** service
-- [Karapace Schema Registry enabled](/docs/products/kafka/howto/enable-karapace/)
-- [Keystore and truststore files](/docs/tools/keystore-truststore) for SSL authentication
+- [Karapace Schema Registry enabled](/docs/products/kafka/karapace/howto/enable-karapace)
+- [Keystore and truststore files](/docs/products/kafka/howto/keystore-truststore) for SSL authentication
 
 </TabItem> <TabItem value="cli" label="Aiven CLI">
 
@@ -88,7 +88,7 @@ related data types.
 Once the schema is defined, compile it either **manually** or **automatically**.
 
 To generate Java classes from Avro, Protobuf, or JSON Schema files, see
-[Generate Java classes from schemas](/docs/products/kafka/howto/Generate-java-pojo-schemas).
+[Generate Java classes from schemas](/docs/products/kafka/howto/generate-java-classes-from-schemas).
 
 ### Manual schema compilation
 

--- a/docs/products/kafka/howto/schema-registry.md
+++ b/docs/products/kafka/howto/schema-registry.md
@@ -15,7 +15,8 @@ To produce and consume Avro messages in Java using the schema registry:
 1. Define your schema.
 1. Generate Java classes from the schema.
 1. Add the required dependencies.
-1. Create a keystore and truststore (if required for your security setup).
+1. Optional: Create a keystore, and create a truststore only if you use SASL
+   authentication.
 1. Configure your Kafka producer and consumer properties.
 
 ## Prerequisites

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -884,6 +884,19 @@ const sidebars: SidebarsConfig = {
                     'products/kafka/howto/create-topics-automatically',
                     'products/kafka/howto/get-topic-partition-details',
                     'products/kafka/howto/schema-registry',
+                    {
+                      type: 'category',
+                      label: 'Generate Java classes from schemas',
+                      link: {
+                        type: 'doc',
+                        id: 'products/kafka/howto/generate-java-classes-from-schemas',
+                      },
+                      items: [
+                        'products/kafka/howto/generate-avro-java-classes',
+                        'products/kafka/howto/generate-protobuf-java-classes',
+                        'products/kafka/howto/generate-json-java-classes',
+                      ],
+                    },
                     'products/kafka/howto/change-retention-period',
                     {
                       type: 'category',


### PR DESCRIPTION
## Describe your changes

Adds documentation for generating Java classes from Avro, Protobuf, and JSON schemas for use with Kafka and Karapace.

Ref: [POD-1457](https://aiven.atlassian.net/browse/POD-1457)

Preview:  https://pod-1319-docs-new-documentat.aiven-docs.pages.dev/docs/products/kafka/howto/generate-java-classes-from-schemas

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.


[POD-1457]: https://aiven.atlassian.net/browse/POD-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ