### PR TITLE
feat: Karapace schema references content

### DIFF
--- a/docs/products/kafka/karapace.md
+++ b/docs/products/kafka/karapace.md
@@ -2,27 +2,38 @@
 title: Karapace
 ---
 
-[Karapace](https://karapace.io/) is an Aiven built open-source Schema Registry for Apache Kafka®, and provides a central repository to store and retrieve schemas.
+[Karapace](https://karapace.io/) is an Aiven-built open-source Schema Registry for
+Apache Kafka®, and provides a central repository to store and retrieve schemas.
 It consists of a **Schema Registry** and a **REST API**. All Kafka services on Aiven
-support both these features (Schema
-registry and REST API), and as a user, based on your requirements, you
-can enable or disable them.
+support both these features, and you can enable or disable them based on your
+requirements.
 
-Karapace supports storing schemas in a central repository, which clients
-can access to serialize and deserialize messages. The schemas also
-maintain their own version histories and can be checked for
-compatibility between their different respective versions. It also
-includes support for JSON Schema, Avro and Protobuf data formats.
+Karapace supports storing schemas in a central repository, which clients can access
+to serialize and deserialize messages. The schemas maintain their own version histories
+and you can check compatibility between versions.
 
-Karapace REST provides a RESTful interface to your Apache Kafka cluster,
-allowing you to perform tasks such as producing and consuming messages
-and performing administrative cluster work while using the web language.
+## Supported schema formats
+
+Karapace supports the following schema formats:
+
+| Format      | Schema registration | Schema references |
+|-------------|--------------------|--------------------|
+| Avro        | ✓                  | ✓                  |
+| Protobuf    | ✓                  | ✓                  |
+| JSON Schema | ✓                  | -                  |
+
+**Schema references** allow you to register a schema that depends on one or more
+previously registered schemas, rather than inlining those definitions each time.
+Karapace supports Avro schema references from v6.1.0 onward.
+See [Schema references in Karapace](/docs/products/kafka/karapace/concepts/schema-references)
+for details and examples.
+
+Karapace REST provides a RESTful interface to your Apache Kafka cluster, allowing
+you to produce and consume messages and perform administrative cluster work using
+standard HTTP.
 
 ## Karapace resources
 
-If you are new to Karapace, learn more from the following resources:
-
--   The Karapace schema registry that Aiven maintains and makes
-    available for every Aiven for Apache Kafka service:
-    [https://karapace.io/](https://karapace.io/)
--   [GitHub repository](https://github.com/aiven/karapace).
+- The Karapace schema registry that Aiven maintains and makes available for every
+  Aiven for Apache Kafka service: [https://karapace.io/](https://karapace.io/)
+- [GitHub repository](https://github.com/aiven/karapace)

--- a/docs/products/kafka/karapace/concepts/schema-references.md
+++ b/docs/products/kafka/karapace/concepts/schema-references.md
@@ -1,5 +1,6 @@
 ---
 title: Schema references in Karapace
+sidebar_label: Schema references
 ---
 
 import RelatedPages from "@site/src/components/RelatedPages";

--- a/docs/products/kafka/karapace/concepts/schema-references.md
+++ b/docs/products/kafka/karapace/concepts/schema-references.md
@@ -1,0 +1,110 @@
+---
+title: Schema references in Karapace
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Schema references let you register a schema that depends on other schemas already
+stored in the Schema Registry. Use schema references to reuse shared schemas instead
+of copying their definitions into every schema that uses them.
+
+For example, if a `Country` record is used by `Address`, and `Address` is used by
+`Person`, you can register each type once and reference it by subject and version.
+
+## Supported schema formats
+
+Karapace supports schema references for:
+
+- Avro
+- Protobuf
+
+:::note
+Schema references are not supported for JSON Schema.
+:::
+
+## How schema references work
+
+When you register a schema that uses types defined in other subjects, include a
+`references` array. Each entry lists the reference `name`, the subject where the
+schema is registered (`subject`), and the version to resolve (`version`).
+
+Each reference points to a specific schema version. Karapace loads those schema
+versions and uses the linked definitions when validating schemas or checking
+compatibility.
+
+## When to use schema references
+
+Use schema references to:
+
+- Reuse the same record or message shape across several subjects with one source of
+  truth instead of duplicated inline definitions.
+- Manage updates to a shared type in one subject instead of editing duplicated
+  definitions in many schemas.
+
+## Schema Registry API structure
+
+When you register a schema with the Schema Registry API, include a `references` array
+in the request body. The following example shows the shape of the payload (the HTTP
+method and path are shown for context):
+
+```json
+POST /subjects/{subject}/versions
+{
+  "schemaType": "AVRO",
+  "schema": "<schema JSON string>",
+  "references": [
+    {
+      "name": "<reference name>",
+      "subject": "<subject where the referenced schema is registered>",
+      "version": <version number>
+    }
+  ]
+}
+```
+
+Each object in `references` uses the following fields:
+
+- **`name`**: A name that identifies the reference within the schema. For Avro, use a
+  file-style name such as `address.avsc`; this value does not need to match an actual
+  file on disk. For Protobuf, use the import path from the Protobuf schema, such as
+  `address.proto`.
+- **`subject`**: The subject where the referenced schema is registered in Karapace.
+- **`version`**: The schema version to reference.
+
+Register every referenced schema before you register a schema that lists it in
+`references`.
+
+## Avro references
+
+In Avro, each `references` entry links your schema to another Avro schema that is
+already registered under its own subject—for example, an `Address` record that includes
+a `Country` type defined elsewhere.
+
+Use
+[Register schemas with references in Karapace](/docs/products/kafka/karapace/howto/register-schemas-with-references)
+for complete `curl` examples that register dependent Avro schemas.
+
+## Protobuf references
+
+Protobuf uses the same `references` array as Avro. Set `name` to the import path from
+your `.proto` file, such as `address.proto`. The value must match the `import`
+statement exactly.
+
+Use
+[Register schemas with references in Karapace](/docs/products/kafka/karapace/howto/register-schemas-with-references)
+for complete `curl` examples that register dependent Protobuf schemas.
+
+## Compatibility checks with references
+
+Compatibility checks behave the same for schemas with references as for standalone
+schemas. Karapace resolves referenced schema versions before it evaluates compatibility.
+
+Each reference pins a specific schema version. Update the `version` field in the
+corresponding `references` entry when adopting a newer version of a referenced schema.
+
+<RelatedPages/>
+
+- [Register schemas with references in Karapace](/docs/products/kafka/karapace/howto/register-schemas-with-references)
+- [Get started with Karapace](/docs/products/kafka/karapace/get-started)
+- [Karapace schema registry authorization](/docs/products/kafka/karapace/concepts/schema-registry-authorization)
+- [Enable Karapace schema registry and REST APIs](/docs/products/kafka/karapace/howto/enable-karapace)

--- a/docs/products/kafka/karapace/concepts/schema-references.md
+++ b/docs/products/kafka/karapace/concepts/schema-references.md
@@ -16,18 +16,19 @@ For example, if a `Country` record is used by `Address`, and `Address` is used b
 
 Karapace supports schema references for:
 
-- Avro
+- Avro (Karapace 6.1.0 or later)
 - Protobuf
 
 :::note
-Schema references are not supported for JSON Schema.
+Schema references are not supported for JSON Schema. If you register a JSON Schema
+with a `references` array, Karapace returns an HTTP `422 Unprocessable Entity` status code.
 :::
 
 ## How schema references work
 
 When you register a schema that uses types defined in other subjects, include a
-`references` array. Each entry lists the reference `name`, the subject where the
-schema is registered (`subject`), and the version to resolve (`version`).
+`references` array. Each entry lists `name`, `subject`, and `version`. For Avro,
+`name` is a label. For Protobuf, `name` must match the `import` path.
 
 Each reference points to a specific schema version. Karapace loads those schema
 versions and uses the linked definitions when validating schemas or checking
@@ -65,10 +66,12 @@ POST /subjects/{subject}/versions
 
 Each object in `references` uses the following fields:
 
-- **`name`**: A name that identifies the reference within the schema. For Avro, use a
-  file-style name such as `address.avsc`; this value does not need to match an actual
-  file on disk. For Protobuf, use the import path from the Protobuf schema, such as
-  `address.proto`.
+- **`name`**: Identifies the reference in the registration payload. For Avro, use a
+  file-style label such as `address.avsc`; the `.avsc` suffix is a convention, not a
+  requirement. For Protobuf, set `name` to the import path, such as `address.proto`,
+  which must match the `import` statement exactly. Resolution behavior differs by
+  format; see [Avro references](#avro-references) and
+  [Protobuf references](#protobuf-references).
 - **`subject`**: The subject where the referenced schema is registered in Karapace.
 - **`version`**: The schema version to reference.
 
@@ -77,9 +80,11 @@ Register every referenced schema before you register a schema that lists it in
 
 ## Avro references
 
-In Avro, each `references` entry links your schema to another Avro schema that is
-already registered under its own subject—for example, an `Address` record that includes
-a `Country` type defined elsewhere.
+In Avro, the `name` field is a label only. Karapace resolves each reference from the
+Avro type names in your schema, together with the `subject` and `version` fields. For
+example, an `Address` record that uses a `Country` type includes a `references` entry
+with `subject` and `version` pointing to the registration that contains the `Country`
+record.
 
 Use
 [Register schemas with references in Karapace](/docs/products/kafka/karapace/howto/register-schemas-with-references)
@@ -87,9 +92,10 @@ for complete `curl` examples that register dependent Avro schemas.
 
 ## Protobuf references
 
-Protobuf uses the same `references` array as Avro. Set `name` to the import path from
-your `.proto` file, such as `address.proto`. The value must match the `import`
-statement exactly.
+Protobuf uses the same `references` array as Avro. Unlike Avro, Karapace uses the
+`name` field to resolve the reference. Set `name` to the import path from your
+`.proto` file, such as `address.proto`. The value must match the `import` statement
+exactly.
 
 Use
 [Register schemas with references in Karapace](/docs/products/kafka/karapace/howto/register-schemas-with-references)

--- a/docs/products/kafka/karapace/get-started.md
+++ b/docs/products/kafka/karapace/get-started.md
@@ -4,26 +4,25 @@ sidebar_label: Get started
 keywords: [quick start]
 ---
 
-To use Karapace, enable **Karapace Schema registry** and **REST APIs** on your Aiven for Apache Kafka® service, see [Enable Karapace schema registry and REST APIs](/docs/products/kafka/karapace/howto/enable-karapace).
+To use Karapace, enable **Karapace schema registry** and **REST APIs** on your Aiven for Apache Kafka® service.
+For instructions, see
+[Enable Karapace schema registry and REST APIs](/docs/products/kafka/karapace/howto/enable-karapace).
 
 ## Next steps
 
--   Learn more about
-    [Karapace schema registry authorization](/docs/products/kafka/karapace/concepts/schema-registry-authorization) and
-    [ACLs definition](/docs/products/kafka/karapace/concepts/acl-definition).
--   Learn more about how to enable
-    [Karapace schema registry authorization](/docs/products/kafka/karapace/howto/enable-schema-registry-authorization) and how to
-    [manage Karapace schema registry authorization](/docs/products/kafka/karapace/howto/manage-schema-registry-authorization).
--   Learn more about how to enable
-    [Apache Kafka REST proxy authorization](/docs/products/kafka/karapace/howto/enable-oauth-oidc-kafka-rest-proxy) and how to
-    [Enable Karapace Kafka REST authorization](/docs/products/kafka/karapace/howto/enable-kafka-rest-proxy-authorization).
+- Use [schema references for Avro and Protobuf](/docs/products/kafka/karapace/concepts/schema-references)
+  to reuse shared schemas across subjects.
+- Read about [Karapace schema registry authorization](/docs/products/kafka/karapace/concepts/schema-registry-authorization)
+  and [schema registry ACL definitions](/docs/products/kafka/karapace/concepts/acl-definition).
+- Enable [Karapace schema registry authorization](/docs/products/kafka/karapace/howto/enable-schema-registry-authorization).
+  Manage access in [Manage schema registry authorization](/docs/products/kafka/karapace/howto/manage-schema-registry-authorization).
+- Enable [OAuth2/OIDC for the Apache Kafka® REST proxy](/docs/products/kafka/karapace/howto/enable-oauth-oidc-kafka-rest-proxy)
+  and [Apache Kafka® REST proxy authorization](/docs/products/kafka/karapace/howto/enable-kafka-rest-proxy-authorization).
 
 ## More resources
 
--   For information on how to manage Kafka schema registry ACL resources
-    on Terraform, see
-    [Manage resources via Terraform](/docs/products/kafka/karapace/howto/manage-schema-registry-authorization).
--   For more information on how to set up Karapace with Aiven for Apache
-    Kafka® using [Aiven Terraform
-    Provider](https://registry.terraform.io/providers/aiven/aiven/latest/docs), see
-    [the `aiven_kafka` resource documentation](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/kafka).
+- To manage Kafka schema registry ACL resources with Terraform, refer to
+  [Manage resources via Terraform](/docs/products/kafka/karapace/howto/manage-schema-registry-authorization).
+- To set up Karapace with Aiven for Apache Kafka® using Terraform, refer to the
+  [Aiven provider for Terraform](https://registry.terraform.io/providers/aiven/aiven/latest/docs)
+  and the [`aiven_kafka` resource documentation](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/kafka).

--- a/docs/products/kafka/karapace/howto/register-schemas-with-references.md
+++ b/docs/products/kafka/karapace/howto/register-schemas-with-references.md
@@ -23,6 +23,10 @@ Karapace resolves linked schemas during compatibility checks.
 
 Avro schema references require Karapace 6.1.0 or later.
 
+In each `references` entry, `name` is a label only and can be any value. Karapace
+resolves the reference from the fully qualified type name in your schema (for example
+`com.example.Country`), together with `subject` and `version`.
+
 Register a `Country` schema, an `Address` schema that references `Country`, a `Job`
 schema, and a `Person` schema that references `Address` and `Job`.
 
@@ -56,6 +60,10 @@ schema, and a `Person` schema that references `Address` and `Job`.
        ]
      }'
    ```
+
+   In this request, `country.avsc` is only a label. Karapace resolves the `Country`
+   record through the `com.example.Country` type in the schema, together with
+   `subject` and `version`.
 
 1. Register the `Job` schema:
 

--- a/docs/products/kafka/karapace/howto/register-schemas-with-references.md
+++ b/docs/products/kafka/karapace/howto/register-schemas-with-references.md
@@ -1,0 +1,135 @@
+---
+title: Register schemas with references in Karapace
+sidebar_label: Register schemas with references
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Use the Karapace Schema Registry API and `curl` to register Avro and Protobuf schemas that use schema references.
+
+[Schema references in Karapace](/docs/products/kafka/karapace/concepts/schema-references)
+explains which formats support references, what each `references` field means, and how
+Karapace resolves linked schemas during compatibility checks.
+
+## Prerequisites
+
+- An [Aiven for Apache Kafka®](/docs/products/kafka) service with the Karapace Schema
+  Registry enabled
+- Registry connection variables: `SCHEMA_REGISTRY_URL`, `SCHEMA_REGISTRY_USER`, and
+  `SCHEMA_REGISTRY_PASSWORD`
+- `curl` available in your environment
+
+## Example: Avro records with references
+
+Avro schema references require Karapace 6.1.0 or later.
+
+Register a `Country` schema, an `Address` schema that references `Country`, a `Job`
+schema, and a `Person` schema that references `Address` and `Job`.
+
+1. Register the `Country` schema:
+
+   ```bash
+   curl -X POST "$SCHEMA_REGISTRY_URL/subjects/country/versions" \
+     -u "$SCHEMA_REGISTRY_USER:$SCHEMA_REGISTRY_PASSWORD" \
+     -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+     -d '{
+       "schemaType": "AVRO",
+       "schema": "{\"type\":\"record\",\"name\":\"Country\",\"namespace\":\"com.example\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"code\",\"type\":\"string\"}]}"
+     }'
+   ```
+
+1. Register the `Address` schema, referencing `Country`:
+
+   ```bash
+   curl -X POST "$SCHEMA_REGISTRY_URL/subjects/address/versions" \
+     -u "$SCHEMA_REGISTRY_USER:$SCHEMA_REGISTRY_PASSWORD" \
+     -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+     -d '{
+       "schemaType": "AVRO",
+       "schema": "{\"type\":\"record\",\"name\":\"Address\",\"namespace\":\"com.example\",\"fields\":[{\"name\":\"street\",\"type\":\"string\"},{\"name\":\"city\",\"type\":\"string\"},{\"name\":\"country\",\"type\":\"com.example.Country\"}]}",
+       "references": [
+         {
+           "name": "country.avsc",
+           "subject": "country",
+           "version": 1
+         }
+       ]
+     }'
+   ```
+
+1. Register the `Job` schema:
+
+   ```bash
+   curl -X POST "$SCHEMA_REGISTRY_URL/subjects/job/versions" \
+     -u "$SCHEMA_REGISTRY_USER:$SCHEMA_REGISTRY_PASSWORD" \
+     -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+     -d '{
+       "schemaType": "AVRO",
+       "schema": "{\"type\":\"record\",\"name\":\"Job\",\"namespace\":\"com.example\",\"fields\":[{\"name\":\"title\",\"type\":\"string\"},{\"name\":\"salary\",\"type\":\"double\"}]}"
+     }'
+   ```
+
+1. Register the `Person` schema, referencing `Address` and `Job`:
+
+   ```bash
+   curl -X POST "$SCHEMA_REGISTRY_URL/subjects/person/versions" \
+     -u "$SCHEMA_REGISTRY_USER:$SCHEMA_REGISTRY_PASSWORD" \
+     -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+     -d '{
+       "schemaType": "AVRO",
+       "schema": "{\"type\":\"record\",\"name\":\"Person\",\"namespace\":\"com.example\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"age\",\"type\":\"int\"},{\"name\":\"address\",\"type\":\"com.example.Address\"},{\"name\":\"job\",\"type\":\"com.example.Job\"}]}",
+       "references": [
+         {
+           "name": "address.avsc",
+           "subject": "address",
+           "version": 1
+         },
+         {
+           "name": "job.avsc",
+           "subject": "job",
+           "version": 1
+         }
+       ]
+     }'
+   ```
+
+## Example: Protobuf messages with imports
+
+Register an `Address` message and a `Customer` message that imports `Address`.
+
+1. Register the `Address` schema:
+
+   ```bash
+   curl -X POST "$SCHEMA_REGISTRY_URL/subjects/address-proto/versions" \
+     -u "$SCHEMA_REGISTRY_USER:$SCHEMA_REGISTRY_PASSWORD" \
+     -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+     -d '{
+       "schemaType": "PROTOBUF",
+       "schema": "syntax = \"proto3\"; package com.example; message Address { string street = 1; string city = 2; }"
+     }'
+   ```
+
+1. Register the `Customer` schema, referencing `Address`:
+
+   ```bash
+   curl -X POST "$SCHEMA_REGISTRY_URL/subjects/customer-proto/versions" \
+     -u "$SCHEMA_REGISTRY_USER:$SCHEMA_REGISTRY_PASSWORD" \
+     -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+     -d '{
+       "schemaType": "PROTOBUF",
+       "schema": "syntax = \"proto3\"; package com.example; import \"address.proto\"; message Customer { int32 id = 1; string name = 2; Address address = 3; }",
+       "references": [
+         {
+           "name": "address.proto",
+           "subject": "address-proto",
+           "version": 1
+         }
+       ]
+     }'
+   ```
+
+<RelatedPages/>
+
+- [Schema references in Karapace](/docs/products/kafka/karapace/concepts/schema-references)
+- [Get started with Karapace](/docs/products/kafka/karapace/get-started)
+- [Enable Karapace schema registry and REST APIs](/docs/products/kafka/karapace/howto/enable-karapace)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1112,6 +1112,7 @@ const sidebars: SidebarsConfig = {
                   label: 'Concepts',
                   items: [
                     'products/kafka/karapace/concepts/schema-registry-authorization',
+                    'products/kafka/karapace/concepts/schema-references',
                     'products/kafka/karapace/concepts/acl-definition',
                     'products/kafka/karapace/concepts/kafka-rest-proxy-authorization',
                   ],
@@ -1121,6 +1122,7 @@ const sidebars: SidebarsConfig = {
                   label: 'How to',
                   items: [
                     'products/kafka/karapace/howto/enable-karapace',
+                    'products/kafka/karapace/howto/register-schemas-with-references',
                     'products/kafka/karapace/howto/enable-schema-registry-authorization',
                     'products/kafka/karapace/howto/enable-kafka-rest-proxy-authorization',
                     'products/kafka/karapace/howto/enable-oauth-oidc-kafka-rest-proxy',


### PR DESCRIPTION
## Describe your changes

Add documentation for Karapace schema references - Arvo and Protobuf.

- New concept page: explains what schema references are, supported formats
  (Avro, Protobuf), API structure, and compatibility behavior
- New how-to page: step-by-step curl examples for registering Avro and
  Protobuf schemas with references
- Updated karapace.md: added supported schema formats table
- Updated get-started.md: added link to schema references in Next steps

Page previews: 
- https://ec-880-document-avro-schema.aiven-docs.pages.dev/docs/products/kafka/karapace/concepts/schema-references
- https://ec-880-document-avro-schema.aiven-docs.pages.dev/docs/products/kafka/karapace/howto/register-schemas-with-references


[EC-880](https://aiven.atlassian.net/browse/EC-880)

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.


[EC-880]: https://aiven.atlassian.net/browse/EC-880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ