### PR TITLE
update: move search for services in sidebar

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -426,6 +426,7 @@ const sidebars: SidebarsConfig = {
       className: 'expandedSection',
       items: [
         'products/services',
+        'platform/howto/search-services',
         {
           type: 'category',
           label: 'Aiven for Apache Flink®',
@@ -2082,7 +2083,6 @@ const sidebars: SidebarsConfig = {
         'platform/concepts/service-power-cycle',
         'platform/concepts/rename-services',
         'platform/howto/tag-resources',
-        'platform/howto/search-services',
         'platform/howto/create_new_service_user',
         'platform/concepts/service-forking',
         'platform/howto/prepare-for-high-load',


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
