### PR TITLE
fix: Aiven logo in Kapa modal

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -86,8 +86,7 @@ const config: Config = {
       'data-project-name': 'Aiven Kapa AI',
       'data-user-analytics-cookie-enabled': 'false',
       'data-project-color': '#5FFA74',
-      'data-project-logo':
-        'https://aiven.io/docs/images/aiven_logo_RGB_blk.svg',
+      'data-project-logo': 'https://aiven.io/docs/images/crabby_RGB_blk.svg',
       'data-modal-title': 'Ask Aiven docs AI',
       'data-modal-image-width': '38px',
       'data-button-hide': 'true',


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
