### PR TITLE
fix: Improve agent-friendly docs support and llms.txt discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,7 @@ We welcome contributions! To contribute to our docs, see [Contributing](./CONTRI
 ## Opening a PR
 
 1. Check for potential broken links with `yarn build` (`yarn start` doesn't check for broken links).
+   After the Docusaurus build, `scripts/limit-llms-txt-size.mjs` keeps `build/llms.txt` under
+   48,000 characters and links to the full index at `llms-full.txt`, so agents can use a compact
+   index without hitting tooling limits (for example ~100K truncation checks).
 1. If you get a green build and when you are happy with your changes, open a PR.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -7,6 +7,9 @@ import rehypeKatex from 'rehype-katex';
 const currentMonth = new Date().getMonth();
 const isJune = currentMonth === 5;
 
+const baseUrl = process.env.BASEURL || '/docs/';
+const llmsTxtUrl = `${baseUrl.replace(/\/$/, '')}/llms.txt`;
+
 const config: Config = {
   // Testing faster build
   future: {},
@@ -14,7 +17,7 @@ const config: Config = {
   tagline: 'Your AI-ready Open Source Data Platform',
   favicon: 'images/favicon.ico',
   url: 'https://aiven.io/',
-  baseUrl: process.env.BASEURL || '/docs/',
+  baseUrl,
   organizationName: 'Aiven',
   projectName: 'docs',
   onBrokenLinks: 'throw',
@@ -34,6 +37,14 @@ const config: Config = {
       attributes: {
         name: 'zd-site-verification',
         content: '1tsz6w2s2we597lbplg9ou',
+      },
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'alternate',
+        type: 'text/plain',
+        href: llmsTxtUrl,
       },
     },
   ],
@@ -164,8 +175,12 @@ const config: Config = {
       title: 'aiven',
       logo: {
         alt: 'Aiven docs',
-        src: isJune ? 'images/rainbowcrab.svg' : 'images/aiven_logo_RGB_blk.svg',
-        srcDark: isJune ? 'images/rainbowcrab.svg' : 'images/aiven_logo_RGB_wht.svg',
+        src: isJune
+          ? 'images/rainbowcrab.svg'
+          : 'images/aiven_logo_RGB_blk.svg',
+        srcDark: isJune
+          ? 'images/rainbowcrab.svg'
+          : 'images/aiven_logo_RGB_wht.svg',
       },
       items: [
         {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus build && node scripts/trim-llms-txt.mjs && node scripts/add-markdown-agent-directive.mjs",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build && node scripts/trim-llms-txt.mjs && node scripts/add-markdown-agent-directive.mjs",
+    "build": "docusaurus build && node scripts/limit-llms-txt-size.mjs && node scripts/add-markdown-agent-directive.mjs",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/add-markdown-agent-directive.mjs
+++ b/scripts/add-markdown-agent-directive.mjs
@@ -24,15 +24,15 @@ async function findMarkdownFiles(dir) {
 }
 
 const files = await findMarkdownFiles(BUILD_DIR);
+let modified = 0;
 
 for (const file of files) {
   const content = await fs.readFile(file, 'utf8');
 
   if (!content.startsWith(DIRECTIVE)) {
     await fs.writeFile(file, DIRECTIVE + content);
+    modified++;
   }
 }
 
-console.log(
-  `Added markdown agent directive to ${files.length} markdown files.`,
-);
+console.log(`Added directive to ${modified}/${files.length} markdown files.`);

--- a/scripts/add-markdown-agent-directive.mjs
+++ b/scripts/add-markdown-agent-directive.mjs
@@ -7,7 +7,13 @@ const llmsTxtUrl = `${baseUrl.replace(/\/$/, '')}/llms.txt`;
 const DIRECTIVE = `> For the complete documentation index, see [llms.txt](${llmsTxtUrl}).\n\n`;
 
 async function findMarkdownFiles(dir) {
-  const entries = await fs.readdir(dir, {withFileTypes: true});
+  let entries;
+  try {
+    entries = await fs.readdir(dir, {withFileTypes: true});
+  } catch (err) {
+    throw new Error(`Failed to read directory ${dir}: ${err.message}`, {cause: err});
+  }
+
   const files = [];
 
   for (const entry of entries) {
@@ -23,16 +29,23 @@ async function findMarkdownFiles(dir) {
   return files;
 }
 
-const files = await findMarkdownFiles(BUILD_DIR);
-let modified = 0;
+async function main() {
+  const files = await findMarkdownFiles(BUILD_DIR);
+  let modified = 0;
 
-for (const file of files) {
-  const content = await fs.readFile(file, 'utf8');
+  for (const file of files) {
+    const content = await fs.readFile(file, 'utf8');
 
-  if (!content.startsWith(DIRECTIVE)) {
-    await fs.writeFile(file, DIRECTIVE + content);
-    modified++;
+    if (!content.startsWith(DIRECTIVE)) {
+      await fs.writeFile(file, DIRECTIVE + content);
+      modified++;
+    }
   }
+
+  console.log(`Added directive to ${modified}/${files.length} markdown files.`);
 }
 
-console.log(`Added directive to ${modified}/${files.length} markdown files.`);
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/add-markdown-agent-directive.mjs
+++ b/scripts/add-markdown-agent-directive.mjs
@@ -1,0 +1,38 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const BUILD_DIR = 'build';
+const baseUrl = process.env.BASEURL || '/docs/';
+const llmsTxtUrl = `${baseUrl.replace(/\/$/, '')}/llms.txt`;
+const DIRECTIVE = `> For the complete documentation index, see [llms.txt](${llmsTxtUrl}).\n\n`;
+
+async function findMarkdownFiles(dir) {
+  const entries = await fs.readdir(dir, {withFileTypes: true});
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await findMarkdownFiles(fullPath)));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+const files = await findMarkdownFiles(BUILD_DIR);
+
+for (const file of files) {
+  const content = await fs.readFile(file, 'utf8');
+
+  if (!content.startsWith(DIRECTIVE)) {
+    await fs.writeFile(file, DIRECTIVE + content);
+  }
+}
+
+console.log(
+  `Added markdown agent directive to ${files.length} markdown files.`,
+);

--- a/scripts/limit-llms-txt-size.mjs
+++ b/scripts/limit-llms-txt-size.mjs
@@ -4,38 +4,91 @@ const LLMS_FILE = 'build/llms.txt';
 const baseUrl = process.env.BASEURL || '/docs/';
 const FULL_INDEX_URL = `https://aiven.io${baseUrl.replace(/\/$/, '')}/llms-full.txt`;
 const MAX_CHARS = 48000;
+const FOOTER_HEADING = '## Full documentation index';
 const FOOTER = [
   '',
-  '## Full documentation index',
+  FOOTER_HEADING,
   '',
   `- ${FULL_INDEX_URL}`,
   '',
 ].join('\n');
 const maxBodyChars = MAX_CHARS - FOOTER.length;
 
-if (maxBodyChars <= 0) {
-  throw new Error('MAX_CHARS is too small to fit the required footer.');
-}
+function removeExistingFooter(content) {
+  const footerStart = content.indexOf(`\n${FOOTER_HEADING}\n`);
 
-const content = await fs.readFile(LLMS_FILE, 'utf8');
-const lines = content.split('\n');
-
-const includedLines = [];
-let charCount = 0;
-
-for (const line of lines) {
-  const lineLength = line.length + 1;
-
-  if (charCount + lineLength > maxBodyChars) {
-    break;
+  if (footerStart === -1) {
+    return content;
   }
 
-  includedLines.push(line);
-  charCount += lineLength;
+  return content.slice(0, footerStart).trimEnd() + '\n';
 }
 
-const finalContent = `${includedLines.join('\n')}${FOOTER}`;
+/** Markdown headings in llms.txt (e.g. ## docs, #### cloudlogging). */
+function isSectionHeader(line) {
+  return /^#{1,6}\s/.test(line);
+}
 
-await fs.writeFile(LLMS_FILE, finalContent);
+/** Drop trailing section headers that have no links/content below them after truncation. */
+function trimTrailingOrphanHeaders(lines) {
+  const trimmed = [...lines];
 
-console.log(`Limited ${LLMS_FILE} to ${finalContent.length} characters (max ${MAX_CHARS}).`);
+  while (trimmed.length > 0) {
+    while (trimmed.length > 0 && trimmed[trimmed.length - 1].trim() === '') {
+      trimmed.pop();
+    }
+
+    if (trimmed.length === 0 || !isSectionHeader(trimmed[trimmed.length - 1])) {
+      break;
+    }
+
+    trimmed.pop();
+  }
+
+  return trimmed;
+}
+
+async function main() {
+  if (maxBodyChars <= 0) {
+    throw new Error('MAX_CHARS is too small to fit the required footer.');
+  }
+
+  let content;
+  try {
+    content = await fs.readFile(LLMS_FILE, 'utf8');
+  } catch (err) {
+    throw new Error(`Failed to read "${LLMS_FILE}": ${err.message}`, {cause: err});
+  }
+
+  const lines = removeExistingFooter(content).split('\n');
+
+  const includedLines = [];
+  let charCount = 0;
+
+  for (const line of lines) {
+    const lineLength = line.length + 1;
+
+    if (charCount + lineLength > maxBodyChars) {
+      break;
+    }
+
+    includedLines.push(line);
+    charCount += lineLength;
+  }
+
+  const bodyLines = trimTrailingOrphanHeaders(includedLines);
+  const finalContent = `${bodyLines.join('\n')}${FOOTER}`;
+
+  try {
+    await fs.writeFile(LLMS_FILE, finalContent);
+  } catch (err) {
+    throw new Error(`Failed to write "${LLMS_FILE}": ${err.message}`, {cause: err});
+  }
+
+  console.log(`Limited ${LLMS_FILE} to ${finalContent.length} characters (max ${MAX_CHARS}).`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/limit-llms-txt-size.mjs
+++ b/scripts/limit-llms-txt-size.mjs
@@ -20,7 +20,7 @@ if (maxBodyChars <= 0) {
 const content = await fs.readFile(LLMS_FILE, 'utf8');
 const lines = content.split('\n');
 
-const trimmedLines = [];
+const includedLines = [];
 let charCount = 0;
 
 for (const line of lines) {
@@ -30,12 +30,12 @@ for (const line of lines) {
     break;
   }
 
-  trimmedLines.push(line);
+  includedLines.push(line);
   charCount += lineLength;
 }
 
-const finalContent = `${trimmedLines.join('\n')}${FOOTER}`;
+const finalContent = `${includedLines.join('\n')}${FOOTER}`;
 
 await fs.writeFile(LLMS_FILE, finalContent);
 
-console.log(`Trimmed ${LLMS_FILE} to ${finalContent.length} characters.`);
+console.log(`Limited ${LLMS_FILE} to ${finalContent.length} characters (max ${MAX_CHARS}).`);

--- a/scripts/trim-llms-txt.mjs
+++ b/scripts/trim-llms-txt.mjs
@@ -1,0 +1,38 @@
+import fs from 'node:fs/promises';
+
+const LLMS_FILE = 'build/llms.txt';
+const FULL_INDEX_URL = 'https://aiven.io/llms-full.txt';
+const MAX_CHARS = 48000;
+const FOOTER = [
+  '',
+  '## Full documentation index',
+  '',
+  `- ${FULL_INDEX_URL}`,
+  '',
+].join('\n');
+const maxBodyChars = MAX_CHARS - FOOTER.length;
+
+if (maxBodyChars <= 0) {
+  throw new Error('MAX_CHARS is too small to fit the required footer.');
+}
+
+const content = await fs.readFile(LLMS_FILE, 'utf8');
+const lines = content.split('\n');
+
+const trimmedLines = [];
+
+for (const line of lines) {
+  const nextContent = [...trimmedLines, line].join('\n');
+
+  if (nextContent.length > maxBodyChars) {
+    break;
+  }
+
+  trimmedLines.push(line);
+}
+
+const finalContent = `${trimmedLines.join('\n')}${FOOTER}`;
+
+await fs.writeFile(LLMS_FILE, finalContent);
+
+console.log(`Trimmed ${LLMS_FILE} to ${finalContent.length} characters.`);

--- a/scripts/trim-llms-txt.mjs
+++ b/scripts/trim-llms-txt.mjs
@@ -1,7 +1,8 @@
 import fs from 'node:fs/promises';
 
 const LLMS_FILE = 'build/llms.txt';
-const FULL_INDEX_URL = 'https://aiven.io/llms-full.txt';
+const baseUrl = process.env.BASEURL || '/docs/';
+const FULL_INDEX_URL = `https://aiven.io${baseUrl.replace(/\/$/, '')}/llms-full.txt`;
 const MAX_CHARS = 48000;
 const FOOTER = [
   '',
@@ -20,15 +21,17 @@ const content = await fs.readFile(LLMS_FILE, 'utf8');
 const lines = content.split('\n');
 
 const trimmedLines = [];
+let charCount = 0;
 
 for (const line of lines) {
-  const nextContent = [...trimmedLines, line].join('\n');
+  const lineLength = line.length + 1;
 
-  if (nextContent.length > maxBodyChars) {
+  if (charCount + lineLength > maxBodyChars) {
     break;
   }
 
   trimmedLines.push(line);
+  charCount += lineLength;
 }
 
 const finalContent = `${trimmedLines.join('\n')}${FOOTER}`;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -517,3 +517,13 @@ html[data-theme='dark'] .prism-code[class*='language-diff'] .token.inserted {
   color: var(--aiven-brand-green) !important;
   font-style: normal !important;
 }
+/* Agent-readable documentation directive */
+.agent-docs-directive {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import Heading from '@theme/Heading';
@@ -43,6 +44,7 @@ function HomepageHeader() {
 
 export default function Home(): JSX.Element {
   const {siteConfig} = useDocusaurusContext();
+  const llmsTxtUrl = useBaseUrl('llms.txt');
   return (
     <Layout
       title=""
@@ -51,6 +53,25 @@ export default function Home(): JSX.Element {
         siteConfig.tagline +
         '. One unified platform to stream, store, and serve data on any cloud.'
       }>
+      <div
+        className="agent-docs-directive"
+        style={{
+          position: 'absolute',
+          width: '1px',
+          height: '1px',
+          padding: 0,
+          margin: '-1px',
+          overflow: 'hidden',
+          clip: 'rect(0,0,0,0)',
+          whiteSpace: 'nowrap',
+          border: 0,
+        }}>
+        For the complete documentation index, see{' '}
+        <a href={llmsTxtUrl} tabIndex={-1}>
+          llms.txt
+        </a>
+        . Markdown versions of pages are available with the .md suffix.
+      </div>
       <HomepageHeader />
       <main>
         <HomepageFeatures />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -53,19 +53,7 @@ export default function Home(): JSX.Element {
         siteConfig.tagline +
         '. One unified platform to stream, store, and serve data on any cloud.'
       }>
-      <div
-        className="agent-docs-directive"
-        style={{
-          position: 'absolute',
-          width: '1px',
-          height: '1px',
-          padding: 0,
-          margin: '-1px',
-          overflow: 'hidden',
-          clip: 'rect(0,0,0,0)',
-          whiteSpace: 'nowrap',
-          border: 0,
-        }}>
+      <div className="agent-docs-directive" aria-hidden="true">
         For the complete documentation index, see{' '}
         <a href={llmsTxtUrl} tabIndex={-1}>
           llms.txt

--- a/src/theme/DocRoot/index.tsx
+++ b/src/theme/DocRoot/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import DocRoot from '@theme-original/DocRoot';
+import type DocRootType from '@theme/DocRoot';
+import type {WrapperProps} from '@docusaurus/types';
+
+type Props = WrapperProps<typeof DocRootType>;
+
+export default function DocRootWrapper(props: Props): JSX.Element {
+  const llmsTxtUrl = useBaseUrl('llms.txt');
+
+  return (
+    <>
+      <div className="agent-docs-directive">
+        For the complete documentation index, see{' '}
+        <a href={llmsTxtUrl} tabIndex={-1}>
+          llms.txt
+        </a>
+        .
+      </div>
+
+      <DocRoot {...props} />
+    </>
+  );
+}

--- a/src/theme/DocRoot/index.tsx
+++ b/src/theme/DocRoot/index.tsx
@@ -11,7 +11,7 @@ export default function DocRootWrapper(props: Props): JSX.Element {
 
   return (
     <>
-      <div className="agent-docs-directive">
+      <div className="agent-docs-directive" aria-hidden="true">
         For the complete documentation index, see{' '}
         <a href={llmsTxtUrl} tabIndex={-1}>
           llms.txt


### PR DESCRIPTION
## Describe your changes

This PR improves agent-friendly access to Aiven documentation by making `llms.txt` easier to discover, keeping it small enough for agents to read, and adding discovery hints to generated markdown files.

The changes target documentation-side AI readiness. Remaining issues such as `Accept: text/markdown` content negotiation and soft 404 behavior require Cloudflare/hosting-layer changes.

## What changed

### Added `llms.txt` discovery in HTML

Updated `docusaurus.config.ts` to add a site-wide alternate link in the page `<head>`:

```html
<link rel="alternate" type="text/plain" href="/docs/llms.txt">
```

The URL is derived from `baseUrl`, so it works across local, preview, and production environments.

### Added hidden page-level discovery directives

Added hidden agent-readable directives to:

```
src/pages/index.tsx
src/theme/DocRoot/index.tsx
```

These directives help agents that inspect page body content find `llms.txt`.

The implementation:

- uses `useBaseUrl('llms.txt')` to make the link base URL-aware across all environments
- avoids hardcoded `/docs/` paths that would break in preview or staging deployments
- uses `aria-hidden="true"` so screen readers do not read hidden agent-only content
- uses `tabIndex={-1}` to remove the hidden link from keyboard navigation
- relies on `.agent-docs-directive` in `custom.css` for visual hiding, avoiding duplicate inline styles

### Added markdown discovery directives

Added `scripts/add-markdown-agent-directive.mjs`.

This post-build script prepends an `llms.txt` pointer to generated `.md` files:

```md
> For the complete documentation index, see [llms.txt](/docs/llms.txt).
```

The link is derived from `BASEURL`, and the script logs how many markdown files were modified out of the total files found.

### Trimmed `llms.txt`

Added `scripts/trim-llms-txt.mjs`.

This script runs after the Docusaurus build and trims `build/llms.txt` below the configured 48,000-character cap. The previous file was 273K — most agents truncate above 100K, making the majority of the docs invisible.

It also appends a footer linking to the full index:

```md
## Full documentation index

- https://aiven.io/docs/llms-full.txt
```

The footer URL is derived from `BASEURL`, and the script reserves footer space before trimming so the final file stays under the cap.

### Updated build pipeline

Updated `package.json` so the standard build runs the post-build processing automatically:

```json
"build": "docusaurus build && node scripts/trim-llms-txt.mjs && node scripts/add-markdown-agent-directive.mjs"
```

No manual step is required.

## Why this matters

AI agents and tools often read documentation differently from humans. They may look for `llms.txt`, parse raw markdown, or inspect page metadata instead of using the browser UI.

Before these changes:

- `llms.txt` was 273K and likely to be truncated by most agents
- HTML pages did not point agents to `llms.txt`
- Markdown pages did not point agents to the full documentation index
- Some links were at risk of being inconsistent across base URL environments

After these changes:

- `llms.txt` is under 48K and fully readable by agents
- `llms-full.txt` remains available for the complete index
- HTML and markdown pages both point agents to `llms.txt`
- All links are base URL-aware and work across local, preview, and production
- Hidden directives do not affect the visible UI or keyboard navigation

## How to test

### 1. Build the site

```bash
yarn build
```

Confirm the post-build scripts run. The terminal output should include:

```
Trimmed build/llms.txt to 47893 characters.
Added directive to 866/866 markdown files.
```

### 2. Start the local server

```bash
yarn serve
```

Note the port shown in the terminal. The examples below use `3000`.

### 3. Check `llms.txt`

Verify the file is under the 48,000-character cap:

```bash
wc -c build/llms.txt
```

Expected:

```
< 48000 build/llms.txt
```

Verify the footer links to the full index:

```bash
grep 'llms-full.txt' build/llms.txt
```

Expected:

```
- https://aiven.io/docs/llms-full.txt
```

### 4. Check `llms-full.txt` is reachable

```bash
curl -I http://localhost:3000/docs/llms-full.txt
```

Expected:

```
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
```

### 5. Check HTML discovery

Verify the `<head>` link and hidden directive are present:

```bash
grep -R 'llms.txt' build/index.html | head
```

Expected output includes:

```html
<link rel="alternate" type="text/plain" href="/docs/llms.txt">
```

And the hidden directive text:

```
For the complete documentation index, see
```

### 6. Check markdown discovery

Verify a doc page has the directive prepended:

```bash
head -5 build/docs/get-started.md
```

Expected:

```
> For the complete documentation index, see [llms.txt](/docs/llms.txt).
```

### 7. Run afdocs

```bash
npx afdocs check http://localhost:3000/docs/ --fixes --verbose
```

Expected result:

```
16 passed, 1 warning, 2 failed, 4 skipped
```

Expected passing checks:

```
llms-txt-exists
llms-txt-valid
llms-txt-size
llms-txt-directive-html
llms-txt-directive-md
markdown-url-support
markdown-content-parity
```

Expected failures (out of scope for this PR — require Cloudflare/hosting changes):

```
content-negotiation
http-status-codes
```

## Validation

Local production build was tested with `afdocs`.

Result:

```
16 passed
1 warning
2 failed
4 skipped
```

Generated file checks:

```
build/llms.txt: 47,893 characters
footer link: https://aiven.io/docs/llms-full.txt
```

## Remaining follow-up work

These are not addressed in this PR because they require routing or hosting changes.

### Content negotiation

The server still returns HTML for requests with:

```
Accept: text/markdown
```

This likely needs Cloudflare configuration or a Worker.

### Soft 404 handling

The local static server returns `200` for nonexistent URLs. This should be verified in production or handled at the hosting/CDN layer.

### Content start position warning

One local warning remains because the docs landing page content starts after some layout/navigation markup. This is not related to the `llms.txt` work and is not a blocker for this PR.

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.