### PR TITLE
fix: BYOC AWS cloud region setting

### DIFF
--- a/docs/platform/howto/byoc/create-cloud/create-aws-custom-cloud.md
+++ b/docs/platform/howto/byoc/create-cloud/create-aws-custom-cloud.md
@@ -633,7 +633,7 @@ Your new custom cloud is ready to use only after its status changes to
      1. Pick a region from the **Cloud** column in the supported
         [AWS cloud regions](/docs/platform/reference/list_of_clouds#amazon-web-services)
         table.
-     1. Drop the `aws-` prefix from the selected region name, for example
+     1. Drop the `aws-` prefix from the selected region name, for example,
         `aws-eu-north-1` > `eu-north-1`.
    - `CIDR_BLOCK` with a CIDR block defining the IP address range of the VPC that Aiven
      creates in your own cloud account, for example: `10.0.0.0/16`, `172.31.0.0/16`, or


### PR DESCRIPTION
[JIRA](https://aiven.atlassian.net/browse/IP-584)

[PREVIEW](https://ip-584-docs-fix-byoc-aws-clo.aiven-docs.pages.dev/docs/platform/howto/byoc/create-cloud/create-aws-custom-cloud#create-a-custom-cloud)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
