### PR TITLE
update: add mcp tool grouping option + enable read-only by default

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -7,23 +7,19 @@ limited: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import {mcpUrl} from '@site/src/components/mcpAivenLiveConstants';
-import LimitedBadge from "@site/src/components/Badges/LimitedBadge";
 import MCPConfigSection from "@site/src/components/MCPConfigSection";
 import CursorConfigTab from "@site/src/components/CursorConfigTab";
-
-:::note
-The Aiven MCP server is in <LimitedBadge/>. Request access when you first connect.
-:::
 
 Create and manage Aiven services from AI assistants such as Cursor and Claude Code,
 including PostgreSQL®, Apache Kafka®, plans, metrics, logs, and service configuration.
 Enable read-only mode in the configuration tabs below to restrict the server to
-non-destructive operations.
+non-destructive operations, or limit tools to specific services to keep the
+assistant focused.
 
 ## Prerequisites
 
 - An [Aiven account](https://console.aiven.io/signup)
-- An MCP-compatible client (Cursor, Claude Code, Claude Desktop, or VS Code)
+- An MCP-compatible client, such as Cursor, Claude Code, Claude Desktop, or VS Code
 
 Authentication uses OAuth 2.0 with PKCE; your browser opens on first connect so you
 can sign in and authorize MCP access.
@@ -54,7 +50,7 @@ For more information, see the [Cursor MCP documentation](https://cursor.com/docs
 <TabItem value="claude-code" label="Claude Code">
 
 1. Open a terminal.
-1. Run the following command:
+1. Choose your options below, then run the generated command:
 
    <MCPConfigSection
      baseUrl={mcpUrl}
@@ -90,7 +86,7 @@ For more information, see the [Claude Code MCP documentation](https://docs.anthr
    - **Windows:**
      `%APPDATA%\Claude\claude_desktop_config.json`
 
-1. Add the following configuration to the file:
+1. Choose your options below, then add the generated configuration to the file:
 
    <MCPConfigSection
      baseUrl={mcpUrl}
@@ -125,7 +121,7 @@ and enabled.
 1. Open your workspace in VS Code.
 1. In the workspace root, create a `.vscode` directory.
 1. In the `.vscode` directory, create or edit the `mcp.json` file.
-1. Add the following configuration:
+1. Choose your options below, then add the generated configuration to the file:
 
    <MCPConfigSection
      baseUrl={mcpUrl}
@@ -157,7 +153,7 @@ For more information, see the [VS Code MCP documentation](https://code.visualstu
 <TabItem value="other" label="Other clients">
 
 1. Open your MCP client configuration.
-1. Add the Aiven MCP server using the following configuration:
+1. Choose your options below, then add the generated configuration to your client:
 
    <MCPConfigSection
      baseUrl={mcpUrl}

--- a/src/components/CursorConfigTab/index.tsx
+++ b/src/components/CursorConfigTab/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import CodeBlock from '@theme/CodeBlock';
-import MCPConfigToggle from '../MCPConfigToggle';
+import MCPConfigToggle, { buildMcpUrl, type MCPConfigState } from '../MCPConfigToggle';
 import CursorIcon from '@site/static/images/icons/cursor.svg';
 import styles from './styles.module.css';
 
@@ -9,19 +9,20 @@ type CursorConfigTabProps = {
 };
 
 export default function CursorConfigTab({ baseUrl }: CursorConfigTabProps): JSX.Element {
-  const [isReadOnly, setIsReadOnly] = useState(false);
+  const [state, setState] = useState<MCPConfigState>({ readOnly: true, scopes: [] });
 
-  const url = isReadOnly ? `${baseUrl}?read_only=true` : baseUrl;
+  const url = buildMcpUrl(baseUrl, state);
   const configJson = JSON.stringify({ mcpServers: { aiven: { type: 'http', url } } }, null, 2);
 
   const cursorConfig = { url, type: 'http' };
   const encodedConfig = typeof btoa !== 'undefined' ? btoa(JSON.stringify(cursorConfig)) : '';
   const deepLink = `cursor://anysphere.cursor-deeplink/mcp/install?name=aiven-mcp&config=${encodedConfig}`;
+  const cacheKey = `${state.readOnly}-${state.scopes.join(',')}`;
 
   return (
     <div className={styles.container}>
       <p>For one-click installation:</p>
-      <a href={deepLink} className={styles.button} key={`cursor-deeplink-${isReadOnly}`}>
+      <a href={deepLink} className={styles.button} key={`cursor-deeplink-${cacheKey}`}>
         <CursorIcon />
         <span>Add to Cursor</span>
       </a>
@@ -30,10 +31,10 @@ export default function CursorConfigTab({ baseUrl }: CursorConfigTabProps): JSX.
         <p>To add the server manually:</p>
         <ol>
           <li>In your project root, create or edit the <code>.cursor/mcp.json</code> file.</li>
-          <li>Add the following configuration:</li>
+          <li>Choose your options below, then copy the generated configuration into the file:</li>
         </ol>
-        <MCPConfigToggle onReadOnlyChange={setIsReadOnly} />
-        <CodeBlock language="json" key={`cursor-config-${isReadOnly}`}>{configJson}</CodeBlock>
+        <MCPConfigToggle onChange={setState} />
+        <CodeBlock language="json" key={`cursor-config-${cacheKey}`}>{configJson}</CodeBlock>
         <ol start={3}>
           <li>Save the file.</li>
           <li>Restart Cursor.</li>

--- a/src/components/MCPConfigSection/index.tsx
+++ b/src/components/MCPConfigSection/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import CodeBlock from '@theme/CodeBlock';
-import MCPConfigToggle from '../MCPConfigToggle';
+import MCPConfigToggle, { buildMcpUrl, type MCPConfigState } from '../MCPConfigToggle';
 import styles from './styles.module.css';
 
 type MCPConfigSectionProps = {
@@ -10,16 +10,17 @@ type MCPConfigSectionProps = {
 };
 
 export default function MCPConfigSection({ baseUrl, format, configTemplate }: MCPConfigSectionProps): JSX.Element {
-  const [isReadOnly, setIsReadOnly] = useState(false);
+  const [state, setState] = useState<MCPConfigState>({ readOnly: true, scopes: [] });
 
-  const url = isReadOnly ? `${baseUrl}?read_only=true` : baseUrl;
+  const url = buildMcpUrl(baseUrl, state);
   const config = configTemplate(url);
   const content = format === 'json' ? JSON.stringify(config, null, 2) : config;
+  const cacheKey = `${format}-${state.readOnly}-${state.scopes.join(',')}`;
 
   return (
     <div className={styles.container}>
-      <MCPConfigToggle onReadOnlyChange={setIsReadOnly} />
-      <CodeBlock language={format} key={`${format}-${isReadOnly}`}>{content}</CodeBlock>
+      <MCPConfigToggle onChange={setState} />
+      <CodeBlock language={format} key={cacheKey}>{content}</CodeBlock>
     </div>
   );
 }

--- a/src/components/MCPConfigToggle/index.tsx
+++ b/src/components/MCPConfigToggle/index.tsx
@@ -1,30 +1,103 @@
 import React, { useState } from 'react';
 import styles from './styles.module.css';
 
-type MCPConfigToggleProps = {
-  onReadOnlyChange?: (isReadOnly: boolean) => void;
+export const SCOPE_OPTIONS = ['pg', 'kafka', 'integrations'] as const;
+export type Scope = typeof SCOPE_OPTIONS[number];
+type ScopeChoice = Scope | 'all';
+
+const SCOPE_LABELS: Record<ScopeChoice, string> = {
+  all: 'All',
+  pg: 'PostgreSQL',
+  kafka: 'Kafka',
+  integrations: 'Integrations',
 };
 
-export default function MCPConfigToggle({ onReadOnlyChange }: MCPConfigToggleProps): JSX.Element {
-  const [isReadOnly, setIsReadOnly] = useState(false);
+const ALL_CHOICES: ScopeChoice[] = ['all', ...SCOPE_OPTIONS];
 
-  const handleChange = (checked: boolean) => {
-    setIsReadOnly(checked);
-    onReadOnlyChange?.(checked);
+export type MCPConfigState = {
+  readOnly: boolean;
+  scopes: Scope[];
+};
+
+type MCPConfigToggleProps = {
+  onChange?: (state: MCPConfigState) => void;
+};
+
+export default function MCPConfigToggle({ onChange }: MCPConfigToggleProps): JSX.Element {
+  const [readOnly, setReadOnly] = useState(true);
+  const [scopes, setScopes] = useState<Scope[]>([]);
+
+  const emit = (next: MCPConfigState) => onChange?.(next);
+
+  const handleReadOnly = (checked: boolean) => {
+    setReadOnly(checked);
+    emit({ readOnly: checked, scopes });
   };
+
+  const handleScope = (choice: ScopeChoice, checked: boolean) => {
+    let next: Scope[];
+    if (choice === 'all') {
+      next = [];
+    } else if (checked) {
+      next = [...scopes, choice];
+    } else {
+      next = scopes.filter((s) => s !== choice);
+    }
+    setScopes(next);
+    emit({ readOnly, scopes: next });
+  };
+
+  const isChecked = (choice: ScopeChoice): boolean =>
+    choice === 'all' ? scopes.length === 0 : scopes.includes(choice);
 
   return (
     <div className={styles.container}>
-      <label className={styles.label}>
-        <input
-          type="checkbox"
-          checked={isReadOnly}
-          onChange={(e) => handleChange(e.target.checked)}
-          className={styles.checkbox}
-        />
-        Install in read-only mode
-      </label>
-      <p className={styles.description}>Allows only read-only operations, such as listing services, viewing metrics, and running read-only queries.</p>
+      <div className={styles.section}>
+        <span className={styles.sectionLabel}>Permissions</span>
+        <label className={styles.option}>
+          <input
+            type="checkbox"
+            checked={readOnly}
+            onChange={(e) => handleReadOnly(e.target.checked)}
+            className={styles.checkbox}
+          />
+          <span>Read-only mode (no create, update, or delete)</span>
+        </label>
+      </div>
+      {!readOnly && (
+        <p className={styles.warning} role="alert">
+          ⚠ Write mode lets the assistant create, modify, and delete services and data.
+          {' '}
+          <a href="#security-and-responsibility">Review security and responsibility</a>.
+        </p>
+      )}
+
+      <div className={styles.separator} aria-hidden="true" />
+
+      <div className={styles.section}>
+        <span className={styles.sectionLabel}>Available tools</span>
+        <div className={styles.scopeRow}>
+          {ALL_CHOICES.map((choice) => (
+            <label key={choice} className={styles.option}>
+              <input
+                type="checkbox"
+                checked={isChecked(choice)}
+                onChange={(e) => handleScope(choice, e.target.checked)}
+                className={styles.checkbox}
+              />
+              <span>{SCOPE_LABELS[choice]}</span>
+            </label>
+          ))}
+        </div>
+      </div>
     </div>
   );
+}
+
+export function buildMcpUrl(baseUrl: string, state: MCPConfigState): string {
+  const params = new URLSearchParams();
+  if (state.scopes.length > 0) params.set('services_scope', state.scopes.join(','));
+  if (state.readOnly) params.set('read_only', 'true');
+  const qs = params.toString();
+  return qs ? `${baseUrl}?${qs}` : baseUrl;
 }

--- a/src/components/MCPConfigToggle/styles.module.css
+++ b/src/components/MCPConfigToggle/styles.module.css
@@ -1,33 +1,70 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
   margin: 12px 0;
-  padding: 12px;
+  padding: 12px 14px;
   background-color: var(--aiven-card-bg);
   border-radius: var(--aiven-radius);
   border: 1px solid var(--aiven-card-border);
+  font-family: var(--aiven-card-font-family);
+  font-size: 13px;
+  color: var(--ifm-color-content);
 }
 
-.label {
+.section {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: 8px 16px;
+}
+
+.sectionLabel {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--ifm-color-content-secondary, var(--ifm-color-content));
+  flex: 0 0 110px;
+}
+
+.separator {
+  height: 1px;
+  background-color: var(--aiven-card-border);
+}
+
+.scopeRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+}
+
+.option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   cursor: pointer;
-  font-weight: 500;
-  color: var(--ifm-color-content);
-  font-family: var(--aiven-card-font-family);
 }
 
 .checkbox {
-  width: 18px;
-  height: 18px;
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  margin: 0;
   cursor: pointer;
   accent-color: var(--aiven-primary-orange);
 }
 
-.description {
+.warning {
   margin: 0;
-  font-size: 14px;
-  color: var(--ifm-color-content);
+  padding: 6px 10px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--ifm-color-warning-darkest, #8a5a00);
+  background-color: var(--ifm-color-warning-contrast-background, #fff8e1);
+  border-left: 3px solid var(--ifm-color-warning, #e6a700);
+  border-radius: 4px;
+}
+
+.warning a {
+  color: inherit;
+  text-decoration: underline;
 }


### PR DESCRIPTION
1. Add documentation for the new tool scoping feature, allowing users to choose whether to install all MCP tools or only specific tool groups such as PG, Kafka, etc. The default behavior remains installing all tools.

2. Enable read-only mode by default, encouraging users to start with safer read-only access.

3. Remove the limited availability info notification, since the same information already appears next to the title. Keeping both is redundant and takes up too much above-the-fold space.

