### PR TITLE
update: Confluent dependency for Avro schema serialization

### DIFF
--- a/docs/products/kafka/howto/generate-avro-java-classes.md
+++ b/docs/products/kafka/howto/generate-avro-java-classes.md
@@ -87,6 +87,11 @@ Avro serialization and deserialization in Kafka producers and consumers.
     <artifactId>kafka-schema-registry-client</artifactId>
     <version>8.0.0</version>
   </dependency>
+  <dependency>
+    <groupId>io.confluent</groupId>
+    <artifactId>kafka-schema-serializer</artifactId>
+    <version>8.0.0</version>
+  </dependency>
 
   <!-- Apache Avro dependency -->
   <dependency>


### PR DESCRIPTION
## Describe your changes

Add missing Confluent dependency for Avro schema serialization

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
