### PR TITLE
fix: link to upstream OS api reference

### DIFF
--- a/docs/products/opensearch.md
+++ b/docs/products/opensearch.md
@@ -78,7 +78,7 @@ and working with your OpenSearch service:
 -   Work with your OpenSearch service
     [using cURL](/docs/products/opensearch/howto/opensearch-with-curl)
 -   Check the [API
-    documentation](https://opensearch.org/docs/opensearch/rest-api/index)
+    documentation](https://docs.opensearch.org/latest/api-reference/)
     for detailed information about the HTTP endpoints.
 -   There's a
     [list of plugins](/docs/products/opensearch/reference/plugins) supported by Aiven for OpenSearch.


### PR DESCRIPTION
https://aiven.atlassian.net/browse/MA-3528

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
