### PR TITLE
update: aiven mcp dynamic read only mode

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -6,9 +6,10 @@ limited: true
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
-import {cursorDeepLink, mcpUrl} from '@site/src/components/mcpAivenLiveConstants';
+import {mcpUrl} from '@site/src/components/mcpAivenLiveConstants';
 import LimitedBadge from "@site/src/components/Badges/LimitedBadge";
+import MCPConfigSection from "@site/src/components/MCPConfigSection";
+import CursorConfigTab from "@site/src/components/CursorConfigTab";
 
 Aiven offers two Model Context Protocol (MCP) servers for use with AI assistants:
 
@@ -41,7 +42,7 @@ cloud regions. Supported services and features include:
   connector lifecycle operations including pause, resume, and restart.
 
 To restrict the server to non-destructive operations, you can enable
-[read-only mode](#read-only-mode).
+read-only mode in the configuration tabs below.
 
 ### Authentication
 
@@ -60,42 +61,7 @@ to Aiven and select your organization. The server refreshes tokens automatically
 <Tabs groupId="aiven-mcp-clients">
 <TabItem value="cursor" label="Cursor" default>
 
-<!-- vale off -->
-<a
-  href={cursorDeepLink}
-  style={{display: 'inline-flex', alignItems: 'center', gap: '10px', padding: '10px 20px', backgroundColor: '#2d2d2d', color: 'white', borderRadius: '8px', textDecoration: 'none', fontSize: '16px', fontWeight: 500, border: 'none', lineHeight: '20px'}}
->
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="20"
-    height="20"
-    viewBox="0 0 24 24"
-    fill="none"
-    aria-hidden="true"
-    focusable="false"
-    style={{display: 'block', flex: 'none'}}
-  >
-    <path d="M21 7.5L12 2L3 7.5M21 7.5L12 13M21 7.5V16.5L12 22M3 7.5L12 13M3 7.5V16.5L12 22M12 13V22" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" strokeLinecap="round"/>
-  </svg>
-  <span>Add to Cursor</span>
-</a>
-<!-- vale on -->
-
-<br /><br />
-
-To add the server manually:
-
-1. In your project root, create or edit the `.cursor/mcp.json` file.
-1. Add the following configuration:
-
-   <!-- vale off -->
-   <CodeBlock language="json">{JSON.stringify({mcpServers: {aiven: {type: "http", url: mcpUrl}}}, null, 2)}</CodeBlock>
-   <!-- vale on -->
-
-1. Save the file.
-1. Restart Cursor.
-1. Open **Settings** > **Tools & MCP**.
-1. Select **aiven** and click **Connect**.
+<CursorConfigTab baseUrl={mcpUrl} />
 
 For more information, see the [Cursor MCP documentation](https://cursor.com/docs/context/mcp).
 
@@ -109,6 +75,7 @@ You can also run the server locally using npx. This requires an
 1. In your project root, create or edit the `.cursor/mcp.json` file.
 1. Add the following configuration:
 
+
    ```json
    {
      "mcpServers": {
@@ -116,12 +83,15 @@ You can also run the server locally using npx. This requires an
          "command": "npx",
          "args": ["-y", "mcp-aiven"],
          "env": {
-           "AIVEN_TOKEN": "your-token-here"
+           "AIVEN_TOKEN": "your-token-here",
+           "AIVEN_READ_ONLY": "false"
          }
        }
      }
    }
    ```
+
+   Set `AIVEN_READ_ONLY` to `"true"` to enable read-only mode.
 
 1. Replace `your-token-here` with your Aiven API token.
 1. Save the file and restart Cursor.
@@ -143,7 +113,11 @@ You can also run the server locally using npx. This requires an
 1. Open a terminal.
 1. Run the following command:
 
-   <CodeBlock language="bash">{`claude mcp add --transport http aiven ${mcpUrl}`}</CodeBlock>
+   <MCPConfigSection
+     baseUrl={mcpUrl}
+     format="bash"
+     configTemplate={(url) => `claude mcp add --transport http aiven ${url}`}
+   />
 
 1. To verify the server is registered, in Claude Code run `/mcp`. The first time
    you use the server, your browser opens.
@@ -161,9 +135,12 @@ You can also run the server locally using npx. This requires an
 1. Open a terminal.
 1. Run the following command:
 
+
    ```bash
-   claude mcp add --scope user aiven-mcp -e AIVEN_TOKEN=your-token-here -- npx -y mcp-aiven
+   claude mcp add --scope user aiven-mcp -e AIVEN_TOKEN=your-token-here -e AIVEN_READ_ONLY=false -- npx -y mcp-aiven
    ```
+
+   Set `AIVEN_READ_ONLY=true` to enable read-only mode.
 
 1. Replace `your-token-here` with your Aiven API token.
 1. Run `/mcp` in Claude Code to verify the server is registered.
@@ -190,9 +167,11 @@ You can also run the server locally using npx. This requires an
 
 1. Add the following configuration to the file:
 
-   <!-- vale off -->
-   <CodeBlock language="json">{JSON.stringify({mcpServers: {aiven: {type: "http", url: mcpUrl}}}, null, 2)}</CodeBlock>
-   <!-- vale on -->
+   <MCPConfigSection
+     baseUrl={mcpUrl}
+     format="json"
+     configTemplate={(url) => ({mcpServers: {aiven: {type: "http", url}}})}
+   />
 
 1. Save the file and restart Claude Desktop.
 
@@ -208,6 +187,7 @@ You can also run the server locally using npx. This requires an
 1. Open the Claude Desktop configuration file.
 1. Add the following configuration:
 
+
    ```json
    {
      "mcpServers": {
@@ -215,12 +195,15 @@ You can also run the server locally using npx. This requires an
          "command": "npx",
          "args": ["-y", "mcp-aiven"],
          "env": {
-           "AIVEN_TOKEN": "your-token-here"
+           "AIVEN_TOKEN": "your-token-here",
+           "AIVEN_READ_ONLY": "false"
          }
        }
      }
    }
    ```
+
+   Set `AIVEN_READ_ONLY` to `"true"` to enable read-only mode.
 
 1. Replace `your-token-here` with your Aiven API token.
 1. Save the file and restart Claude Desktop.
@@ -248,9 +231,11 @@ and enabled.
 1. In the `.vscode` directory, create or edit the `mcp.json` file.
 1. Add the following configuration:
 
-   <!-- vale off -->
-   <CodeBlock language="json">{JSON.stringify({servers: {aiven: {type: "http", url: mcpUrl}}}, null, 2)}</CodeBlock>
-   <!-- vale on -->
+   <MCPConfigSection
+     baseUrl={mcpUrl}
+     format="json"
+     configTemplate={(url) => ({servers: {aiven: {type: "http", url}}})}
+   />
 
 1. Save the file.
 1. Reload VS Code.
@@ -269,6 +254,7 @@ You can also run the server locally using npx. This requires an
 1. In the `.vscode` directory, create or edit the `mcp.json` file.
 1. Add the following configuration:
 
+
    ```json
    {
      "servers": {
@@ -276,12 +262,15 @@ You can also run the server locally using npx. This requires an
          "command": "npx",
          "args": ["-y", "mcp-aiven"],
          "env": {
-           "AIVEN_TOKEN": "your-token-here"
+           "AIVEN_TOKEN": "your-token-here",
+           "AIVEN_READ_ONLY": "false"
          }
        }
      }
    }
    ```
+
+   Set `AIVEN_READ_ONLY` to `"true"` to enable read-only mode.
 
 1. Replace `your-token-here` with your Aiven API token.
 1. Save the file and reload VS Code.
@@ -301,12 +290,15 @@ You can also run the server locally using npx. This requires an
 <TabItem value="other" label="Other clients">
 
 1. Open your MCP client configuration.
-1. Add the Aiven MCP server using the URL <CodeBlock language="text">{mcpUrl}</CodeBlock>
-   Most clients use a configuration similar to:
+1. Add the Aiven MCP server using the following configuration:
 
-   <!-- vale off -->
-   <CodeBlock language="json">{JSON.stringify({mcpServers: {aiven: {url: mcpUrl}}}, null, 2)}</CodeBlock>
-   <!-- vale on -->
+   <MCPConfigSection
+     baseUrl={mcpUrl}
+     format="json"
+     configTemplate={(url) => ({mcpServers: {aiven: {url}}})}
+   />
+
+   Most clients use a configuration similar to the above.
 
 1. Save the file and restart your client.
 
@@ -373,22 +365,8 @@ Aiven secures the platform and API. You are responsible for the following:
   (principle of least privilege) and rotating them regularly.
 - **Reviewing AI agent actions** before they run, especially for write or delete
   operations on production resources.
-- **Configuring MCP servers securely**, including choosing
-  [read-only mode](/docs/tools/mcp-server#read-only-mode) where appropriate to
-  restrict the server to non-destructive operations.
-
-### Read-only mode
-
-To restrict the server to read-only operations, set the `AIVEN_READ_ONLY`
-environment variable to `true` in your MCP client configuration:
-
-<!-- vale off -->
-<CodeBlock language="json">{JSON.stringify({mcpServers: {aiven: {type: "http", url: mcpUrl, env: {AIVEN_READ_ONLY: "true"}}}}, null, 2)}</CodeBlock>
-<!-- vale on -->
-
-In read-only mode, the server only allows operations that read data, such as
-listing services, viewing metrics, and running SELECT queries. The server blocks
-write operations, such as creating services or modifying data.
+- **Configuring MCP servers securely**, including enabling read-only mode (available
+  on the configuration tabs above) to restrict the server to non-destructive operations.
 
 ## Documentation MCP server
 

--- a/src/components/CursorConfigTab/index.tsx
+++ b/src/components/CursorConfigTab/index.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import CodeBlock from '@theme/CodeBlock';
+import MCPConfigToggle from '../MCPConfigToggle';
+import CursorIcon from '@site/static/images/icons/cursor.svg';
+import styles from './styles.module.css';
+
+type CursorConfigTabProps = {
+  baseUrl: string;
+};
+
+export default function CursorConfigTab({ baseUrl }: CursorConfigTabProps): JSX.Element {
+  const [isReadOnly, setIsReadOnly] = useState(false);
+
+  const url = isReadOnly ? `${baseUrl}?read_only=true` : baseUrl;
+  const configJson = JSON.stringify({ mcpServers: { aiven: { type: 'http', url } } }, null, 2);
+
+  const cursorConfig = { url, type: 'http' };
+  const encodedConfig = typeof btoa !== 'undefined' ? btoa(JSON.stringify(cursorConfig)) : '';
+  const deepLink = `cursor://anysphere.cursor-deeplink/mcp/install?name=aiven-mcp&config=${encodedConfig}`;
+
+  return (
+    <div className={styles.container}>
+      <a href={deepLink} className={styles.button}>
+        <CursorIcon />
+        <span>Add to Cursor</span>
+      </a>
+
+      <div className={styles.manualSetup}>
+        <p>To add the server manually:</p>
+        <ol>
+          <li>In your project root, create or edit the <code>.cursor/mcp.json</code> file.</li>
+          <li>Add the following configuration:</li>
+        </ol>
+        <MCPConfigToggle onReadOnlyChange={setIsReadOnly} />
+        <CodeBlock language="json" key={`cursor-config-${isReadOnly}`}>{configJson}</CodeBlock>
+        <ol start={3}>
+          <li>Save the file.</li>
+          <li>Restart Cursor.</li>
+          <li>Open <strong>Settings</strong> &gt; <strong>Tools &amp; MCP</strong>.</li>
+          <li>Select <strong>aiven</strong> and click <strong>Connect</strong>.</li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CursorConfigTab/styles.module.css
+++ b/src/components/CursorConfigTab/styles.module.css
@@ -1,0 +1,38 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 20px;
+  background-color: var(--aiven-grey-90);
+  color: white;
+  border-radius: var(--aiven-radius);
+  text-decoration: none;
+  font-size: 16px;
+  font-weight: 500;
+  border: none;
+  line-height: 20px;
+  width: fit-content;
+  transition: background-color 0.2s;
+}
+
+.button:hover,
+.button:focus {
+  background-color: var(--aiven-grey-80);
+  color: white;
+  text-decoration: none;
+}
+
+.button svg {
+  display: block;
+  flex: none;
+}
+
+.manualSetup {
+  margin-top: 8px;
+}

--- a/src/components/MCPConfigSection/index.tsx
+++ b/src/components/MCPConfigSection/index.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import CodeBlock from '@theme/CodeBlock';
+import MCPConfigToggle from '../MCPConfigToggle';
+import styles from './styles.module.css';
+
+type MCPConfigSectionProps = {
+  baseUrl: string;
+  format: 'json' | 'bash';
+  configTemplate: (url: string) => any;
+};
+
+export default function MCPConfigSection({ baseUrl, format, configTemplate }: MCPConfigSectionProps): JSX.Element {
+  const [isReadOnly, setIsReadOnly] = useState(false);
+
+  const url = isReadOnly ? `${baseUrl}?read_only=true` : baseUrl;
+  const config = configTemplate(url);
+  const content = format === 'json' ? JSON.stringify(config, null, 2) : config;
+
+  return (
+    <div className={styles.container}>
+      <MCPConfigToggle onReadOnlyChange={setIsReadOnly} />
+      <CodeBlock language={format} key={`${format}-${isReadOnly}`}>{content}</CodeBlock>
+    </div>
+  );
+}

--- a/src/components/MCPConfigSection/styles.module.css
+++ b/src/components/MCPConfigSection/styles.module.css
@@ -1,0 +1,5 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}

--- a/src/components/MCPConfigToggle/index.tsx
+++ b/src/components/MCPConfigToggle/index.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import styles from './styles.module.css';
+
+type MCPConfigToggleProps = {
+  onReadOnlyChange?: (isReadOnly: boolean) => void;
+};
+
+export default function MCPConfigToggle({ onReadOnlyChange }: MCPConfigToggleProps): JSX.Element {
+  const [isReadOnly, setIsReadOnly] = useState(false);
+
+  const handleChange = (checked: boolean) => {
+    setIsReadOnly(checked);
+    onReadOnlyChange?.(checked);
+  };
+
+  return (
+    <div className={styles.container}>
+      <label className={styles.label}>
+        <input
+          type="checkbox"
+          checked={isReadOnly}
+          onChange={(e) => handleChange(e.target.checked)}
+          className={styles.checkbox}
+        />
+        Read-only mode
+      </label>
+      <p className={styles.description}>Allows only read-only operations, such as listing services, viewing metrics, and running read-only queries.</p>
+    </div>
+  );
+}

--- a/src/components/MCPConfigToggle/styles.module.css
+++ b/src/components/MCPConfigToggle/styles.module.css
@@ -1,0 +1,33 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 12px 0;
+  padding: 12px;
+  background-color: var(--aiven-card-bg);
+  border-radius: var(--aiven-radius);
+  border: 1px solid var(--aiven-card-border);
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-weight: 500;
+  color: var(--ifm-color-content);
+  font-family: var(--aiven-card-font-family);
+}
+
+.checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: var(--aiven-primary-orange);
+}
+
+.description {
+  margin: 0;
+  font-size: 14px;
+  color: var(--ifm-color-content);
+}

--- a/src/components/mcpAivenLiveConstants.ts
+++ b/src/components/mcpAivenLiveConstants.ts
@@ -1,9 +1,5 @@
 /**
- * MCP server URL and Cursor install deep link for `docs/tools/mcp-server.md`.
+ * MCP server URL for `docs/tools/mcp-server.md`.
  * Change `mcpUrl` here to update every sample on that page.
  */
 export const mcpUrl = 'https://mcp.aiven.live/mcp';
-
-export const cursorDeepLink = `cursor://anysphere.cursor-deeplink/mcp/install?name=aiven-mcp&config=${
-  typeof btoa !== 'undefined' ? btoa(JSON.stringify({url: mcpUrl})) : ''
-}`;

--- a/static/images/icons/cursor.svg
+++ b/static/images/icons/cursor.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none">
+  <path d="M21 7.5L12 2L3 7.5M21 7.5L12 13M21 7.5V16.5L12 22M3 7.5L12 13M3 7.5V16.5L12 22M12 13V22" stroke="currentColor" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Add a documentation about the dynamic read only mode on remote hosted aiven mcp

## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
