### PR TITLE
update: service naming restrictions in compose files

### DIFF
--- a/docs/products/apps/manifest-files/compose-files.md
+++ b/docs/products/apps/manifest-files/compose-files.md
@@ -50,8 +50,8 @@ and Aiven for OpenSearch®.
 You define the service type and version with the `image` property.
 Service names must:
 
-- Consist of lowercase letters a-z, numbers 0-9, and `-`
-- Begin with a letter
+- Consist only of lowercase letters a-z, numbers 0-9, and `-`
+- Begin with a lowercase letter
 - Be between 1 and 64 characters in length
 
 The following examples show how to specify the image for each supported service.

--- a/docs/products/apps/manifest-files/compose-files.md
+++ b/docs/products/apps/manifest-files/compose-files.md
@@ -47,8 +47,14 @@ Aiven Apps automatically detects and creates the following data services based
 on Docker image names: Aiven for Apache Kafka®, Aiven for PostgreSQL®, Aiven for Valkey™,
 and Aiven for OpenSearch®.
 
-You define the service type and version with the `image` property. The following examples
-show how to specify the image for each supported service.
+You define the service type and version with the `image` property.
+Service names must:
+
+- Consist of lowercase letters a-z, numbers 0-9, and `-`
+- Begin with a letter
+- Be between 1 and 64 characters in length
+
+The following examples show how to specify the image for each supported service.
 
 #### Kafka
 


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
