### PR TITLE
feat: developer tier for Apache Kafka

### DIFF
--- a/docs/platform/concepts/service-pricing.md
+++ b/docs/platform/concepts/service-pricing.md
@@ -94,7 +94,7 @@ instance size.
 Developer tier plans, pricing, and limits vary by product. Each subsection describes
 one offering; for complete specifications, see the linked product pages.
 
-#### Aiven for PostgreSQL® and Aiven for MySQL®
+#### Aiven for PostgreSQL and Aiven for MySQL
 
 The Developer tier is available for Aiven for PostgreSQL® and Aiven for MySQL® services,
 letting you scale up your service in a cost-effective way. Services on this Developer tier

--- a/docs/platform/concepts/service-pricing.md
+++ b/docs/platform/concepts/service-pricing.md
@@ -91,8 +91,13 @@ instance size.
 
 ### Developer tier
 
-The Developer tier is available for Aiven for PostgreSQL® and Aiven for MySQL services,
-letting you scale up your service in a cost-effective way. Services on the Developer tier
+Developer tier plans, pricing, and limits vary by product. Each subsection describes
+one offering; for complete specifications, see the linked product pages.
+
+#### Aiven for PostgreSQL® and Aiven for MySQL®
+
+The Developer tier is available for Aiven for PostgreSQL® and Aiven for MySQL® services,
+letting you scale up your service in a cost-effective way. Services on this Developer tier
 are not automatically powered off if they're inactive.
 
 The Developer tier includes:
@@ -116,7 +121,13 @@ Limitations of the Developer tier are:
 -   For PostgreSQL: `max_connections` limit set to `20`
 
 Aiven reserves the right to change the cloud provider, region, or configuration
-of Developer tier services at any point in time.
+of these Developer tier services at any point in time.
+
+#### Aiven for Apache Kafka®
+
+Aiven for Apache Kafka® has a separate [Developer tier](/docs/products/kafka/dev-tier/kafka-dev-tier)
+paid plan for development and testing, with its own throughput, storage, retention, and
+pricing.
 
 ### Custom plans
 

--- a/docs/platform/concepts/service-pricing.md
+++ b/docs/platform/concepts/service-pricing.md
@@ -91,14 +91,13 @@ instance size.
 
 ### Developer tier
 
-Developer tier plans, pricing, and limits vary by product. Each subsection describes
-one offering; for complete specifications, see the linked product pages.
+Developer tier plans, pricing, and limits vary by product. Developer tier services are
+not automatically powered off when inactive.
 
 #### Aiven for PostgreSQL and Aiven for MySQL
 
 The Developer tier is available for Aiven for PostgreSQL® and Aiven for MySQL® services,
-letting you scale up your service in a cost-effective way. Services on this Developer tier
-are not automatically powered off if they're inactive.
+letting you scale up your service in a cost-effective way.
 
 The Developer tier includes:
 

--- a/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
+++ b/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
@@ -7,11 +7,9 @@ keywords: [create, kafka, developer tier]
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Create an Aiven for Apache Kafka® Developer tier **Classic** service when throughput,
-topics, retention, or storage exceed [Free tier](/docs/products/kafka/free-tier/kafka-free-tier)
-limits, or when you use Kafka Connect or integrations excluded from the Free tier.
-
-For quotas, pricing, and features, see
+Create an Aiven for Apache Kafka® Developer tier **Classic** service when throughput, topic limits, retention, or storage exceed the[Free tier](/docs/products/kafka/free-tier/kafka-free-tier).
+Use it to run Kafka Connect or integrations that are not available on the Free tier. For
+quotas, pricing, and features, see
 [Aiven for Apache Kafka® Developer tier](/docs/products/kafka/dev-tier/kafka-dev-tier).
 
 ## Prerequisites
@@ -58,13 +56,17 @@ When the status changes to **Running**, your Kafka service is ready to use.
 
 ## Create a Developer tier service using Skills
 
-Skills install automation that creates and configures the Kafka service through the CLI.
+Use Skills to create and configure the Kafka service from the command line.
 
 1. Install the Skills bundle:
 
    ```bash
    npx skills add Aiven-Open/aiven-skills-bundle
    ```
+
+   If your tool supports Skills, you can also invoke them through AI-enabled tools such as
+   Claude Code, Cursor, or Copilot Chat by describing the task, for example:
+   `Create a test Kafka service in Aiven`.
 
 1. Run the Kafka service creation Skill:
 
@@ -97,18 +99,21 @@ After the service status is **Running**:
 - **Define topics**: Stay within
   [Developer tier limits](/docs/products/kafka/dev-tier/kafka-dev-tier#limits-and-specifications).
   See [Create a Kafka topic](/docs/products/kafka/howto/create-topic).
-- **Run connectors**: Up to two connectors per service on the dedicated Connect node. See
-  [Get started with Aiven for Apache Kafka Connect](/docs/products/kafka/kafka-connect/get-started)
-  and [list of available connectors](/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins).
+- **Run connectors**: Add an [Aiven for Apache Kafka Connect](/docs/products/kafka/kafka-connect/get-started)
+  service and integrate it with this Kafka service. See
+  [list of available connectors](/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins).
 
 ## Upgrade the service
 
-Upgrade to a higher **Professional** tier plan when quotas or features exceed Developer tier
-limits.
+Upgrade to a higher **Professional** tier plan when quotas or features exceed Developer
+tier limits.
 
-If you use **Kafka Connect** on the same service, upgrade Kafka and Connect in the order
-described in
-[Upgrade Kafka with integrated Kafka Connect](/docs/products/kafka/dev-tier/kafka-dev-tier#upgrade-kafka-with-integrated-kafka-connect).
+For upgrade paths between Free, Developer, and **Professional** tiers, see
+[Upgrade path](/docs/products/kafka/dev-tier/kafka-dev-tier#upgrade-path).
+
+If you use a **Kafka Connect** service integrated with this Kafka service, upgrade Kafka
+and Connect in the order described in
+[Upgrade Kafka with Kafka Connect](/docs/products/kafka/dev-tier/kafka-dev-tier#upgrade-kafka-with-kafka-connect).
 
 To upgrade from the service overview:
 

--- a/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
+++ b/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
@@ -106,6 +106,10 @@ After the service status is **Running**:
 Upgrade to a higher **Professional** tier plan when quotas or features exceed Developer tier
 limits.
 
+If you use **Kafka Connect** on the same service, upgrade Kafka and Connect in the order
+described in
+[Upgrade Kafka with integrated Kafka Connect](/docs/products/kafka/dev-tier/kafka-dev-tier#upgrade-kafka-with-integrated-kafka-connect).
+
 To upgrade from the service overview:
 
 1. Open your service's <ConsoleLabel name="overview" /> page.

--- a/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
+++ b/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
@@ -115,6 +115,12 @@ If you use a **Kafka Connect** service integrated with this Kafka service, upgra
 and Connect in the order described in
 [Upgrade Kafka with Kafka Connect](/docs/products/kafka/dev-tier/kafka-dev-tier#upgrade-kafka-with-kafka-connect).
 
+:::note
+Before you upgrade this Kafka service, power off any connected **Kafka Connect** service
+on **Professional** tier. A **Professional** Kafka Connect service cannot run with a
+**Developer** tier Kafka service during the upgrade transition.
+:::
+
 To upgrade from the service overview:
 
 1. Open your service's <ConsoleLabel name="overview" /> page.

--- a/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
+++ b/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
@@ -7,7 +7,7 @@ keywords: [create, kafka, developer tier]
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Create an Aiven for Apache Kafka® Developer tier **Classic** service when throughput, topic limits, retention, or storage exceed the[Free tier](/docs/products/kafka/free-tier/kafka-free-tier).
+Create an Aiven for Apache Kafka® Developer tier **Classic** service when throughput, topic limits, retention, or storage exceed the [Free tier](/docs/products/kafka/free-tier/kafka-free-tier).
 Use it to run Kafka Connect or integrations that are not available on the Free tier. For
 quotas, pricing, and features, see
 [Aiven for Apache Kafka® Developer tier](/docs/products/kafka/dev-tier/kafka-dev-tier).

--- a/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
+++ b/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
@@ -7,7 +7,7 @@ keywords: [create, kafka, developer tier]
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Create an Aiven for Apache Kafka® Developer tier **Classic** service when throughput, topic limits, retention, or storage exceed the [Free tier](/docs/products/kafka/free-tier/kafka-free-tier).
+Create an Aiven for Apache Kafka® Developer tier Classic Kafka service when throughput, topic limits, retention, or storage exceed the [Free tier](/docs/products/kafka/free-tier/kafka-free-tier).
 Use it to run Kafka Connect or integrations that are not available on the Free tier. For
 quotas, pricing, and features, see
 [Aiven for Apache Kafka® Developer tier](/docs/products/kafka/dev-tier/kafka-dev-tier).
@@ -16,15 +16,17 @@ quotas, pricing, and features, see
 
 - An Aiven account. Sign up or sign in using the [Aiven Console](https://console.aiven.io).
 - A project where you can create paid services.
-- For paid charges, billing set up for your organization if you use billing groups or
-  payment methods on file. See [Billing and payment](/docs/platform/concepts/billing-and-payment).
+- If you use paid services, set up billing for your organization. See
+  [Billing and payment](/docs/platform/concepts/billing-and-payment).
+- To create the service with Skills, install the [Aiven CLI](/docs/tools/cli) and
+  authenticate. You also need [Node.js](https://nodejs.org/) to run `npx` commands.
 
 ## Choose how to create the service
 
-Create a Developer tier service using one of the following:
+Use one of the following:
 
-- **Aiven Console**: guided setup.
-- **Skills**: CLI-driven setup with `npx` and the Aiven CLI.
+- **Aiven Console**: guided setup in the browser.
+- **Skills**: command-line setup with `npx` and the Aiven CLI.
 
 ## Create a Developer tier service using the Aiven Console
 
@@ -35,8 +37,8 @@ Create a Developer tier service using one of the following:
 1. Choose your **Region**.
 
    :::note
-   On Developer tier, you select a region only. The Console indicates that you can choose
-   a specific cloud provider on the **Professional** tier.
+   On the Developer tier, you can select a region only. To choose a specific cloud
+   provider, you need the Professional tier.
    :::
 
 1. In **Retention**, select a retention period between **1 day** and **7 days**.
@@ -77,9 +79,10 @@ Use Skills to create and configure the Kafka service from the command line.
 1. Follow the prompts to select your project, **Developer** tier, and **region** options.
 
    :::note
-   On **Developer** tier, the console collects a **region** only. Cloud selection is
-   available on **Professional** tier plans. The Skill can still prompt for cloud and region
-   so the CLI can place the service. Select the options the Skill lists for Developer tier.
+   When you create a Developer tier service in the Aiven Console, you only choose a
+   **region**. On **Professional** tier plans, you can also choose the cloud provider. The
+   Skill can still ask for **cloud** and **region** so the CLI can create the service.
+   Select the options the Skill lists for Developer tier.
    :::
 
 The Skill creates and configures the service. When the run completes, the Kafka service is
@@ -88,60 +91,67 @@ ready to use.
 For the full Skills workflow, see
 [Set up Aiven for Apache Kafka® using Skills](/docs/products/kafka/howto/set-up-kafka-with-skills).
 
-## After service creation
+## After you create the service
 
-After the service status is **Running**:
+When the service status is **Running**, you can:
 
-- **Connect a client**: Open **Quick connect** on the service for connection parameters and
-  sample code. See [Connect to Aiven for Apache Kafka®](/docs/products/kafka/howto/list-code-samples).
-- **Run sample workload**: Use the sample data generator for produce and consume checks. See
+- **Connect a client**: On your service's <ConsoleLabel name="overview" /> page, open
+  **Quick connect** for connection details and sample code. See
+  [Connect to Aiven for Apache Kafka®](/docs/products/kafka/howto/list-code-samples).
+- **Run a sample workload**: Use the sample data generator to test produce and consume
+  operations. See
   [Generate sample data for Aiven for Apache Kafka®](/docs/products/kafka/howto/generate-sample-data).
-- **Define topics**: Stay within
+- **Create topics**: Keep topic and partition counts within the
   [Developer tier limits](/docs/products/kafka/dev-tier/kafka-dev-tier#limits-and-specifications).
   See [Create a Kafka topic](/docs/products/kafka/howto/create-topic).
 - **Run connectors**: Add an [Aiven for Apache Kafka Connect](/docs/products/kafka/kafka-connect/get-started)
-  service and integrate it with this Kafka service. See
+  service and integrate it with your Kafka service. See the
   [list of available connectors](/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins).
 
 ## Upgrade the service
 
-Upgrade to a higher **Professional** tier plan when quotas or features exceed Developer
-tier limits.
+Upgrade to a Professional tier plan when Developer tier limits no longer meet
+your needs. For upgrade paths between Free, Developer, and Professional tiers,
+see [Upgrade path](/docs/products/kafka/dev-tier/kafka-dev-tier#upgrade-path).
 
-For upgrade paths between Free, Developer, and **Professional** tiers, see
-[Upgrade path](/docs/products/kafka/dev-tier/kafka-dev-tier#upgrade-path).
+You can upgrade from the service overview or from service settings.
 
-If you use a **Kafka Connect** service integrated with this Kafka service, upgrade Kafka
-and Connect in the order described in
-[Upgrade Kafka with Kafka Connect](/docs/products/kafka/dev-tier/kafka-dev-tier#upgrade-kafka-with-kafka-connect).
+### Before you upgrade
 
-:::note
-Before you upgrade this Kafka service, power off any connected **Kafka Connect** service
-on **Professional** tier. A **Professional** Kafka Connect service cannot run with a
-**Developer** tier Kafka service during the upgrade transition.
-:::
+If your Kafka service is integrated with a Kafka Connect service, power off the
+Kafka Connect service before you upgrade the Kafka service. You cannot upgrade the
+Kafka service while an integrated Kafka Connect service is powered on.
 
-To upgrade from the service overview:
+After you upgrade the Kafka service, upgrade the Kafka Connect service to the
+same tier before you power it back on. Both services must stay on the same
+tier.
+
+For details, see
+[Kafka and Kafka Connect tier compatibility](/docs/products/kafka/dev-tier/kafka-dev-tier#kafka-and-kafka-connect-tier-compatibility).
+
+### Upgrade from the service overview
 
 1. Open your service's <ConsoleLabel name="overview" /> page.
 1. In **Service usage**, click **Upgrade**.
+1. Select **Professional**, choose a cloud provider, region, and plan, and then
+   click **Upgrade service**.
 
-Or upgrade from service settings:
+### Upgrade from service settings
 
 1. In your service, click <ConsoleLabel name="servicesettings" />.
 1. In **Service summary**, click **Upgrade**.
-1. Select **Professional**, choose a cloud provider, region, and plan, then click
-   **Upgrade service**.
+1. Select **Professional**, choose a cloud provider, region, and plan, and then
+   click **Upgrade service**.
 
-Upgrades from Free tier to Developer tier stay on the same service. Upgrades to
-Professional tier follow the console steps for cloud, region, and plan.
+### Limitations
 
-:::note
-Downgrading from Developer tier to Free tier is not supported. After you upgrade to
-**Professional** tier, returning to Developer tier depends on the plan. Use the
-[Aiven Console](https://console.aiven.io) to review allowed plan changes. See
+- Downgrading from Developer tier to Free tier is not supported.
+- After you upgrade to Professional tier, the downgrade options available to
+  you depend on the plan you chose. To review supported plan changes, use the
+  [Aiven Console](https://console.aiven.io).
+
+For more information, see
 [Aiven for Apache Kafka® Developer tier](/docs/products/kafka/dev-tier/kafka-dev-tier).
-:::
 
 <RelatedPages />
 

--- a/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
+++ b/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
@@ -1,0 +1,136 @@
+---
+title: Create an Aiven for Apache Kafka® Developer tier service
+sidebar_label: Create Developer tier service
+keywords: [create, kafka, developer tier]
+---
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Create an Aiven for Apache Kafka® Developer tier **Classic** service when throughput,
+topics, retention, or storage exceed [Free tier](/docs/products/kafka/free-tier/kafka-free-tier)
+limits, or when you use Kafka Connect or integrations excluded from the Free tier.
+
+For quotas, pricing, and features, see
+[Aiven for Apache Kafka® Developer tier](/docs/products/kafka/dev-tier/kafka-dev-tier).
+
+## Prerequisites
+
+- An Aiven account. Sign up or sign in using the [Aiven Console](https://console.aiven.io).
+- A project where you can create paid services.
+- For paid charges, billing set up for your organization if you use billing groups or
+  payment methods on file. See [Billing and payment](/docs/platform/concepts/billing-and-payment).
+
+## Choose how to create the service
+
+Create a Developer tier service using one of the following:
+
+- **Aiven Console**: guided setup.
+- **Skills**: CLI-driven setup with `npx` and the Aiven CLI.
+
+## Create a Developer tier service using the Aiven Console
+
+1. In your project, click <ConsoleLabel name="services" />.
+1. Click **Create service**.
+1. Select **Aiven for Apache Kafka®**.
+1. In **Service tier**, select **Developer**.
+1. Choose your **Region**.
+
+   :::note
+   On Developer tier, you select a region only. The Console indicates that you can choose
+   a specific cloud provider on the **Professional** tier.
+   :::
+
+1. In **Retention**, select a retention period between **1 day** and **7 days**.
+
+   :::note
+   The base price includes 1 day of data retention.
+
+   You can increase retention to 3, 5, or 7 days. Each additional 2 days adds
+   $10 USD per month.
+   :::
+
+1. In **Service basics**, enter a **Service name**.
+1. Review the **Service summary** and estimated monthly cost.
+1. Click **Create service**.
+
+When the status changes to **Running**, your Kafka service is ready to use.
+
+## Create a Developer tier service using Skills
+
+Skills install automation that creates and configures the Kafka service through the CLI.
+
+1. Install the Skills bundle:
+
+   ```bash
+   npx skills add Aiven-Open/aiven-skills-bundle
+   ```
+
+1. Run the Kafka service creation Skill:
+
+   ```bash
+   npx skills run kafka-create-service
+   ```
+
+1. Follow the prompts to select your project, **Developer** tier, and **region** options.
+
+   :::note
+   On **Developer** tier, the console collects a **region** only. Cloud selection is
+   available on **Professional** tier plans. The Skill can still prompt for cloud and region
+   so the CLI can place the service. Select the options the Skill lists for Developer tier.
+   :::
+
+The Skill creates and configures the service. When the run completes, the Kafka service is
+ready to use.
+
+For the full Skills workflow, see
+[Set up Aiven for Apache Kafka® using Skills](/docs/products/kafka/howto/set-up-kafka-with-skills).
+
+## After service creation
+
+After the service status is **Running**:
+
+- **Connect a client**: Open **Quick connect** on the service for connection parameters and
+  sample code. See [Connect to Aiven for Apache Kafka®](/docs/products/kafka/howto/list-code-samples).
+- **Run sample workload**: Use the sample data generator for produce and consume checks. See
+  [Generate sample data for Aiven for Apache Kafka®](/docs/products/kafka/howto/generate-sample-data).
+- **Define topics**: Stay within
+  [Developer tier limits](/docs/products/kafka/dev-tier/kafka-dev-tier#limits-and-specifications).
+  See [Create a Kafka topic](/docs/products/kafka/howto/create-topic).
+- **Run connectors**: Up to two connectors per service on the dedicated Connect node. See
+  [Get started with Aiven for Apache Kafka Connect](/docs/products/kafka/kafka-connect/get-started)
+  and [list of available connectors](/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins).
+
+## Upgrade the service
+
+Upgrade to a higher **Professional** tier plan when quotas or features exceed Developer tier
+limits.
+
+To upgrade from the service overview:
+
+1. Open your service's <ConsoleLabel name="overview" /> page.
+1. In **Service usage**, click **Upgrade**.
+
+Or upgrade from service settings:
+
+1. In your service, click <ConsoleLabel name="servicesettings" />.
+1. In **Service summary**, click **Upgrade**.
+1. Select **Professional**, choose a cloud provider, region, and plan, then click
+   **Upgrade service**.
+
+Upgrades from Free tier to Developer tier stay on the same service. Upgrades to
+Professional tier follow the console steps for cloud, region, and plan.
+
+:::note
+Downgrading from Developer tier to Free tier is not supported. After you upgrade to
+**Professional** tier, returning to Developer tier depends on the plan. Use the
+[Aiven Console](https://console.aiven.io) to review allowed plan changes. See
+[Aiven for Apache Kafka® Developer tier](/docs/products/kafka/dev-tier/kafka-dev-tier).
+:::
+
+<RelatedPages />
+
+- [Developer tier overview](/docs/products/kafka/dev-tier/kafka-dev-tier)
+- [Connect to Aiven for Apache Kafka®](/docs/products/kafka/howto/list-code-samples)
+- [Generate sample data for Aiven for Apache Kafka®](/docs/products/kafka/howto/generate-sample-data)
+- [Create a Kafka topic](/docs/products/kafka/howto/create-topic)

--- a/docs/products/kafka/dev-tier/kafka-dev-tier.md
+++ b/docs/products/kafka/dev-tier/kafka-dev-tier.md
@@ -6,29 +6,28 @@ keywords: [kafka developer tier, kafka dev tier, kafka paid development, kafka p
 
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Aiven for Apache Kafka® **Developer tier** is a paid **Classic** Apache Kafka® plan for building, testing, and early stage application development.
-It sits between the [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) and
-Professional tier plans.
+Aiven for Apache Kafka® **Developer tier** is a paid **Classic** plan that sits between the [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) and Professional tier plans.
+It provides higher throughput, topic limits, and retention than the Free tier. Each
+service includes Karapace Schema Registry and the REST Proxy.
 
-The service uses the same managed Kafka implementation as other Classic plans, so
-configuration and connection patterns remain consistent across tiers.
+[Service integrations](/docs/platform/concepts/service-integration) are supported where the Developer tier allows them. [Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started) is available as a separate service.
 
-Each service includes Karapace Schema Registry, the REST Proxy, and Aiven for Apache Kafka®
-Connect. Capacity, pricing, and limits are listed in
-[Limits and specifications](#limits-and-specifications).
+Capacity, pricing, and limits are listed in [Limits and specifications](#limits-and-specifications).
 
-Manage the service using the [Aiven Console](https://console.aiven.io), the
-[Aiven CLI](/docs/tools/cli), or the API. You can also use Skills on Developer
-and Professional tier services.
+The service uses the same managed Kafka implementation as other Classic plans, so configuration and connection patterns remain consistent across tiers.
+
+Manage the service using the [Aiven Console](https://console.aiven.io), the [Aiven CLI](/docs/tools/cli), or the API. You can also use Skills on Developer and Professional tier services.
+
 
 ## When to use the Developer tier
 
 Use the Developer tier when:
 
-- Throughput, topic count, retention, or storage exceed
+- Throughput, topic limits, retention, or storage exceed
   [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) limits.
-- You need Apache Kafka® Connect or [service integrations](/docs/platform/concepts/service-integration),
-  which are not available on the Free tier.
+- You need a paid Aiven for Apache Kafka® Connect service (integrated with your cluster)
+  or [service integrations](/docs/platform/concepts/service-integration), which are not
+  available on the Free tier.
 - You want to move beyond the Free tier for development or testing without using a
   production-grade Professional plan.
 
@@ -36,11 +35,12 @@ Use the Developer tier when:
 
 The Developer tier includes:
 
-- Apache Kafka® on three nodes (1 CPU, 4 GB RAM per node).
+- Apache Kafka® on two nodes with fixed compute and storage resources.
 - Karapace Schema Registry.
 - REST Proxy.
-- Aiven for Apache Kafka® Connect on a dedicated node with up to two connectors per
-  service.
+- Optional, separately billed
+  [Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started) as a
+  standalone service integrated with your cluster.
 - [Service integrations](/docs/platform/concepts/service-integration) where this tier
   supports them.
 - Prometheus-compatible metrics through a [Prometheus integration](/docs/platform/howto/integrations/prometheus-metrics).
@@ -72,17 +72,17 @@ The following applies to Developer tier services.
 
 | Specification | Developer tier |
 |-------------------------------|----------------|
-| Price | $49 USD/month; includes 3 nodes and 1 day retention |
+| Price | $29 USD/month, includes 2 nodes and 1 day retention |
 | Throughput | 1 MB/s ingress / 2 MB/s egress |
 | Topics | Up to 20 |
 | Partitions | Up to 100 total across topics |
-| Retention | 1-7 days; 1 day included; +$10 USD per 2 days |
-| Storage | 50 GB |
+| Retention | 1-7 days, 1 day included, +$10 USD per 2 days |
+| Storage | Fixed local storage per node |
 | SLA | 99% |
 | Kafka services per organization | Up to 5 |
-| Kafka Connect | Yes; max 2 connectors on a dedicated node |
-| Cloud provider | Region only in the Console; cloud selection available on Professional plans |
-| Service integrations | Yes |
+| Kafka Connect | Optional add-on (paid) |
+| Cloud provider | Console: region only, Professional: full cloud/region |
+| Service integrations | Yes, with limitations |
 | Upgrade | To a Professional plan in the Console |
 | Downgrade to free tier | Not supported |
 
@@ -93,14 +93,15 @@ For higher throughput, storage, retention, or connector limits, upgrade the serv
 
 | Feature | Free | Developer | Professional |
 |--------|------|-----------|--------------|
-| Price | $0 | $49/month | Varies by plan |
-| Throughput | Up to 250 KiB/s ingress/egress | 1 MB/s ingress / 2 MB/s egress | Higher, plan-dependent |
+| Price | $0 | $29/month | Varies by plan |
+| Throughput | Up to 250 KiB/s ingress and egress | 1 MB/s ingress, 2 MB/s egress | Higher, plan-dependent |
 | Topics | Up to 5 | Up to 20 | Plan-dependent |
 | Partitions | 1 per topic | Up to 100 total | Plan-dependent |
 | Retention | Fixed | 1—7 days | Plan-dependent |
-| Storage | Fixed | 50 GB | Plan-dependent |
+| Storage | Fixed | Fixed local storage per node | Plan-dependent |
 | SLA | None | 99% | Up to 99.99%, plan-dependent |
-| Kafka Connect | Not supported | Up to 2 connectors | Full support, plan-dependent |
+| Kafka Connect | Not supported | Optional (paid) | Full support, plan-dependent |
+| Service integrations | No | Yes, with limitations | Yes, plan-dependent |
 | Cloud selection | Fixed | Region only | Cloud and region selectable |
 
 ## Upgrade path
@@ -119,10 +120,10 @@ and plan size can differ by tier.
 
 ### Upgrade Kafka with Kafka Connect
 
-When your Developer tier Kafka service uses the included
-[Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started),
-the Kafka service and Kafka Connect must stay on compatible plans. Follow this order
-when upgrading:
+When your Developer tier Kafka project includes an
+[Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started) service
+integrated with your Kafka service, the two services must stay on compatible plans. Follow
+this order when upgrading:
 
 1. **Upgrade the Kafka service before Kafka Connect.** Kafka Connect cannot move to a
    higher plan while Kafka is still on Developer tier.

--- a/docs/products/kafka/dev-tier/kafka-dev-tier.md
+++ b/docs/products/kafka/dev-tier/kafka-dev-tier.md
@@ -6,143 +6,140 @@ keywords: [kafka developer tier, kafka dev tier, kafka paid development, kafka p
 
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Aiven for Apache Kafka® **Developer tier** is a paid **Classic** plan between the [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) and Professional tier plans.
-It provides higher throughput, topic limits, and retention than the Free tier. Each
-service includes Karapace Schema Registry and the REST Proxy.
-
-[Service integrations](/docs/platform/concepts/service-integration) are supported where
-the Developer tier supports them.
+Aiven for Apache Kafka® **Developer tier** is a paid **Classic Kafka** plan that sits between the [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) and Professional tier.
+Use it for development, prototyping, or test workloads that need more throughput, more
+topics, longer retention, more storage, or
+[service integrations](/docs/platform/concepts/service-integration) than the Free tier
+provides, without committing to a Professional plan.
 [Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started) is
-available from Developer tier onward as a separate service.
+available as a separately billed add-on.
 
 For capacity, pricing, and service limits, see
 [Limits and specifications](#limits-and-specifications).
-
-Manage the service using the [Aiven Console](https://console.aiven.io), the
-[Aiven CLI](/docs/tools/cli), or the API. Skills are supported on Developer and
-Professional tier services.
 
 ## When to use the Developer tier
 
 Use the Developer tier when:
 
-- Throughput, topic limits, retention, or storage exceed
-  [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) limits.
-- You need a paid Aiven for Apache Kafka® Connect service (integrated with your cluster)
-  or [service integrations](/docs/platform/concepts/service-integration), which are not
-  available on the Free tier.
-- You want to move beyond the Free tier for development or testing without using a
-  production-grade Professional plan.
+- You need higher throughput, more topics, longer retention, or more storage than the
+  [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) offers.
+- You need a paid Aiven for Apache Kafka® Connect service or
+  [service integrations](/docs/platform/concepts/service-integration), neither of which
+  is available on the Free tier.
+- You want a paid environment for development or testing without committing to a
+  Professional plan.
 
 ## What the Developer tier includes
 
-The Developer tier includes:
+A Developer tier service includes:
 
-- Apache Kafka® on two nodes with fixed compute and storage resources.
-- Karapace Schema Registry.
-- REST Proxy.
-- Optional, separately billed
-  [Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started) as a
-  standalone service integrated with your cluster.
-- [Service integrations](/docs/platform/concepts/service-integration) where this tier
+- Apache Kafka® on two nodes with fixed compute and storage.
+- Karapace Schema Registry and REST Proxy.
+- A sample data generator in the console for testing producers and consumers.
+- Quick connect from the Kafka service overview page in the Aiven Console using
+  **Set up your Stream** or **Connection information** to get connection parameters and
+  sample client code. For details,
+  see [Connect to Aiven for Apache Kafka®](/docs/products/kafka/howto/list-code-samples).
+- Prometheus-compatible metrics through a
+  [Prometheus integration](/docs/platform/howto/integrations/prometheus-metrics). For
+  the available metrics, see
+  [Aiven for Apache Kafka® metrics available via Prometheus](/docs/products/kafka/reference/kafka-metrics-prometheus).
+- Optional [Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started),
+  available as a standalone service that integrates with your cluster and is billed
+  separately.
+- [Service integrations](/docs/platform/concepts/service-integration), where this tier
   supports them.
-- Prometheus-compatible metrics through a [Prometheus integration](/docs/platform/howto/integrations/prometheus-metrics).
-  See [Aiven for Apache Kafka® metrics available via Prometheus](/docs/products/kafka/reference/kafka-metrics-prometheus).
-- **Quick connect** on the Kafka service using **Set up your stream** or **Connection information**
-  for connection parameters and sample client code. See
-  [Connect to Aiven for Apache Kafka®](/docs/products/kafka/howto/list-code-samples).
-- A sample data generator in the console for produce and consume tests.
 
-## Use Skills to automate workflows
+### Automate workflows with Skills
 
-**Skills** are ready-to-run workflows that automate common Kafka tasks. Run them with the
-Aiven CLI and `npx`, or through integrations that invoke the same commands.
+**Skills** are ready-to-run workflows that automate common Kafka tasks, such as:
 
-With Skills, you can:
+- Creating a Kafka service and configuring it end to end.
+- Creating topics, users, and permissions.
+- Generating sample data and validating the deployment.
+- Configuring connectors and integrations.
 
-- Create a Kafka service and configure it end-to-end.
-- Create topics, users, and permissions.
-- Generate sample data and validate the deployment.
-- Configure connectors and integrations.
-
-Create Free tier Kafka services in the console. Skills are available on Developer and
-Professional tier services. See
+Skills are available on Developer tier and Professional tier services. You run them
+through the Aiven CLI, or with `npx` if you use Node.js. For details, see
 [Set up Aiven for Apache Kafka® using Skills](/docs/products/kafka/howto/set-up-kafka-with-skills).
+
+Manage Developer tier services from the [Aiven Console](https://console.aiven.io), the
+[Aiven CLI](/docs/tools/cli), or the [Aiven API](/docs/tools/api).
 
 ## Limits and specifications
 
-The following applies to Developer tier services.
+The following specifications apply to Developer tier services.
 
-| Specification | Developer tier |
-|-------------------------------|----------------|
-| Price | $29 USD/month, includes 2 nodes and 1 day retention |
-| Throughput | 1 MB/s ingress / 2 MB/s egress |
-| Topics | Up to 20 |
-| Partitions | Up to 100 total across topics |
-| Retention | 1-7 days, 1 day included, +$10 USD per 2 days |
-| Storage | Fixed local storage per node |
-| SLA | 99% |
-| Kafka services per organization | Up to 5 |
-| Kafka Connect | Optional add-on (paid) |
-| Cloud provider | Region selection in the console |
-| Service integrations | Yes, with limitations |
-| Upgrade | To a Professional plan in the Console |
-| Downgrade to free tier | Not supported |
+| Specification                   | Developer tier                                            |
+|---------------------------------|-----------------------------------------------------------|
+| Price                           | $29 per month, includes 2 nodes and 1 day of retention    |
+| Throughput                      | 1 MB/s ingress, 2 MB/s egress                             |
+| Topics                          | Up to 20                                                  |
+| Partitions                      | Up to 100 total across topics                             |
+| Retention                       | 1 to 7 days; 1 day included, +$10 per additional 2 days   |
+| Storage                         | Fixed local storage per node                              |
+| Kafka services per organization | Up to 5                                                   |
+| Kafka Connect                   | Optional add-on, billed separately                        |
+| Cloud provider                  | Region selection in the console                           |
+| Service integrations            | Yes, with limitations                                     |
+| Upgrade                         | To a Professional plan from the Aiven Console             |
+| Downgrade to Free tier          | Not supported                                             |
 
-For higher throughput, storage, retention, or connector limits, upgrade the service to a
-**Professional** plan in the [Aiven Console](https://console.aiven.io).
+For higher throughput, storage, retention, or connector limits, upgrade your service to
+a Professional plan in the [Aiven Console](https://console.aiven.io).
 
 ## Compare service tiers
 
-| Feature | Free | Developer | Professional |
-|--------|------|-----------|--------------|
-| Price | $0 | $29/month | Varies by plan |
-| Throughput | Up to 250 KiB/s ingress and egress | 1 MB/s ingress, 2 MB/s egress | Higher, plan-dependent |
-| Topics | Up to 5 | Up to 20 | Plan-dependent |
-| Partitions | 1 per topic | Up to 100 total | Plan-dependent |
-| Retention | Fixed | 1—7 days | Plan-dependent |
-| Storage | Fixed | Fixed local storage per node | Plan-dependent |
-| SLA | None | 99% | Up to 99.99%, plan-dependent |
-| Kafka Connect | Not supported | Optional (paid) | Full support, plan-dependent |
-| Service integrations | No | Yes, with limitations | Yes, plan-dependent |
-| Cloud selection | Fixed | Region only | Cloud and region selectable |
+| Feature              | Free                              | Developer                     | Professional                 |
+|----------------------|-----------------------------------|-------------------------------|------------------------------|
+| Price                | $0                                | $29 per month                 | Varies by plan               |
+| Throughput           | Up to 250 KB/s ingress and egress | 1 MB/s ingress, 2 MB/s egress | Higher, plan-dependent       |
+| Topics               | Up to 5                           | Up to 20                      | Plan-dependent               |
+| Partitions           | 1 per topic                       | Up to 100 total               | Plan-dependent               |
+| Retention            | Fixed                             | 1 to 7 days                   | Plan-dependent               |
+| Storage              | Fixed                             | Fixed local storage per node  | Plan-dependent               |
+| SLA                  | None                              | 99%                           | Up to 99.99%, plan-dependent |
+| Kafka Connect        | Not supported                     | Optional, billed separately   | Full support, plan-dependent |
+| Service integrations | Not supported                     | Yes, with limitations         | Yes, plan-dependent          |
+| Cloud selection      | Fixed                             | Region only                   | Cloud and region selectable  |
 
 ## Upgrade path
 
-Upgrade paths:
+You can upgrade from Free tier to Developer tier, or from Developer tier to Professional
+tier. Upgrade to Developer tier for higher limits, Kafka Connect support, and
+integrations. Upgrade to Professional tier for higher throughput, storage, topic limits,
+and SLA.
 
-- Upgrade from Free tier to Developer tier
-- Upgrade from Developer tier to Professional tier
+Your service configuration is preserved when you upgrade. The cloud, region, and plan
+options available to you can differ by tier.
 
-Upgrade from Free tier to increase capacity and enable connectors and integrations.
-Upgrade to Professional tier for higher throughput, storage, topic limits, and SLA.
+### Kafka and Kafka Connect tier compatibility
 
-Your service configuration remains consistent as you upgrade. Available cloud, region, and
-plan options can differ by tier.
+Aiven for Apache Kafka® and Aiven for Apache Kafka® Connect services that are
+integrated with each other must run on the same service tier. Both services must
+be on the Developer tier, or both must be on the Professional tier. A Kafka
+service and its integrated Kafka Connect service cannot run on different tiers.
 
-### Upgrade Kafka with Kafka Connect
+Within a tier, the two services do not need to use the same plan. For example, a
+Professional tier Kafka service on `business-8` can be integrated with a
+Professional tier Kafka Connect service on `startup-4`.
 
-When your Developer tier Kafka service includes an
-[Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started) service
-integrated with it, the two services must stay on compatible plans. Follow this order
-when upgrading:
+This compatibility requirement affects how you upgrade integrated services:
 
-1. Upgrade the Kafka service before the Kafka Connect service. The Kafka Connect
-   service cannot move to a higher plan while the Kafka service is still on Developer tier.
-1. Power off the Kafka Connect service before you change the Kafka service plan.
-   The Kafka Connect service must be powered off before you can upgrade the Kafka
-   service plan.
-1. After the Kafka service is on the new plan, upgrade the Kafka Connect service, then
-   power it on.** If the Kafka service is on a higher plan but the Kafka Connect service
-   is not, you cannot power it on.
+- Upgrade the Kafka service first. Kafka Connect cannot move to Professional
+  until Kafka is also on Professional.
+- Power off Kafka Connect before changing the Kafka service tier. Powering off
+  Kafka Connect preserves the service and its configuration.
+- After Kafka is upgraded, upgrade Kafka Connect to the same tier before
+  powering it on again.
 
-Powering off Kafka Connect preserves the service and configuration. Make sure both
-services use the same plan before powering Kafka Connect on again.
+For the steps to perform an upgrade, see
+[Upgrade the service](/docs/products/kafka/dev-tier/create-dev-tier-kafka-service#upgrade-the-service).
 
 :::note
-You cannot move a Developer tier service back to the Free tier. After you upgrade to
-Professional tier, whether you can move back to Developer tier depends on the service plan.
-Use the [Aiven Console](https://console.aiven.io) to view allowed changes for your service.
+Developer tier services cannot be downgraded to Free tier. Professional tier
+downgrade options depend on the current plan and the changes available in the
+[Aiven Console](https://console.aiven.io).
 :::
 
 <RelatedPages/>

--- a/docs/products/kafka/dev-tier/kafka-dev-tier.md
+++ b/docs/products/kafka/dev-tier/kafka-dev-tier.md
@@ -1,0 +1,130 @@
+---
+title: Aiven for Apache Kafka® Developer tier
+sidebar_label: Developer tier overview
+keywords: [kafka developer tier, kafka dev tier, kafka paid development, kafka prototype]
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Aiven for Apache Kafka® **Developer tier** is a paid **Classic** Apache Kafka® plan for building, testing, and early stage application development.
+It sits between the [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) and
+Professional tier plans.
+
+The service uses the same managed Kafka implementation as other Classic plans, so
+configuration and connection patterns remain consistent across tiers.
+
+Each service includes Karapace Schema Registry, the REST Proxy, and Aiven for Apache Kafka®
+Connect. Capacity, pricing, and limits are listed in
+[Limits and specifications](#limits-and-specifications).
+
+Manage the service using the [Aiven Console](https://console.aiven.io), the
+[Aiven CLI](/docs/tools/cli), or the API. You can also use Skills on Developer
+and Professional tier services.
+
+## When to use the Developer tier
+
+Use the Developer tier when:
+
+- Throughput, topic count, retention, or storage exceed
+  [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) limits.
+- You need Apache Kafka® Connect or [service integrations](/docs/platform/concepts/service-integration),
+  which are not available on the Free tier.
+- You want to move beyond the Free tier for development or testing without using a
+  production-grade Professional plan.
+
+## What the Developer tier includes
+
+The Developer tier includes:
+
+- Apache Kafka® on three nodes (1 CPU, 4 GB RAM per node).
+- Karapace Schema Registry.
+- REST Proxy.
+- Aiven for Apache Kafka® Connect on a dedicated node with up to two connectors per
+  service.
+- [Service integrations](/docs/platform/concepts/service-integration) where this tier
+  supports them.
+- Prometheus-compatible metrics through a [Prometheus integration](/docs/platform/howto/integrations/prometheus-metrics).
+  See [Aiven for Apache Kafka® metrics available via Prometheus](/docs/products/kafka/reference/kafka-metrics-prometheus).
+- **Quick connect** on the Kafka service using **Set up your stream** or **Connection information**
+  for connection parameters and sample client code. See
+  [Connect to Aiven for Apache Kafka®](/docs/products/kafka/howto/list-code-samples).
+- A sample data generator in the console for produce and consume tests.
+
+## Use Skills to automate workflows
+
+**Skills** are ready-to-run workflows that automate common Kafka tasks. Run them with the
+Aiven CLI and `npx`, or through integrations that invoke the same commands.
+
+With Skills, you can:
+
+- Create a Kafka service and configure it end to end.
+- Create topics, users, and permissions.
+- Generate sample data and validate the deployment.
+- Configure connectors and integrations.
+
+Create Free tier Kafka services in the console. Skills are available on Developer and
+Professional tier services. See
+[Set up Aiven for Apache Kafka® using Skills](/docs/products/kafka/howto/set-up-kafka-with-skills).
+
+## Limits and specifications
+
+The following applies to Developer tier services.
+
+| Specification | Developer tier |
+|-------------------------------|----------------|
+| Price | $49 USD/month; includes 3 nodes and 1 day retention |
+| Throughput | 1 MB/s ingress / 2 MB/s egress |
+| Topics | Up to 20 |
+| Partitions | Up to 100 total across topics |
+| Retention | 1-7 days; 1 day included; +$10 USD per 2 days |
+| Storage | 50 GB |
+| SLA | 99% |
+| Kafka services per organization | Up to 5 |
+| Kafka Connect | Yes; max 2 connectors on a dedicated node |
+| Cloud provider | Region only in the Console; cloud selection available on Professional plans |
+| Service integrations | Yes |
+| Upgrade | To a Professional plan in the Console |
+| Downgrade to free tier | Not supported |
+
+For higher throughput, storage, retention, or connector limits, upgrade the service to a
+**Professional** plan in the [Aiven Console](https://console.aiven.io).
+
+## Compare service tiers
+
+| Feature | Free | Developer | Professional |
+|--------|------|-----------|--------------|
+| Price | $0 | $49/month | Varies by plan |
+| Throughput | Up to 250 KiB/s ingress/egress | 1 MB/s ingress / 2 MB/s egress | Higher, plan-dependent |
+| Topics | Up to 5 | Up to 20 | Plan-dependent |
+| Partitions | 1 per topic | Up to 100 total | Plan-dependent |
+| Retention | Fixed | 1—7 days | Plan-dependent |
+| Storage | Fixed | 50 GB | Plan-dependent |
+| SLA | None | 99% | Up to 99.99%, plan-dependent |
+| Kafka Connect | Not supported | Up to 2 connectors | Full support, plan-dependent |
+| Cloud selection | Fixed | Region only | Cloud and region selectable |
+
+## Upgrade path
+
+Upgrade paths:
+
+- From Free tier to Developer tier in place.
+- From Developer tier to **Professional** tier in the Aiven Console.
+
+Upgrade from Free tier to increase capacity and enable connectors and integrations.
+Upgrade to Professional tier for higher throughput, storage, topic limits, and SLA.
+
+Developer tier uses the same managed Kafka implementation as Professional tier services, so
+configuration remains consistent when you upgrade. Available options such as cloud, region,
+and plan size can differ by tier.
+
+:::note
+You cannot move a Developer tier service back to the Free tier. After you upgrade to
+Professional tier, whether you can move back to Developer tier depends on the service plan.
+Use the [Aiven Console](https://console.aiven.io) to view allowed changes for your service.
+:::
+
+<RelatedPages/>
+
+- [Create an Aiven for Apache Kafka® Developer tier service](/docs/products/kafka/dev-tier/create-dev-tier-kafka-service)
+- [Manage Apache Kafka® parameters](/docs/products/kafka/howto/set-kafka-parameters)
+- [Apache Kafka® upgrade procedure](/docs/products/kafka/concepts/upgrade-procedure)

--- a/docs/products/kafka/dev-tier/kafka-dev-tier.md
+++ b/docs/products/kafka/dev-tier/kafka-dev-tier.md
@@ -54,7 +54,7 @@ A Developer tier service includes:
 
 **Skills** are ready-to-run workflows that automate common Kafka tasks, such as:
 
-- Creating a Kafka service and configuring it end to end.
+- Creating a Kafka service and configuring it end-to-end.
 - Creating topics, users, and permissions.
 - Generating sample data and validating the deployment.
 - Configuring connectors and integrations.

--- a/docs/products/kafka/dev-tier/kafka-dev-tier.md
+++ b/docs/products/kafka/dev-tier/kafka-dev-tier.md
@@ -57,7 +57,7 @@ Aiven CLI and `npx`, or through integrations that invoke the same commands.
 
 With Skills, you can:
 
-- Create a Kafka service and configure it end to end.
+- Create a Kafka service and configure it end-to-end.
 - Create topics, users, and permissions.
 - Generate sample data and validate the deployment.
 - Configure connectors and integrations.
@@ -81,7 +81,7 @@ The following applies to Developer tier services.
 | SLA | 99% |
 | Kafka services per organization | Up to 5 |
 | Kafka Connect | Optional add-on (paid) |
-| Cloud provider | Console: region only, Professional: full cloud/region |
+| Cloud provider | Region selection in the console |
 | Service integrations | Yes, with limitations |
 | Upgrade | To a Professional plan in the Console |
 | Downgrade to free tier | Not supported |

--- a/docs/products/kafka/dev-tier/kafka-dev-tier.md
+++ b/docs/products/kafka/dev-tier/kafka-dev-tier.md
@@ -6,18 +6,21 @@ keywords: [kafka developer tier, kafka dev tier, kafka paid development, kafka p
 
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Aiven for Apache Kafka® **Developer tier** is a paid **Classic** plan that sits between the [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) and Professional tier plans.
+Aiven for Apache Kafka® **Developer tier** is a paid **Classic** plan between the [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) and Professional tier plans.
 It provides higher throughput, topic limits, and retention than the Free tier. Each
 service includes Karapace Schema Registry and the REST Proxy.
 
-[Service integrations](/docs/platform/concepts/service-integration) are supported where the Developer tier allows them. [Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started) is available as a separate service.
+[Service integrations](/docs/platform/concepts/service-integration) are supported where
+the Developer tier supports them.
+[Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started) is
+available from Developer tier onward as a separate service.
 
-Capacity, pricing, and limits are listed in [Limits and specifications](#limits-and-specifications).
+For capacity, pricing, and service limits, see
+[Limits and specifications](#limits-and-specifications).
 
-The service uses the same managed Kafka implementation as other Classic plans, so configuration and connection patterns remain consistent across tiers.
-
-Manage the service using the [Aiven Console](https://console.aiven.io), the [Aiven CLI](/docs/tools/cli), or the API. You can also use Skills on Developer and Professional tier services.
-
+Manage the service using the [Aiven Console](https://console.aiven.io), the
+[Aiven CLI](/docs/tools/cli), or the API. Skills are supported on Developer and
+Professional tier services.
 
 ## When to use the Developer tier
 
@@ -108,29 +111,30 @@ For higher throughput, storage, retention, or connector limits, upgrade the serv
 
 Upgrade paths:
 
-- From Free tier to Developer tier in place.
-- From Developer tier to **Professional** tier in the Aiven Console.
+- Upgrade from Free tier to Developer tier
+- Upgrade from Developer tier to Professional tier
 
 Upgrade from Free tier to increase capacity and enable connectors and integrations.
 Upgrade to Professional tier for higher throughput, storage, topic limits, and SLA.
 
-Developer tier uses the same managed Kafka implementation as Professional tier services, so
-configuration remains consistent when you upgrade. Available options such as cloud, region,
-and plan size can differ by tier.
+Your service configuration remains consistent as you upgrade. Available cloud, region, and
+plan options can differ by tier.
 
 ### Upgrade Kafka with Kafka Connect
 
-When your Developer tier Kafka project includes an
+When your Developer tier Kafka service includes an
 [Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started) service
-integrated with your Kafka service, the two services must stay on compatible plans. Follow
-this order when upgrading:
+integrated with it, the two services must stay on compatible plans. Follow this order
+when upgrading:
 
-1. **Upgrade the Kafka service before Kafka Connect.** Kafka Connect cannot move to a
-   higher plan while Kafka is still on Developer tier.
-1. **Power off Kafka Connect before you change the Kafka plan.** Kafka Connect must be
-   off before you can upgrade the Kafka service plan.
-1. **After Kafka is on the new plan, upgrade Kafka Connect, then power it on.** If Kafka
-   is on a higher plan but Kafka Connect is not, you cannot power it on.
+1. Upgrade the Kafka service before the Kafka Connect service. The Kafka Connect
+   service cannot move to a higher plan while the Kafka service is still on Developer tier.
+1. Power off the Kafka Connect service before you change the Kafka service plan.
+   The Kafka Connect service must be powered off before you can upgrade the Kafka
+   service plan.
+1. After the Kafka service is on the new plan, upgrade the Kafka Connect service, then
+   power it on.** If the Kafka service is on a higher plan but the Kafka Connect service
+   is not, you cannot power it on.
 
 Powering off Kafka Connect preserves the service and configuration. Make sure both
 services use the same plan before powering Kafka Connect on again.

--- a/docs/products/kafka/dev-tier/kafka-dev-tier.md
+++ b/docs/products/kafka/dev-tier/kafka-dev-tier.md
@@ -117,6 +117,23 @@ Developer tier uses the same managed Kafka implementation as Professional tier s
 configuration remains consistent when you upgrade. Available options such as cloud, region,
 and plan size can differ by tier.
 
+### Upgrade Kafka with Kafka Connect
+
+When your Developer tier Kafka service uses the included
+[Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started),
+the Kafka service and Kafka Connect must stay on compatible plans. Follow this order
+when upgrading:
+
+1. **Upgrade the Kafka service before Kafka Connect.** Kafka Connect cannot move to a
+   higher plan while Kafka is still on Developer tier.
+1. **Power off Kafka Connect before you change the Kafka plan.** Kafka Connect must be
+   off before you can upgrade the Kafka service plan.
+1. **After Kafka is on the new plan, upgrade Kafka Connect, then power it on.** If Kafka
+   is on a higher plan but Kafka Connect is not, you cannot power it on.
+
+Powering off Kafka Connect preserves the service and configuration. Make sure both
+services use the same plan before powering Kafka Connect on again.
+
 :::note
 You cannot move a Developer tier service back to the Free tier. After you upgrade to
 Professional tier, whether you can move back to Developer tier depends on the service plan.

--- a/docs/products/kafka/get-started/get-started-kafka.md
+++ b/docs/products/kafka/get-started/get-started-kafka.md
@@ -22,21 +22,24 @@ For limits, regions, and supported features, see the
 - Basic Kafka workflows are supported, including service creation and sample data
   generation.
 
-**Next step:** [Create a Kafka service using the Free tier](/docs/products/kafka/free-tier/create-free-tier-kafka-service).
+**Continue with:** [Create a Kafka service using the Free tier](/docs/products/kafka/free-tier/create-free-tier-kafka-service).
 
 ## Developer tier
 
-Developer tier is a paid **Classic** plan with higher throughput limits, topic count, and
-retention than the Free tier. Each service includes Apache Kafka® Connect, Karapace Schema
-Registry, REST Proxy, and supported
-[service integrations](/docs/platform/concepts/service-integration).
+The Developer tier is a paid **Classic** plan with higher throughput, topic limits, and
+retention than the
+[Free tier](/docs/products/kafka/free-tier/kafka-free-tier). Each service includes
+Karapace Schema Registry and the REST Proxy.
+[Service integrations](/docs/platform/concepts/service-integration) are supported where
+the Developer tier allows them. [Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started)
+is available as a separate service.
 
 Manage the service in the console, CLI, API, or with
 [Skills](/docs/products/kafka/howto/set-up-kafka-with-skills). See
 [Aiven for Apache Kafka® Developer tier](/docs/products/kafka/dev-tier/kafka-dev-tier)
 for quotas, pricing, metrics export, and upgrades.
 
-**Next step:** [Create an Aiven for Apache Kafka® Developer tier service](/docs/products/kafka/dev-tier/create-dev-tier-kafka-service).
+**Continue with:** [Create an Aiven for Apache Kafka® Developer tier service](/docs/products/kafka/dev-tier/create-dev-tier-kafka-service).
 
 ## Create an Inkless Kafka service
 
@@ -50,7 +53,7 @@ of fixed hardware plans.
   and cost.
 - On BYOC, select the BYOC environment, region, and an Inkless plan.
 
-**Next step:** [Create an Inkless Kafka service](/docs/products/kafka/get-started/create-inkless-service).
+**Continue with:** [Create an Inkless Kafka service](/docs/products/kafka/get-started/create-inkless-service).
 
 ## Create a Classic Kafka service
 
@@ -62,26 +65,30 @@ supported plans and cloud providers.
 - Select a plan that defines compute, memory, and storage.
 - Optionally adjust disk capacity, enable tiered storage, and select the Kafka version.
 
-**Next step:** [Create a Classic Kafka service](/docs/products/kafka/get-started/create-classic-kafka-service).
+**Continue with:** [Create a Classic Kafka service](/docs/products/kafka/get-started/create-classic-kafka-service).
 
 ## Set up a Kafka service using Skills
 
-Skills script **Classic** Kafka provisioning for brokers, topics, ACLs, Karapace Schema
-Registry, and Java producer and consumer samples. Invoke the bundled commands with `npx`
-and the [Aiven CLI](/docs/tools/cli), or call the same commands from an automation layer.
+Use Skills to create and configure a Kafka service from the command line.
 
-**Before you begin:**
+Install the Aiven Skills bundle:
+
+```bash
+npx skills add Aiven-Open/aiven-skills-bundle
+```
+
+To run this command, make sure you have the following:
 
 - [Aiven CLI](/docs/tools/cli) installed and authenticated.
 - Node.js installed so `npm` provides `npx`.
 
 :::note
-Skills operate on **Developer** and **Professional** tier services. Create
-[Free tier](/docs/products/kafka/free-tier/kafka-free-tier) Kafka services in the console.
-Skills create services through the CLI.
+Skills operate on **Developer** and **Professional** tier services.
+Create [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) Kafka services in the
+console.
 :::
 
-**Next step:** [Set up Kafka using Skills](/docs/products/kafka/howto/set-up-kafka-with-skills).
+**Continue with:** [Set up Kafka using Skills](/docs/products/kafka/howto/set-up-kafka-with-skills).
 
 ## Generate sample data using the console
 
@@ -92,7 +99,7 @@ the service is working.
 - Consume messages from the topic to verify connectivity.
 - Validate access control, networking, and client configuration.
 
-**Next step:** [Generate sample data in the console](/docs/products/kafka/howto/generate-sample-data).
+**After your service is running, continue with:** [Generate sample data in the console](/docs/products/kafka/howto/generate-sample-data).
 
 ## Generate data manually (optional)
 
@@ -103,7 +110,7 @@ Produce data manually to test application integrations or custom workloads.
   container-based utilities.
 - Use this approach for development, automation, or advanced testing scenarios.
 
-**Next step:** [Generate sample data manually with Docker](/docs/products/kafka/howto/generate-sample-data-manually).
+**After your service is running, continue with:** [Generate sample data manually with Docker](/docs/products/kafka/howto/generate-sample-data-manually).
 
 ## Create and manage Kafka using AI assistants
 
@@ -115,4 +122,4 @@ clients such as Cursor, Claude Code, and VS Code.
 - Describe the service or operation you want in natural language.
 - The assistant creates and manages Kafka resources through the Aiven API.
 
-**Next step:** [Set up the Aiven MCP server](/docs/tools/mcp-server).
+**Continue with:** [Set up the Aiven MCP server](/docs/tools/mcp-server).

--- a/docs/products/kafka/get-started/get-started-kafka.md
+++ b/docs/products/kafka/get-started/get-started-kafka.md
@@ -3,7 +3,8 @@ title: Get started with Aiven for Apache Kafka®
 sidebar_label: Get started
 ---
 
-Create a managed Apache Kafka® service on Aiven, explore the Free tier, and send sample data to validate end-to-end streaming in minutes.
+Create a managed Apache Kafka® service on Aiven, use the Free tier where it fits your workload,
+and send sample data to verify end-to-end streaming.
 
 ## Prerequisites
 
@@ -22,6 +23,20 @@ For limits, regions, and supported features, see the
   generation.
 
 **Next step:** [Create a Kafka service using the Free tier](/docs/products/kafka/free-tier/create-free-tier-kafka-service).
+
+## Developer tier
+
+Developer tier is a paid **Classic** plan with higher throughput limits, topic count, and
+retention than the Free tier. Each service includes Apache Kafka® Connect, Karapace Schema
+Registry, REST Proxy, and supported
+[service integrations](/docs/platform/concepts/service-integration).
+
+Manage the service in the console, CLI, API, or with
+[Skills](/docs/products/kafka/howto/set-up-kafka-with-skills). See
+[Aiven for Apache Kafka® Developer tier](/docs/products/kafka/dev-tier/kafka-dev-tier)
+for quotas, pricing, metrics export, and upgrades.
+
+**Next step:** [Create an Aiven for Apache Kafka® Developer tier service](/docs/products/kafka/dev-tier/create-dev-tier-kafka-service).
 
 ## Create an Inkless Kafka service
 
@@ -48,6 +63,25 @@ supported plans and cloud providers.
 - Optionally adjust disk capacity, enable tiered storage, and select the Kafka version.
 
 **Next step:** [Create a Classic Kafka service](/docs/products/kafka/get-started/create-classic-kafka-service).
+
+## Set up a Kafka service using Skills
+
+Skills script **Classic** Kafka provisioning for brokers, topics, ACLs, Karapace Schema
+Registry, and Java producer and consumer samples. Invoke the bundled commands with `npx`
+and the [Aiven CLI](/docs/tools/cli), or call the same commands from an automation layer.
+
+**Before you begin:**
+
+- [Aiven CLI](/docs/tools/cli) installed and authenticated.
+- Node.js installed so `npm` provides `npx`.
+
+:::note
+Skills operate on **Developer** and **Professional** tier services. Create
+[Free tier](/docs/products/kafka/free-tier/kafka-free-tier) Kafka services in the console.
+Skills create services through the CLI.
+:::
+
+**Next step:** [Set up Kafka using Skills](/docs/products/kafka/howto/set-up-kafka-with-skills).
 
 ## Generate sample data using the console
 

--- a/docs/products/kafka/get-started/get-started-kafka.md
+++ b/docs/products/kafka/get-started/get-started-kafka.md
@@ -25,13 +25,13 @@ For limits, regions, and supported features, see the
 
 ## Developer tier
 
-The Developer tier is a paid **Classic** plan with higher throughput, topic limits, and
-retention than the
+The Developer tier is a paid Classic Kafka plan with higher throughput, topic limits,
+and retention than the
 [Free tier](/docs/products/kafka/free-tier/kafka-free-tier). Each service includes
 Karapace Schema Registry and the REST Proxy.
-[Service integrations](/docs/platform/concepts/service-integration) are supported where
-the Developer tier allows them. [Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started)
-is available as a separate service.
+[Service integrations](/docs/platform/concepts/service-integration) are supported with
+limitations on the Developer tier. [Aiven for Apache Kafka® Connect](/docs/products/kafka/kafka-connect/get-started)
+is available as a separately billed service.
 
 Manage the service in the console, CLI, API, or with
 [Skills](/docs/products/kafka/howto/set-up-kafka-with-skills). See

--- a/docs/products/kafka/get-started/get-started-kafka.md
+++ b/docs/products/kafka/get-started/get-started-kafka.md
@@ -3,8 +3,7 @@ title: Get started with Aiven for Apache Kafka®
 sidebar_label: Get started
 ---
 
-Create a managed Apache Kafka® service on Aiven, use the Free tier where it fits your workload,
-and send sample data to verify end-to-end streaming.
+Create a managed Apache Kafka® service on Aiven, use the Free tier where it fits your workload, and send sample data to verify end-to-end streaming.
 
 ## Prerequisites
 
@@ -84,8 +83,8 @@ To run this command, make sure you have the following:
 
 :::note
 Skills operate on **Developer** and **Professional** tier services.
-Create [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) Kafka services in the
-console.
+Create [Free tier](/docs/products/kafka/free-tier/kafka-free-tier) Kafka services in
+the console.
 :::
 
 **Continue with:** [Set up Kafka using Skills](/docs/products/kafka/howto/set-up-kafka-with-skills).

--- a/docs/products/kafka/howto/set-kafka-parameters.md
+++ b/docs/products/kafka/howto/set-kafka-parameters.md
@@ -14,14 +14,14 @@ end-to-end example of how to manage Aiven for Apache Kafka® parameters.
 :::
 
 You can read and edit these configuration properties in the Advanced
-configuration section of the Overview page in [Aiven web
-console](https://console.aiven.io/) or using the
+configuration section of the Overview page in the [Aiven
+Console](https://console.aiven.io/) or using the
 [Aiven CLI service update command](/docs/tools/cli/service-cli#avn-cli-service-update).
 
 :::warning
 Most of the Apache Kafka settings cause the service to restart when
 changed. Aiven for Apache Kafka restarts nodes one at a time to ensure
-minimal disruption to service availability. However, it can take few
+minimal disruption to service availability. However, it can take a few
 minutes from the change before the new settings are in use.
 :::
 
@@ -38,8 +38,8 @@ The output is the JSON representation of the service configuration.
 
 ## Retrieve the customizable parameters with Aiven CLI
 
-Not all Aiven for Apache Kafka parameters are customizable, to retrieve
-the list of those parameters you can change use the following command:
+Not all Aiven for Apache Kafka parameters are customizable. To retrieve
+the list of parameters you can change, use the following command:
 
 ```
 avn service types -v
@@ -51,9 +51,9 @@ Apache Kafka.
 
 ## Update a service parameter with the Aiven CLI
 
-To modify a service parameter use the
-[Aiven CLI service update command](/docs/tools/cli/service-cli#avn-cli-service-update). for example, to modify the `message.max.bytes` parameter use the
-following command:
+To modify a service parameter, use the
+[Aiven CLI service update command](/docs/tools/cli/service-cli#avn-cli-service-update).
+For example, to modify the `message.max.bytes` parameter, use the following command:
 
 ```
 avn service update SERVICE_NAME -c "kafka.message_max_bytes=newmaximumbytelimit"

--- a/docs/products/kafka/howto/set-up-kafka-with-skills.md
+++ b/docs/products/kafka/howto/set-up-kafka-with-skills.md
@@ -6,14 +6,14 @@ keywords: [kafka, skills, automation, cli, developer tier]
 
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Use [Skills to automate Kafka workflows](/docs/products/kafka/dev-tier/kafka-dev-tier#use-skills-to-automate-workflows) to create and configure an Aiven for Apache Kafka® service from the command line.
+Use [Skills to automate Kafka workflows](/docs/products/kafka/dev-tier/kafka-dev-tier#automate-workflows-with-skills) to create and configure an Aiven for Apache Kafka® service from the command line.
 A Skill can create a service and configure topics, access control lists (ACLs), and
 Karapace Schema Registry.
 
 :::note
-On the [Free tier](/docs/products/kafka/free-tier/kafka-free-tier), create services in
-the [Aiven Console](https://console.aiven.io). Skills are supported on **Developer** and
-**Professional** tiers.
+If you use the [Free tier](/docs/products/kafka/free-tier/kafka-free-tier), create
+services in the [Aiven Console](https://console.aiven.io). Skills are available only on
+**Developer** and **Professional** tiers.
 :::
 
 ## Prerequisites
@@ -49,7 +49,7 @@ the CLI can create the service—pick the options the Skill offers for Developer
 
 When the run finishes, your service is configured and ready to use. For more about what
 Skills can automate, see
-[Use Skills to automate workflows](/docs/products/kafka/dev-tier/kafka-dev-tier#use-skills-to-automate-workflows).
+[Use Skills to automate workflows](/docs/products/kafka/dev-tier/kafka-dev-tier#automate-workflows-with-skills).
 
 ## Use an AI agent
 

--- a/docs/products/kafka/howto/set-up-kafka-with-skills.md
+++ b/docs/products/kafka/howto/set-up-kafka-with-skills.md
@@ -1,0 +1,69 @@
+---
+title: Set up Aiven for Apache Kafka® using Skills
+sidebar_label: Set up using Skills
+keywords: [kafka, skills, automation, cli, developer tier]
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Use [Skills to automate Kafka workflows](/docs/products/kafka/dev-tier/kafka-dev-tier#use-skills-to-automate-workflows)
+to create and configure an Aiven for Apache Kafka® service from the command line.
+A Skill can create a service and configure topics, access control lists (ACLs), and
+Karapace Schema Registry.
+
+:::note
+On the [Free tier](/docs/products/kafka/free-tier/kafka-free-tier), create services in
+the [Aiven Console](https://console.aiven.io). Skills are supported on **Developer** and
+**Professional** tiers.
+:::
+
+## Prerequisites
+
+- An Aiven account and a project where you can create services.
+- [Aiven CLI](/docs/tools/cli) installed and authenticated.
+- [Node.js](https://nodejs.org/) installed so `npm` provides `npx`.
+
+## Install the Skills bundle
+
+Install the Aiven Skills bundle:
+
+```bash
+npx skills add Aiven-Open/aiven-skills-bundle
+```
+
+## Run the Kafka service Skill
+
+Start the Kafka service creation Skill:
+
+```bash
+npx skills run kafka-create-service
+```
+
+Follow the prompts to choose your project, cloud, and region from the options the Skill
+shows, and your service tier (**Developer** or **Professional**).
+
+:::note
+If you select **Developer** tier, the **Aiven Console** only asks for a **region** when
+you create the service there. The Skill may still prompt for **cloud** and **region** so
+the CLI can create the service—pick the options the Skill offers for Developer tier.
+:::
+
+When the run finishes, your service is configured and ready to use. For more about what
+Skills can automate, see
+[Use Skills to automate workflows](/docs/products/kafka/dev-tier/kafka-dev-tier#use-skills-to-automate-workflows).
+
+## Use an AI agent
+
+If your editor or automation exposes Skills, trigger the same shell commands through that
+integration. Local `npx`, an authenticated Aiven CLI session, or an equivalent documented
+setup is still required.
+
+## Next steps
+
+- [Connect to Aiven for Apache Kafka®](/docs/products/kafka/howto/list-code-samples)
+- [Generate sample data for Aiven for Apache Kafka®](/docs/products/kafka/howto/generate-sample-data)
+- [Create a Kafka topic](/docs/products/kafka/howto/create-topic)
+
+<RelatedPages />
+
+- [Aiven for Apache Kafka® Developer tier](/docs/products/kafka/dev-tier/kafka-dev-tier)

--- a/docs/products/kafka/howto/set-up-kafka-with-skills.md
+++ b/docs/products/kafka/howto/set-up-kafka-with-skills.md
@@ -39,7 +39,7 @@ npx skills run kafka-create-service
 ```
 
 Follow the prompts to choose your project, cloud, and region from the options the Skill
-shows, and your service tier (**Developer** or **Professional**).
+shows, and your service tier: **Developer** or **Professional**.
 
 :::note
 If you select **Developer** tier, the **Aiven Console** only asks for a **region** when

--- a/docs/products/kafka/howto/set-up-kafka-with-skills.md
+++ b/docs/products/kafka/howto/set-up-kafka-with-skills.md
@@ -6,8 +6,7 @@ keywords: [kafka, skills, automation, cli, developer tier]
 
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Use [Skills to automate Kafka workflows](/docs/products/kafka/dev-tier/kafka-dev-tier#use-skills-to-automate-workflows)
-to create and configure an Aiven for Apache Kafka® service from the command line.
+Use [Skills to automate Kafka workflows](/docs/products/kafka/dev-tier/kafka-dev-tier#use-skills-to-automate-workflows) to create and configure an Aiven for Apache Kafka® service from the command line.
 A Skill can create a service and configure topics, access control lists (ACLs), and
 Karapace Schema Registry.
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -548,6 +548,17 @@ const sidebars: SidebarsConfig = {
                 },
                 {
                   type: 'category',
+                  label: 'Developer tier',
+                  link: {
+                    type: 'doc',
+                    id: 'products/kafka/dev-tier/kafka-dev-tier',
+                  },
+                  items: [
+                    'products/kafka/dev-tier/create-dev-tier-kafka-service',
+                  ],
+                },
+                {
+                  type: 'category',
                   label: 'Create Kafka service',
                   link: {
                     type: 'doc',
@@ -567,6 +578,7 @@ const sidebars: SidebarsConfig = {
                   },
                   items: ['products/kafka/howto/generate-sample-data-manually'],
                 },
+                'products/kafka/howto/set-up-kafka-with-skills',
               ],
             },
             {


### PR DESCRIPTION
## Describe your changes

Adds documentation for Aiven for Apache Kafka® Developer tier, including overview, use cases, features, limits, tier comparison, upgrade path, and Skills-based setup via CLI.

[POD-2412](https://aiven.atlassian.net/browse/POD-2412)

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
