### PR TITLE
update: clickhouse resource usage constrains per users

### DIFF
--- a/docs/products/clickhouse/howto/manage-users-roles.md
+++ b/docs/products/clickhouse/howto/manage-users-roles.md
@@ -117,7 +117,7 @@ Configure user settings, for example, to restrict resource use per user. This ca
     SHOW SETTINGS LIKE 'max_threads';
     ```
 
-    This should display the `max_threads` setting with a value of `1` for the `limited_user`.
+    This displays the `max_threads` setting with a value of `1` for the `limited_user`.
 
 #### Set per-query resource limits
 


### PR DESCRIPTION
[JIRA](https://aiven.atlassian.net/browse/DDB-2369)
[DOCS PREVIEW](https://ddb-2369-docs-how-to-constra.aiven-docs.pages.dev/docs/products/clickhouse/howto/manage-users-roles#set-user-resource-limits)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
