### PR TITLE
update: fix redirect for Kafka TS page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -204,6 +204,8 @@
 /products/kafka/howto/list-security                        /docs/products/kafka/howto/keystore-truststore  301
 /products/kafka/howto/list-tools                           /docs/products/kafka/howto/kafka-tools-config-file  301
 /products/kafka/howto/list-topic-management                /docs/products/kafka/howto/create-topic  301
+/products/kafka/howto/tiered-storage-overview-page         /docs/products/kafka/concepts/kafka-tiered-storage   301
+/products/kafka/howto/tiered-storage-overview-page/        /docs/products/kafka/concepts/kafka-tiered-storage   301
 /products/kafka/howto/use-zookeeper                        /docs/products/kafka  301
 /products/kafka/tiered-storage-overview-page               /docs/products/kafka/howto/view-kafka-storage-in-console   301
 /products/kafka/index.html                                 /docs/products/kafka  301


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
