### PR TITLE
update: remove Kafka service limits per org

### DIFF
--- a/docs/products/kafka/dev-tier/kafka-dev-tier.md
+++ b/docs/products/kafka/dev-tier/kafka-dev-tier.md
@@ -78,7 +78,6 @@ The following specifications apply to Developer tier services.
 | Partitions                      | Up to 100 total across topics                             |
 | Retention                       | 1 to 7 days; 1 day included, +$10 per additional 2 days   |
 | Storage                         | Fixed local storage per node                              |
-| Kafka services per organization | Up to 5                                                   |
 | Kafka Connect                   | Optional add-on, billed separately                        |
 | Cloud provider                  | Region selection in the console                           |
 | Service integrations            | Yes, with limitations                                     |


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
