### PR TITLE
update: improve howto use aws privatelink

### DIFF
--- a/docs/platform/howto/use-aws-privatelinks.md
+++ b/docs/platform/howto/use-aws-privatelinks.md
@@ -27,7 +27,7 @@ the IP range are not an issue.
 
 To set up AWS PrivateLink, use the
 [Aiven CLI](/docs/tools/cli). You also
-need the [AWS console](https://aws.amazon.com/console) or
+need [AWS Management Console](https://aws.amazon.com/console) or
 [CLI](https://aws.amazon.com/cli) to create a VPC endpoint.
 
 :::note


### PR DESCRIPTION
## Describe your changes
Fixed an outdated link to aws docs and added missing guidance about mandatory vpce security group rule.

## Checklist
- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
