### PR TITLE
fix: m3db CLI redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -228,7 +228,6 @@
 /tools/cli/project                                         /docs/tools/cli
 /tools/cli/service                                         /docs/tools/cli/service-cli
 /tools/cli/service/m3                                      /docs/tools/cli/service-cli#avn-service-metrics
-/tools/cli/service-cli#avn-service-m3                      /docs/tools/cli/service-cli#avn-service-metrics
 /tools/cli/ticket                                          /docs/platform/howto/support
 /tools/terraform/concepts/data-sources                     /docs/tools/terraform
 /tools/terraform/get-started                               /docs/tools/terraform


### PR DESCRIPTION
[JIRA](https://aiven.atlassian.net/browse/DOC-1601)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
