### PR TITLE
fix: add more options for accessing and visualizing pg audit logs

### DIFF
--- a/docs/products/postgresql/concepts/pg-audit-logging.md
+++ b/docs/products/postgresql/concepts/pg-audit-logging.md
@@ -169,13 +169,15 @@ For information on all the configuration parameters, preview
 
 ### Collecting and visualizing logs
 
-You can
-[access your collected audit logs](/docs/products/postgresql/howto/use-pg-audit-logging)
-either directly in the log output of your Aiven for PostgreSQL service or by integrating
-with another service that allows monitoring and analyzing logs, such as Aiven for
-OpenSearch®. To
-[visualize your audit logs](/docs/products/postgresql/howto/use-pg-audit-logging), you can
-use [OpenSearch Dashboards](/docs/products/opensearch/dashboards).
+[Access or visualize collected audit logs](/docs/products/postgresql/howto/use-pg-audit-logging)
+using one of the supported methods:
+
+| Methodology | Accessing `pgaudit` logs | Visualizing `pgaudit` logs |
+| :--- | :--- | :---
+| Aiven for PostgreSQL | Log output from Aiven for PostgreSQL®| [OpenSearch Dashboards](/docs/products/opensearch/dashboards) |
+| Aiven-native integration | [Aiven for OpenSearch®](/docs/products/opensearch/)| [OpenSearch Dashboards](/docs/products/opensearch/dashboards) |
+| External integration | Remote Syslog (`rsyslog`) | Third-party platforms: Datadog's Log Explorer, Google Cloud's Logs Explorer, Amazon's CloudWatch Logs, and other Syslog-compatible tools |
+| Aiven for Apache Kafka | Kafka topic in Aiven for Apache Kafka | Requires a separate downstream tool to consume the log data from Aiven for Kafka and provide visualization |
 
 ### Disabling audit logging
 

--- a/docs/products/postgresql/concepts/pg-audit-logging.md
+++ b/docs/products/postgresql/concepts/pg-audit-logging.md
@@ -172,7 +172,7 @@ For information on all the configuration parameters, preview
 [Access and visualize collected audit logs](/docs/products/postgresql/howto/use-pg-audit-logging)
 using one of the supported methods:
 
-| Methodology | Accessing `pgaudit` logs | Visualizing `pgaudit` logs |
+| Integration method | Accessing `pgaudit` logs | Visualizing `pgaudit` logs |
 | :--- | :--- | :--- |
 | Aiven-native integration | [Aiven for OpenSearch®](/docs/products/opensearch/)| [OpenSearch Dashboards](/docs/products/opensearch/dashboards) |
 | External integration | `rsyslog` | Third-party platforms: Datadog, Google Cloud Logging, Amazon CloudWatch Logs, and other syslog-compatible tools |

--- a/docs/products/postgresql/concepts/pg-audit-logging.md
+++ b/docs/products/postgresql/concepts/pg-audit-logging.md
@@ -173,8 +173,7 @@ For information on all the configuration parameters, preview
 using one of the supported methods:
 
 | Methodology | Accessing `pgaudit` logs | Visualizing `pgaudit` logs |
-| :--- | :--- | :---
-| Aiven for PostgreSQL | Log output from Aiven for PostgreSQL®| [OpenSearch Dashboards](/docs/products/opensearch/dashboards) |
+| :--- | :--- | :--- |
 | Aiven-native integration | [Aiven for OpenSearch®](/docs/products/opensearch/)| [OpenSearch Dashboards](/docs/products/opensearch/dashboards) |
 | External integration | `rsyslog` | Third-party platforms: Datadog, Google Cloud Logging, Amazon CloudWatch Logs, and other syslog-compatible tools |
 | Aiven for Apache Kafka | Kafka topic in Aiven for Apache Kafka | Requires a separate downstream tool to consume the log data from Aiven for Kafka and provide visualization |

--- a/docs/products/postgresql/concepts/pg-audit-logging.md
+++ b/docs/products/postgresql/concepts/pg-audit-logging.md
@@ -169,14 +169,14 @@ For information on all the configuration parameters, preview
 
 ### Collecting and visualizing logs
 
-[Access or visualize collected audit logs](/docs/products/postgresql/howto/use-pg-audit-logging)
+[Access and visualize collected audit logs](/docs/products/postgresql/howto/use-pg-audit-logging)
 using one of the supported methods:
 
 | Methodology | Accessing `pgaudit` logs | Visualizing `pgaudit` logs |
 | :--- | :--- | :---
 | Aiven for PostgreSQL | Log output from Aiven for PostgreSQL®| [OpenSearch Dashboards](/docs/products/opensearch/dashboards) |
 | Aiven-native integration | [Aiven for OpenSearch®](/docs/products/opensearch/)| [OpenSearch Dashboards](/docs/products/opensearch/dashboards) |
-| External integration | Remote Syslog (`rsyslog`) | Third-party platforms: Datadog's Log Explorer, Google Cloud's Logs Explorer, Amazon's CloudWatch Logs, and other Syslog-compatible tools |
+| External integration | `rsyslog` | Third-party platforms: Datadog, Google Cloud Logging, Amazon CloudWatch Logs, and other syslog-compatible tools |
 | Aiven for Apache Kafka | Kafka topic in Aiven for Apache Kafka | Requires a separate downstream tool to consume the log data from Aiven for Kafka and provide visualization |
 
 ### Disabling audit logging

--- a/docs/products/postgresql/concepts/pg-audit-logging.md
+++ b/docs/products/postgresql/concepts/pg-audit-logging.md
@@ -174,9 +174,9 @@ using one of the supported methods:
 
 | Integration method | Accessing `pgaudit` logs | Visualizing `pgaudit` logs |
 | :--- | :--- | :--- |
-| Aiven-native integration | [Aiven for OpenSearch®](/docs/products/opensearch/)| [OpenSearch Dashboards](/docs/products/opensearch/dashboards) |
-| External integration | `rsyslog` | Third-party platforms: Datadog, Google Cloud Logging, Amazon CloudWatch Logs, and other syslog-compatible tools |
-| Aiven for Apache Kafka | Kafka topic in Aiven for Apache Kafka | Requires a separate downstream tool to consume the log data from Aiven for Kafka and provide visualization |
+| Aiven for OpenSearch integration | [Aiven for OpenSearch®](/docs/products/opensearch/)| [OpenSearch Dashboards](/docs/products/opensearch/dashboards) |
+| Aiven for Apache Kafka integration | Kafka topic in Aiven for Apache Kafka | Requires a separate downstream tool to consume the log data from Aiven for Kafka and provide visualization |
+| External syslog integration | `rsyslog` | Third-party platforms: Datadog, Google Cloud Logging, Amazon CloudWatch Logs, and other syslog-compatible tools |
 
 ### Disabling audit logging
 

--- a/docs/products/postgresql/howto/use-pg-audit-logging.md
+++ b/docs/products/postgresql/howto/use-pg-audit-logging.md
@@ -278,9 +278,12 @@ Choose one of the
 
 Example: **[OpenSearch Dashboards](/docs/products/opensearch/dashboards/get-started)**
 
-1. Integrate your Aiven for PostgreSQL with Aiven for OpenSearch.
+1. Integrate your Aiven for PostgreSQL with Aiven for OpenSearch.  
+   See [Integrating PostgreSQL with OpenSearch](/docs/products/postgresql/howto/integrate-with-opensearch) or follow the steps above to create the integration.
 1. Go to OpenSearch Dashboards.
-1. Set up **Index Pattern** to match your audit logs index.
+1. Set up an **Index Pattern** in OpenSearch Dashboards to match your audit logs index.  
+   For guidance, see [Create index patterns in OpenSearch Dashboards](https://opensearch.org/docs/latest/dashboards/index-patterns/).  
+   The index name for audit logs typically starts with `avnlog-pg-`.
 1. Filter the audit logs.
    1. Go to **Discover**.
    1. Select your audit logs index pattern.

--- a/docs/products/postgresql/howto/use-pg-audit-logging.md
+++ b/docs/products/postgresql/howto/use-pg-audit-logging.md
@@ -278,15 +278,12 @@ Choose one of the
 
 Example: **[OpenSearch Dashboards](/docs/products/opensearch/dashboards/get-started)**
 
-1. Integrate your Aiven for PostgreSQL with Aiven for OpenSearch.  
-   See
-   [Integrating PostgreSQL with OpenSearch](/docs/products/postgresql/howto/integrate-with-opensearch)
-   or the [Access-your-logs steps](/docs/products/postgresql/howto/use-pg-audit-logging#access-your-logs)
-   to create the integration.
+1. Integrate your Aiven for PostgreSQL with Aiven for OpenSearch by following the steps in
+   [Access-your-logs](/docs/products/postgresql/howto/use-pg-audit-logging#access-your-logs).
 1. Go to OpenSearch Dashboards.
-1. Set up an **Index Pattern** in OpenSearch Dashboards to match your audit logs index.  
+1. Set up an **Index Pattern** in OpenSearch Dashboards to match your audit logs index.
    For guidance, see
-   [Create index patterns in OpenSearch Dashboards](https://opensearch.org/docs/latest/dashboards/index-patterns/).  
+   [Create index patterns in OpenSearch Dashboards](https://opensearch.org/docs/latest/dashboards/index-patterns/).
    The index name for audit logs typically starts with `avnlog-pg-`.
 1. To filter the audit logs:
    1. Go to **Discover**.

--- a/docs/products/postgresql/howto/use-pg-audit-logging.md
+++ b/docs/products/postgresql/howto/use-pg-audit-logging.md
@@ -288,7 +288,7 @@ Example: **[OpenSearch Dashboards](/docs/products/opensearch/dashboards/get-star
    For guidance, see
    [Create index patterns in OpenSearch Dashboards](https://opensearch.org/docs/latest/dashboards/index-patterns/).  
    The index name for audit logs typically starts with `avnlog-pg-`.
-1. Filter the audit logs.
+1. To filter the audit logs:
    1. Go to **Discover**.
    1. Select your audit logs index pattern.
    1. In the filter tool, set the value of `AIVEN_AUDIT_FROM` to `pg`.

--- a/docs/products/postgresql/howto/use-pg-audit-logging.md
+++ b/docs/products/postgresql/howto/use-pg-audit-logging.md
@@ -291,7 +291,7 @@ Example: **[OpenSearch Dashboards](/docs/products/opensearch/dashboards/get-star
 1. Filter the audit logs.
    1. Go to **Discover**.
    1. Select your audit logs index pattern.
-   1. Use the filter tool: Set the value of `AIVEN_AUDIT_FROM` to `pg`.
+   1. In the filter tool, set the value of `AIVEN_AUDIT_FROM` to `pg`.
    1. Apply the filter.
 1. Preview and analyze the logs.
 

--- a/docs/products/postgresql/howto/use-pg-audit-logging.md
+++ b/docs/products/postgresql/howto/use-pg-audit-logging.md
@@ -279,10 +279,14 @@ Choose one of the
 Example: **[OpenSearch Dashboards](/docs/products/opensearch/dashboards/get-started)**
 
 1. Integrate your Aiven for PostgreSQL with Aiven for OpenSearch.  
-   See [Integrating PostgreSQL with OpenSearch](/docs/products/postgresql/howto/integrate-with-opensearch) or follow the steps above to create the integration.
+   See
+   [Integrating PostgreSQL with OpenSearch](/docs/products/postgresql/howto/integrate-with-opensearch)
+   or the [Access-your-logs steps](/docs/products/postgresql/howto/use-pg-audit-logging#access-your-logs)
+   to create the integration.
 1. Go to OpenSearch Dashboards.
 1. Set up an **Index Pattern** in OpenSearch Dashboards to match your audit logs index.  
-   For guidance, see [Create index patterns in OpenSearch Dashboards](https://opensearch.org/docs/latest/dashboards/index-patterns/).  
+   For guidance, see
+   [Create index patterns in OpenSearch Dashboards](https://opensearch.org/docs/latest/dashboards/index-patterns/).  
    The index name for audit logs typically starts with `avnlog-pg-`.
 1. Filter the audit logs.
    1. Go to **Discover**.

--- a/docs/products/postgresql/howto/use-pg-audit-logging.md
+++ b/docs/products/postgresql/howto/use-pg-audit-logging.md
@@ -219,8 +219,10 @@ For more details on how to set up, configure, and use session audit logging, che
 
 ## Access your logs
 
-Access your Aiven for PostgreSQL audit logs by integrating with an Aiven for OpenSearch®
-service, which allows monitoring and analyzing logs.
+Choose one of the
+[tools or methods for accessing, monitoring, or analyzing your audit logs](/docs/products/postgresql/concepts/pg-audit-logging#collecting-and-visualizing-logs).
+
+Example: **Aiven for OpenSearch®**
 
 <Tabs groupId="group1">
 <TabItem value="1" label="Aiven Console" default>
@@ -271,12 +273,20 @@ curl --request POST \
 
 ## Visualize your logs
 
-If your logs are available in Aiven for OpenSearch, use
-[OpenSearch Dashboards](/docs/products/opensearch/dashboards/get-started) to visualize the
-logs.
+Choose one of the
+[tools or methods for visualizing your collected audit logs](/docs/products/postgresql/concepts/pg-audit-logging#collecting-and-visualizing-logs).
 
-To preview your audit logs in OpenSearch Dashboards, use the filtering tool: select
-`AIVEN_AUDIT_FROM`, set its value to `pg`, and apply the filter.
+Example: **[OpenSearch Dashboards](/docs/products/opensearch/dashboards/get-started)**
+
+1. Integrate your Aiven for PostgreSQL with Aiven for OpenSearch.
+1. Go to OpenSearch Dashboards.
+1. Set up **Index Pattern** to match your audit logs index.
+1. Filter the audit logs.
+   1. Go to **Discover**.
+   1. Select your audit logs index pattern.
+   1. Use the filter tool: Set the value of `AIVEN_AUDIT_FROM` to `pg`.
+   1. Apply the filter.
+1. Preview and analyze the logs.
 
 <img src={AuditLogsOpenSearchDashboards} class="image"/>
 


### PR DESCRIPTION
[JIRA](https://aiven.atlassian.net/browse/BF-3575)

- [PREVIEW: CONCEPT](https://bf-3575-docs-pg-audit-docs-i.aiven-docs.pages.dev/docs/products/postgresql/concepts/pg-audit-logging#collecting-and-visualizing-logs)
- [PREVIEW: HOW-TO](https://bf-3575-docs-pg-audit-docs-i.aiven-docs.pages.dev/docs/products/postgresql/howto/use-pg-audit-logging#access-your-logs)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
