### PR TITLE
update: add Gemini CLI as MCP client

### DIFF
--- a/docs/products/kafka/get-started/get-started-kafka.md
+++ b/docs/products/kafka/get-started/get-started-kafka.md
@@ -122,7 +122,7 @@ flow when you first connect.
 
 Use the [Aiven MCP server](/docs/tools/mcp-server) to create Kafka services, manage
 topics, produce and consume messages, and configure connectors from MCP-compatible
-clients such as Cursor, Claude Code, and VS Code.
+clients such as Cursor, Claude Code, VS Code, and Gemini CLI.
 
 - Configure the Aiven MCP server in your AI assistant.
 - Describe the service or operation you want in natural language.

--- a/docs/products/postgresql/get-started.md
+++ b/docs/products/postgresql/get-started.md
@@ -34,7 +34,7 @@ Start using Aiven for PostgreSQL® by creating a service, connecting to it, and 
 </TabItem>
 <TabItem value="mcp" label="MCP">
 
-- An MCP-compatible client such as Cursor, Claude Code, Claude Desktop, or VS Code
+- An MCP-compatible client such as Cursor, Claude Code, Claude Desktop, VS Code, or Gemini CLI
 - A configured Aiven MCP server <LimitedBadge/> in your client
 
 </TabItem>

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -52,8 +52,8 @@ to Aiven and select your organization. The server refreshes tokens automatically
 ### Prerequisites
 
 - An [Aiven account](https://console.aiven.io/signup)
-- An MCP-compatible client, such as Cursor, Claude Code, Claude Desktop, or
-  Visual Studio Code (VS Code)
+- An MCP-compatible client, such as Cursor, Claude Code, Claude Desktop,
+  Visual Studio Code (VS Code), or Gemini CLI
 
 ### Configure your MCP client {#configure-aiven-mcp}
 
@@ -298,6 +298,41 @@ You can also run the server locally using npx. This requires an
 1. If prompted to allow tool execution, click **Allow**.
 
 </TabItem>
+<TabItem value="gemini-cli" label="Gemini CLI">
+
+1. Install the Gemini CLI:
+
+   ```bash
+   npm install -g @google/gemini-cli
+   ```
+
+   Or, on macOS:
+
+   ```bash
+   brew install gemini-cli
+   ```
+
+1. Create or edit the `~/.gemini/settings.json` file.
+1. Add the following configuration:
+
+   <!-- vale off -->
+   <CodeBlock language="json">{JSON.stringify({mcpServers: {aiven: {httpUrl: mcpUrl}}}, null, 2)}</CodeBlock>
+   <!-- vale on -->
+
+1. Save the file.
+1. Run `gemini` to start the CLI.
+1. Run `/mcp auth aiven` to sign in via your browser.
+1. Run `/mcp list` to confirm the server is connected.
+
+#### Verify the connection
+
+1. In the Gemini CLI, try a prompt such as:
+
+   > List my Aiven projects.
+
+1. If prompted to allow tool execution, approve the request.
+
+</TabItem>
 <TabItem value="other" label="Other clients">
 
 1. Open your MCP client configuration.
@@ -536,6 +571,39 @@ if the steps do not match your interface.
 1. Confirm that **Aiven** appears under **Settings** > **Apps**.
 
 For more information, see the [OpenAI Developer mode documentation](https://developers.openai.com/api/docs/guides/developer-mode).
+
+</TabItem>
+<TabItem value="gemini-cli" label="Gemini CLI">
+
+1. Install the Gemini CLI:
+
+   ```bash
+   npm install -g @google/gemini-cli
+   ```
+
+   Or, on macOS:
+
+   ```bash
+   brew install gemini-cli
+   ```
+
+1. Create or edit the `~/.gemini/settings.json` file.
+1. Add the following configuration:
+
+   ```json
+   {
+     "mcpServers": {
+       "aiven-docs": {
+         "httpUrl": "https://aiven-docs.mcp.kapa.ai"
+       }
+     }
+   }
+   ```
+
+1. Save the file.
+1. Run `gemini` to start the CLI.
+1. Run `/mcp auth aiven-docs` to sign in via your browser.
+1. Run `/mcp list` to confirm the server is connected.
 
 </TabItem>
 <TabItem value="other" label="Other clients">


### PR DESCRIPTION
Add Gemini CLI as an MCP client option in the Aiven MCP server and Documentation MCP
server setup instructions. Includes installation via npm/brew, configuration in
~/.gemini/settings.json with the httpUrl key, and authentication/verification steps.
Also updates client lists in the PostgreSQL and Kafka get-started pages.

## Checklist
- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
