### PR TITLE
update: Fix call-out about Kafka OAUTHBEARER and SASL config

### DIFF
--- a/docs/products/kafka/howto/enable-oidc.md
+++ b/docs/products/kafka/howto/enable-oidc.md
@@ -18,8 +18,8 @@ of the Kafka brokers. This restart does not cause service downtime.
 
 :::note
 To use the `OAUTHBEARER` mechanism, you must enable `kafka_authentication_methods.sasl`.
-Additionally, at least one of the SASL mechanisms (PLAIN, SCRAM-SHA-256, or SCRAM-SHA-512)
-must be enabled. See
+Other SASL mechanisms (PLAIN, SCRAM-SHA-256, and SCRAM-SHA-512) are optional and can be
+disabled independently. See
 [Enable and configure SASL authentication with Aiven for Apache Kafka®](/docs/products/kafka/howto/kafka-sasl-auth).
 :::
 


### PR DESCRIPTION
The note claimed that OAUTHBEARER requires at least one of PLAIN, SCRAM-SHA-256, or SCRAM-SHA-512 to also be enabled. That's wrong — kafka.sasl_oauthbearer_jwks_endpoint_url alone is sufficient and the other SASL mechanisms can be disabled independently.

The requirement to enable kafka_authentication_methods.sasl is accurate and kept.

## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
