### PR TITLE
fix: small fixup to remove duplicate information

### DIFF
--- a/scripts/kafka/shared.js
+++ b/scripts/kafka/shared.js
@@ -80,7 +80,7 @@ import Link from '@docusaurus/Link'
             <div className="constraints">
               <ul>
                 {{#if this.orBetween}}
-                  <li>range: <code>{{this.minimum}}</code> or between <code>{{this.orBetween.[0]}}</code> and <code>{{this.orBetween.[1]}}</code></li>
+                  <li>range: <code>{{this.orBetween.[0]}}</code> - <code>{{this.orBetween.[1]}}</code></li>
                 {{/if}}
                 {{#if this.minimum}}
                   <li>min: <code>{{this.minimum}}</code></li>

--- a/static/includes/config-kafka-inkless-saas-topic.md
+++ b/static/includes/config-kafka-inkless-saas-topic.md
@@ -240,7 +240,7 @@ import Link from '@docusaurus/Link'
 
             <div className="constraints">
               <ul>
-                  <li>range: <code>-1</code> or between <code>60000</code> and <code>9223372036854775807</code></li>
+                  <li>range: <code>60000</code> - <code>9223372036854775807</code></li>
                   <li>min: <code>-1</code></li>
               </ul>
             </div>

--- a/static/includes/config-kafka-inkless-saas.md
+++ b/static/includes/config-kafka-inkless-saas.md
@@ -913,7 +913,7 @@ import Link from '@docusaurus/Link'
 
             <div className="constraints">
               <ul>
-                  <li>range: <code>-1</code> or between <code>60000</code> and <code>9223372036854775807</code></li>
+                  <li>range: <code>60000</code> - <code>9223372036854775807</code></li>
                   <li>min: <code>-1</code></li>
               </ul>
             </div>


### PR DESCRIPTION
## Describe your changes

The min was repeated in the range, now they are separate and more clear:

<img width="1240" height="348" alt="image" src="https://github.com/user-attachments/assets/f3e3c41c-2c9d-414a-863d-4292de78dd61" />


## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
