### PR TITLE
update: align Kafka dev-tier docs with new retention options

### DIFF
--- a/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
+++ b/docs/products/kafka/dev-tier/create-dev-tier-kafka-service.md
@@ -48,13 +48,13 @@ Use one of the following:
    message in the **Cloud** section of the Aiven Console.
    :::
 
-1. In **Retention**, select a retention period between **1 day** and **7 days**.
+1. In **Retention**, select a retention period between **1 day** and **3 days**.
 
    :::note
    Your estimated monthly cost depends on **retention**, **Cloud**, and geographical
    region. Check the **Service summary** for the price that applies to your selections.
 
-   Retention options are 1 day, 3 days, 5 days, or 7 days, with pricing adjusted
+   Retention options are 1 day, 2 days, or 3 days, with pricing adjusted
    accordingly.
    :::
 
@@ -129,7 +129,7 @@ If your Kafka service is integrated with a Kafka Connect service:
 - After upgrading Kafka, upgrade the Kafka Connect service to the same tier
   before powering it on again.
 
-Both services must run on the same tier.
+Run both services on the same tier.
 
 For details, see
 [Kafka and Kafka Connect tier compatibility](/docs/products/kafka/dev-tier/kafka-dev-tier#kafka-and-kafka-connect-tier-compatibility).

--- a/docs/products/kafka/dev-tier/kafka-dev-tier.md
+++ b/docs/products/kafka/dev-tier/kafka-dev-tier.md
@@ -70,14 +70,14 @@ The following specifications apply to Developer tier services.
 
 | Specification                   | Developer tier                                            |
 |---------------------------------|-----------------------------------------------------------|
-| Price                           | Starts at $29 per month for 1 day retention; pricing varies by Cloud and geographical region |
+| Price                           | Starts at $35 per month for 1 day retention; pricing varies by cloud and geographical region |
 | Nodes                           | 2                                                         |
 | Throughput                      | 1 MB/s ingress, 2 MB/s egress                             |
 | Topics                          | Up to 20                                                  |
 | Partitions                      | Up to 100 per topic and 2000 max across the service      |
 | Replication factor              | 1                                                         |
 | Metadata mode                   | KRaft                                                     |
-| Retention                       | 1-7 days. Pricing varies by option and is shown in the Aiven Console|
+| Retention                       | 1, 2, or 3 days. Pricing varies by option and is shown in the Aiven Console |
 | Storage                         | Fixed local storage per node                              |
 | Kafka Connect                   | Optional service, billed separately                        |
 | Cloud                           | Geographical region in the Aiven Console. Pricing varies by cloud |
@@ -85,7 +85,7 @@ The following specifications apply to Developer tier services.
 | Upgrade                         | To a Professional tier from the Aiven Console             |
 | Downgrade to Free tier          | Not supported                                             |
 
-Developer tier pricing depends on retention, **Cloud**, and geographical region. Review
+Developer tier pricing depends on retention, cloud, and geographical region. Review
 current pricing during service creation in the [Aiven Console](https://console.aiven.io)
 and on [Aiven for Apache Kafka® pricing](https://aiven.io/pricing?product=kafka).
 
@@ -96,14 +96,14 @@ a Professional plan in the [Aiven Console](https://console.aiven.io).
 
 | Feature                         | Free                              | Developer                     | Professional                 |
 |---------------------------------|-----------------------------------|-------------------------------|------------------------------|
-| Price                           | $0                                | Starts at $29 per month       | Varies by plan               |
+| Price                           | $0                                | Starts at $35 per month       | Varies by plan               |
 | Throughput                      | Up to 250 KB/s ingress and egress | 1 MB/s ingress, 2 MB/s egress | Higher, plan-dependent       |
 | Topics                          | Up to 5                           | Up to 20                      | Plan-dependent               |
 | Partitions                      | 1 per topic                       | Up to 100 per topic           | Plan-dependent               |
 | Nodes                           | 1                                 | 2                             | Plan-dependent               |
 | Replication factor              | 1                                 | 1                             | Plan-dependent               |
 | Metadata mode                   | KRaft                             | KRaft                         | KRaft                        |
-| Retention                       | Fixed                             | 1 to 7 days                   | Plan-dependent               |
+| Retention                       | Fixed                             | 1, 2, or 3 days               | Plan-dependent               |
 | Storage                         | Fixed                             | Fixed local storage per node  | Plan-dependent               |
 | SLA                             | None                              | 99%                           | Up to 99.99%, plan-dependent |
 | Kafka Connect                   | Not supported                     | Optional, billed separately   | Full support, plan-dependent |

--- a/docs/products/kafka/get-started/get-started-kafka.md
+++ b/docs/products/kafka/get-started/get-started-kafka.md
@@ -5,12 +5,30 @@ sidebar_label: Get started
 
 import LimitedBadge from "@site/src/components/Badges/LimitedBadge";
 
-Create a managed Apache Kafka® service on Aiven, use the Free tier where it fits your workload, and send sample data to verify end-to-end streaming.
+Create a managed Apache Kafka® service on Aiven.
+Choose the tier and deployment model that fit your workload, then send sample data
+to verify end-to-end streaming.
 
 ## Prerequisites
 
 - Create an Aiven account and sign in to the [Aiven Console](https://console.aiven.io).
 - Create or select an Aiven project with permission to create services.
+
+## Choose your path
+
+Choose one of the following paths based on your workload and platform
+needs:
+
+- Start with [Free tier](#free-tier) for no-cost, low-throughput Kafka
+  workloads.
+- Use [Developer tier](#developer-tier) for paid development and smaller
+  production workloads.
+- Create [Inkless Kafka](#create-an-inkless-kafka-service) for
+  cloud-object-storage-backed topics.
+- Create [Classic Kafka](#create-a-classic-kafka-service) for fixed plans
+  with local broker storage.
+- Use [Skills](#set-up-a-kafka-service-using-skills) for command-line
+  setup and configuration.
 
 ## Free tier
 
@@ -38,7 +56,7 @@ For limits, pricing, Karapace, Connect, integrations, and upgrades, see
 Manage the service in the console, CLI, API, or with
 [Skills](/docs/products/kafka/howto/set-up-kafka-with-skills).
 
-**Continue with:** [Create an Aiven for Apache Kafka® Developer tier service](/docs/products/kafka/dev-tier/create-dev-tier-kafka-service).
+**Continue with:** [Create a Kafka service using the Developer tier](/docs/products/kafka/dev-tier/create-dev-tier-kafka-service).
 
 ## Create an Inkless Kafka service
 
@@ -47,7 +65,7 @@ storage rather than on local disks. Compute capacity is sized based on stream lo
 of fixed hardware plans.
 
 - Select **Inkless** as the service type.
-- Choose **Aiven cloud** or **Bring your own cloud (BYOC)** as the deployment mode.
+- Select **Aiven cloud** or **Bring your own cloud (BYOC)** as the deployment mode.
 - On Aiven cloud, select **AWS**, **Google**, or **Azure** and a region;
   then provide expected ingress, egress, and retention to estimate capacity and cost.
 - On BYOC, select the BYOC environment, region, and an Inkless plan.
@@ -60,7 +78,7 @@ Classic Kafka uses fixed plans with local broker storage. Tiered storage is avai
 supported plans and cloud providers.
 
 - Select **Classic Kafka** as the service type.
-- Choose **Aiven cloud** or **BYOC** as the deployment mode.
+- Select **Aiven cloud** or **BYOC** as the deployment mode.
 - Select a plan that defines compute, memory, and storage.
 - Optionally adjust disk capacity, enable tiered storage, and select the Kafka version.
 


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
