### PR TITLE
fix: Redirect links

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -239,11 +239,9 @@
 /tools/terraform/reference/cookbook/kafka-connect-terraform-recipe    /docs/tools/terraform/get-started
 /tools/terraform/reference/troubleshooting                            /docs/tools/terraform
 /tools/terraform/reference/troubleshooting/private-access-error       /docs/tools/terraform
-<<<<<<< HEAD
 /tutorials/anomaly-detection                                          /docs
-=======
 /valkey                                          /docs/products/valkey
->>>>>>> 0eac90a1 (update: unify Snowflake sink connector content)
+
 
 #
 # Redirect to external resources


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
