### PR TITLE
update: max number of topics per cluster

### DIFF
--- a/docs/products/kafka/howto/best-practices.md
+++ b/docs/products/kafka/howto/best-practices.md
@@ -27,6 +27,7 @@ start with a low number that supports efficient processing and increase as neede
 
 A maximum of 4,000 partitions per broker and 200,000 per cluster is recommended. For more
 details, see this [Apache Kafka blog post](https://blogsarchive.apache.org/kafka/entry/apache-kafka-supports-more-partitions).
+In addition, the total number of topics per cluster should remain under 7,000.
 
 :::note
 Ordering is only guaranteed within a partition. To maintain the order of related records,


### PR DESCRIPTION
## Describe your changes

Aiven leverages a cache to manage topics in Apache Kafka clusters. In order to guarantee the stability of the service through this cache, a maximum number of 7,000 topics is recommended. A user alert was also created to warn users about too many topics.

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
