### PR TITLE
update: configure a custom domain for Kafka REST endpoints

### DIFF
--- a/docs/products/kafka/howto/configure-custom-domain.md
+++ b/docs/products/kafka/howto/configure-custom-domain.md
@@ -1,0 +1,108 @@
+---
+title: Configure a custom domain for Kafka REST, Schema Registry, and Kafka Connect
+sidebar_label: Configure custom domain
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Configure a custom domain to replace the default Aiven service hostname for Kafka REST API, Schema Registry, and Kafka Connect endpoints.
+
+## About custom domains
+
+Custom domains let you use your own domain name, such as `kafka.example.com`, instead of
+the default Aiven service hostname for REST-based Kafka components.
+
+Supported services include Kafka REST API, Schema Registry, and Kafka Connect.
+
+Custom domains are not supported for Kafka broker endpoints that use the native Kafka
+protocol.
+
+## Prerequisites
+
+- A running Aiven for Apache Kafka service
+- Permission to manage DNS records for your domain
+- Access to the Aiven CLI or Aiven API
+
+## Configure a custom domain
+
+### Step 1: Create a DNS CNAME record
+
+Create a CNAME record for your custom domain in your DNS provider. The record must point
+your custom domain to the Kafka service hostname.
+
+Use one of the following targets:
+
+- `subdomain.mydomain.com` → `project_name-service_name.aivencloud.com`
+- `subdomain.mydomain.com` → `public-project_name-service_name.aivencloud.com`
+
+Choose the target based on whether the service is accessed through private or public
+networking.
+
+### Step 2: Configure the custom domain
+
+Set the custom domain in the Kafka service configuration.
+
+<Tabs groupId="config-methods">
+<TabItem value="cli" label="CLI" default>
+
+Configure the custom domain for the service using the Aiven CLI:
+
+```bash
+avn service update <service-name> \
+  --user-config '{"custom_domain": "subdomain.mydomain.com"}'
+```
+
+Parameters:
+
+- `<service-name>`: Name of your Aiven for Apache Kafka service.
+- `custom_domain`: Custom domain to use for Kafka REST API, Schema Registry, and
+  Kafka Connect endpoints.
+
+</TabItem>
+<TabItem value="api" label="API">
+
+Use the
+[ServiceUpdate](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
+API to configure the custom domain for the service:
+
+```bash
+curl --request PUT \
+  --url https://api.aiven.io/v1/project/YOUR_PROJECT_NAME/service/YOUR_SERVICE_NAME \
+  --header 'Authorization: Bearer YOUR_BEARER_TOKEN' \
+  --header 'content-type: application/json' \
+  --data '{
+    "user_config": {
+      "custom_domain": "subdomain.mydomain.com"
+    }
+  }'
+```
+
+Parameters:
+
+- `YOUR_PROJECT_NAME`: Name of your project.
+- `YOUR_SERVICE_NAME`: Name of your service.
+- `YOUR_BEARER_TOKEN`: API token for authentication.
+- `custom_domain`: Custom domain to use for Kafka REST API, Schema Registry, and Kafka
+  Connect endpoints.
+
+</TabItem>
+</Tabs>
+
+### Step 3: Wait for certificate provisioning
+
+After you configure the custom domain, Aiven automatically requests a TLS certificate
+from Let’s Encrypt.
+
+Certificate provisioning typically completes within a few minutes. No additional action
+is required.
+
+### Step 4: Update client configuration
+
+Update client applications to use the custom domain and the existing service port.
+
+```text
+https://subdomain.mydomain.com:<port>
+```
+
+Use the same port that was previously used with the default Aiven endpoint.

--- a/docs/products/kafka/howto/configure-custom-domain.md
+++ b/docs/products/kafka/howto/configure-custom-domain.md
@@ -1,12 +1,12 @@
 ---
-title: Configure a custom domain for Kafka REST, Schema Registry, and Kafka Connect
+title: Configure a custom domain for Kafka REST API, Schema Registry, and Kafka Connect
 sidebar_label: Configure custom domain
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Configure a custom domain to replace the default Aiven service hostname for Kafka REST API, Schema Registry, and Kafka Connect endpoints.
+Configure a custom domain to replace the default Aiven service hostname for Kafka REST API, Schema Registry, and Kafka Connect.
 
 ## About custom domains
 
@@ -20,7 +20,7 @@ protocol.
 
 ## Prerequisites
 
-- A running Aiven for Apache Kafka service
+- A running Aiven for Apache Kafka® service
 - Permission to manage DNS records for your domain
 - Access to the Aiven CLI or Aiven API
 
@@ -33,11 +33,11 @@ your custom domain to the Kafka service hostname.
 
 Use one of the following targets:
 
-- `subdomain.mydomain.com` → `project_name-service_name.aivencloud.com`
-- `subdomain.mydomain.com` → `public-project_name-service_name.aivencloud.com`
+- `SUBDOMAIN.example.com` → `PROJECT_NAME-SERVICE_NAME.aivencloud.com`:
+   Use this target when the service is accessed through private networking.
 
-Choose the target based on whether the service is accessed through private or public
-networking.
+- `SUBDOMAIN.example.com` → `public-PROJECT_NAME-SERVICE_NAME.aivencloud.com`:
+   Use this target when the service is accessed through public networking.
 
 ### Step 2: Configure the custom domain
 
@@ -46,18 +46,18 @@ Set the custom domain in the Kafka service configuration.
 <Tabs groupId="config-methods">
 <TabItem value="cli" label="CLI" default>
 
-Configure the custom domain for the service using the Aiven CLI:
+Configure the custom domain using Aiven CLI:
 
 ```bash
-avn service update <service-name> \
-  --user-config '{"custom_domain": "subdomain.mydomain.com"}'
+avn service update SERVICE_NAME \
+  --user-config '{"custom_domain": "SUBDOMAIN.example.com"}'
 ```
 
 Parameters:
 
-- `<service-name>`: Name of your Aiven for Apache Kafka service.
-- `custom_domain`: Custom domain to use for Kafka REST API, Schema Registry, and
-  Kafka Connect endpoints.
+- `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
+- `custom_domain`: Custom domain for Kafka REST API, Schema Registry, and
+  Kafka Connect.
 
 </TabItem>
 <TabItem value="api" label="API">
@@ -68,23 +68,23 @@ API to configure the custom domain for the service:
 
 ```bash
 curl --request PUT \
-  --url https://api.aiven.io/v1/project/YOUR_PROJECT_NAME/service/YOUR_SERVICE_NAME \
-  --header 'Authorization: Bearer YOUR_BEARER_TOKEN' \
+  --url https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME \
+  --header 'Authorization: Bearer API_TOKEN' \
   --header 'content-type: application/json' \
   --data '{
     "user_config": {
-      "custom_domain": "subdomain.mydomain.com"
+      "custom_domain": "SUBDOMAIN.example.com"
     }
   }'
 ```
 
 Parameters:
 
-- `YOUR_PROJECT_NAME`: Name of your project.
-- `YOUR_SERVICE_NAME`: Name of your service.
-- `YOUR_BEARER_TOKEN`: API token for authentication.
-- `custom_domain`: Custom domain to use for Kafka REST API, Schema Registry, and Kafka
-  Connect endpoints.
+- `PROJECT_NAME`: Name of your project.
+- `SERVICE_NAME`: Name of your service.
+- `API_TOKEN`: API token for authentication.
+- `custom_domain`: Custom domain for Kafka REST API, Schema Registry, and Kafka
+  Connect.
 
 </TabItem>
 </Tabs>
@@ -102,7 +102,7 @@ is required.
 Update client applications to use the custom domain and the existing service port.
 
 ```text
-https://subdomain.mydomain.com:<port>
+https://SUBDOMAIN.example.com:PORT
 ```
 
-Use the same port that was previously used with the default Aiven endpoint.
+Use the same port as the default Aiven endpoint.

--- a/docs/products/kafka/howto/configure-custom-domain.md
+++ b/docs/products/kafka/howto/configure-custom-domain.md
@@ -28,17 +28,21 @@ protocol.
 
 ### Step 1: Create a DNS CNAME record
 
-Create a CNAME record for your custom domain in your DNS provider. The record must point
-your custom domain to the Kafka service hostname.
+Create a `CNAME` record for your custom domain in your DNS provider.
+Point the record to the Aiven hostname that matches custom domain certificate
+provisioning.
 
-Use one of the following targets:
-
-- `SUBDOMAIN.example.com` → `PROJECT_NAME-SERVICE_NAME.aivencloud.com`:
-   Use this target when the service is accessed through private networking.
+Use the following target:
 
 - `SUBDOMAIN.example.com` → `public-PROJECT_NAME-SERVICE_NAME.aivencloud.com`:
-   Use this target when the service is accessed through public networking.
+  Use this target for public access.
+  Use this target for VPC or other private-network access when you configure
+  `custom_domain`.
+  Aiven creates the certificate for the `public-*` hostname and for your custom
+  domain.
 
+If your service uses a VPC or another private network path, clients can still use the
+custom domain. The `CNAME` target remains `public-PROJECT_NAME-SERVICE_NAME.aivencloud.com`.
 ### Step 2: Configure the custom domain
 
 Set the custom domain in the Kafka service configuration.

--- a/docs/products/kafka/howto/configure-custom-domain.md
+++ b/docs/products/kafka/howto/configure-custom-domain.md
@@ -96,7 +96,7 @@ Parameters:
 ### Step 3: Wait for certificate provisioning
 
 After you configure the custom domain, Aiven automatically requests a TLS certificate
-from Let’s Encrypt.
+from Let's Encrypt.
 
 Certificate provisioning typically completes within a few minutes. No additional action
 is required.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -885,6 +885,7 @@ const sidebars: SidebarsConfig = {
                     'products/kafka/howto/enable-schema-registry',
                     'products/kafka/howto/configure-with-kafka-cli',
                     'products/kafka/howto/set-kafka-parameters',
+                    'products/kafka/howto/configure-custom-domain',
                     'products/kafka/howto/viewing-resetting-offset',
                     'products/kafka/howto/configure-log-cleaner',
                     'products/kafka/howto/prevent-full-disks',


### PR DESCRIPTION
## Describe your changes

Document how to configure a custom domain for Kafka REST endpoints.

Preview: https://doc-1726-document-how-to-con.aiven-docs.pages.dev/docs/products/kafka/howto/configure-custom-domain

[DOC-1726](https://aiven.atlassian.net/browse/DOC-1726)


## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.


[DOC-1726]: https://aiven.atlassian.net/browse/DOC-1726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ