### PR TITLE
feat: update kafka docs

### DIFF
--- a/docs/products/kafka/reference/advanced-params-inkless.md
+++ b/docs/products/kafka/reference/advanced-params-inkless.md
@@ -5,6 +5,9 @@ sidebar_label: Inkless Kafka
 
 View the configuration options for Aiven for Apache Kafka® Inkless. These configurations apply to Inkless Kafka on Aiven Cloud.
 
+Inkless supports two topic types: classic topics with remote.storage.enable=true and diskless topics with diskless.enable=true.
+For more information about the differences and use cases, see [Classic topics vs. diskless topics](https://aiven.io/docs/products/kafka/diskless/concepts/topics-vs-classic#compare-classic-and-diskless-topics).
+
 import BrokerReference from '@site/static/includes/config-kafka-inkless-saas.md';
 import TopicReference from '@site/static/includes/config-kafka-inkless-saas-topic.md';
 

--- a/static/includes/config-kafka-inkless-saas-topic.md
+++ b/static/includes/config-kafka-inkless-saas-topic.md
@@ -24,7 +24,7 @@ import Link from '@docusaurus/Link'
             </div>
 
               <div className="description">
-                <p>The retention policy to use on old segments. Possible values include &#x27;delete&#x27;, &#x27;compact&#x27;, or a comma-separated list of them. The default policy (&#x27;delete&#x27;) will discard old segments when their retention time or size limit has been reached. The &#x27;compact&#x27; setting will enable log compaction on the topic.</p>
+                <p>The retention policy to use on old segments. The default policy (&#x27;delete&#x27;) will discard old segments when their retention time or size limit has been reached. The &#x27;compact&#x27; setting will enable log compaction on the topic. The &#x27;compact&#x27; setting is not supported for diskless topics.</p>
               </div>
         </td>
       </tr>
@@ -173,7 +173,7 @@ import Link from '@docusaurus/Link'
             </div>
 
               <div className="description">
-                <p>When a producer sets acks to &#x27;all&#x27; (or &#x27;-1&#x27;), this configuration specifies the minimum number of replicas that must acknowledge a write for the write to be considered successful. If this minimum cannot be met, then the producer will raise an exception (either NotEnoughReplicas or NotEnoughReplicasAfterAppend). When used together, min.insync.replicas and acks allow you to enforce greater durability guarantees. A typical scenario would be to create a topic with a replication factor of 3, set min.insync.replicas to 2, and produce with acks of &#x27;all&#x27;. This will ensure that the producer raises an exception if a majority of replicas do not receive a write.</p>
+                <p>When a producer sets acks to &#x27;all&#x27; (or &#x27;-1&#x27;), min.insync.replicas specifies the minimum number of replicas that must acknowledge a write for the write to be considered successful. This configuration is not supported for Diskless topics. (Default: 1)</p>
               </div>
         </td>
       </tr>
@@ -269,7 +269,7 @@ import Link from '@docusaurus/Link'
             </div>
 
               <div className="description">
-                <p>Indicates whether diskless should be enabled. This is only available for BYOC services with Diskless feature enabled.</p>
+                <p>Indicates whether diskless should be enabled. (Default: false)</p>
               </div>
         </td>
       </tr>
@@ -292,7 +292,7 @@ import Link from '@docusaurus/Link'
             </div>
 
               <div className="description">
-                <p>Indicates whether tiered storage should be enabled. This is only available for services with Tiered Storage feature enabled.</p>
+                <p>Indicates whether tiered storage should be enabled. If neither diskless.enable or remote.storage.enable are specified then this configuration is automatically set to &#x27;true&#x27; when topic is created. (Default: false)</p>
               </div>
         </td>
       </tr>

--- a/static/includes/config-kafka-inkless-saas.md
+++ b/static/includes/config-kafka-inkless-saas.md
@@ -804,54 +804,6 @@ import Link from '@docusaurus/Link'
         <td>
             <div className="param">
               <p className="name">
-                <Link id="kafka.log_local_retention_ms" to="#kafka.log_local_retention_ms">
-                  <strong>kafka.log_local_retention_ms</strong>
-                </Link>
-              </p>
-              <p>
-                <code className="type" title="integer">integer</code>
-              </p>
-            </div>
-
-            <div className="constraints">
-              <ul>
-                  <li>min: <code>900000</code></li>
-              </ul>
-            </div>
-
-              <div className="description">
-                <p>The number of milliseconds to keep the local log segments before it gets eligible for deletion. If set to -2, the value of log.retention.ms is used. The effective value should always be less than or equal to log.retention.ms value. (Default: -2)</p>
-              </div>
-        </td>
-      </tr>
-      <tr>
-        <td>
-            <div className="param">
-              <p className="name">
-                <Link id="kafka.log_local_retention_bytes" to="#kafka.log_local_retention_bytes">
-                  <strong>kafka.log_local_retention_bytes</strong>
-                </Link>
-              </p>
-              <p>
-                <code className="type" title="integer">integer</code>
-              </p>
-            </div>
-
-            <div className="constraints">
-              <ul>
-                  <li>min: <code>5368709120</code></li>
-              </ul>
-            </div>
-
-              <div className="description">
-                <p>The maximum size of local log segments that can grow for a partition before it gets eligible for deletion. If set to -2, the value of log.retention.bytes is used. The effective value should always be less than or equal to log.retention.bytes value. (Default: -2)</p>
-              </div>
-        </td>
-      </tr>
-      <tr>
-        <td>
-            <div className="param">
-              <p className="name">
                 <Link id="kafka.log_retention_bytes" to="#kafka.log_retention_bytes">
                   <strong>kafka.log_retention_bytes</strong>
                 </Link>
@@ -942,7 +894,7 @@ import Link from '@docusaurus/Link'
             </div>
 
               <div className="description">
-                <p>Enable auto-creation of topics. (Default: false)</p>
+                <p>Enable auto-creation of topics. (Default: true)</p>
               </div>
         </td>
       </tr>
@@ -992,7 +944,7 @@ import Link from '@docusaurus/Link'
             </div>
 
               <div className="description">
-                <p>Replication factor for auto-created topics (Default: 3)</p>
+                <p>Replication factor for created topics. For Classic topics, the default is 3. For Diskless topics, the default is 1.</p>
               </div>
         </td>
       </tr>


### PR DESCRIPTION
## Describe your changes

Update to latest configs, add link to reference different topic types in inkless.

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
