### PR TITLE
feat: DataHub notifications

### DIFF
--- a/docs/products/datahub/configure-slack-notifications.md
+++ b/docs/products/datahub/configure-slack-notifications.md
@@ -23,15 +23,15 @@ and setting environment variables on the actions app.
 1. On the **OAuth & Permissions** page, add these
    [app scopes](https://docs.slack.dev/app-management/quickstart-app-settings#scopes):
 
-- `chat:write`: Post messages as the Slack bot
-- `chat:write.public`: Post in public channels without being a member
-- `channels:read`: Look up channel IDs
+   - `chat:write`: Post messages as the Slack bot
+   - `chat:write.public`: Post in public channels without being a member
+   - `channels:read`: Look up channel IDs
 
 1. [Install the app](https://docs.slack.dev/app-management/quickstart-app-settings#installing).
 
 1. Get the following app credentials:
 
-   - [Slack bot token](https://api.slack.com/authentication/token-types#bot): On the
+   - [Slack bot token](https://api.slack.com/authentication/token-types#bot): On
      the **OAuth & Permissions** page. Bot tokens begin with `xoxb-`.
    - [Signing secret](https://api.slack.com/authentication/verifying-requests-from-slack):
      From the **Basic Info** section.
@@ -61,7 +61,9 @@ and setting environment variables on the actions app.
    | `DATAHUB_ACTIONS_SLACK_ENABLED` | `true` |
    | `DATAHUB_ACTIONS_SLACK_CHANNEL` | Your Slack channel ID. |
    | `DATAHUB_ACTIONS_SLACK_DATAHUB_BASE_URL` | The DataHub **Application URL** from the **Connection information**. Adds links in messages. |
-   | `DATAHUB_ACTIONS_SLACK_SUPPRESS_SYSTEM_ACTIVITY` | Optional. To get low level system activity notifications such as datasets being ingested, set to `false`. Defaults to `true`. |
+   | `DATAHUB_ACTIONS_SLACK_SUPPRESS_SYSTEM_ACTIVITY` | Optional. To get low-level system activity notifications such as datasets being ingested, set to `false`. Defaults to `true`. |
+
+1. Click **Save**.
 
 After setting the variables, the actions app restarts automatically.
 

--- a/docs/products/datahub/configure-slack-notifications.md
+++ b/docs/products/datahub/configure-slack-notifications.md
@@ -1,0 +1,69 @@
+---
+title: Configure Slack notifications for DataHub activity
+sidebar_label: Configure Slack notifications
+limited: true
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Get activity notifications for your DataHub service in a Slack channel, including new datasets, ownership changes, tags, and glossary updates.
+
+You can enable Slack notifications by configuring a Slack app
+and setting environment variables on the actions app.
+
+## Prerequisites
+
+- A Slack workspace where you can create and install apps.
+- The ID of the Slack channel to send notifications to.
+
+## Create and configure a Slack app
+
+1. [Create a Slack app](https://docs.slack.dev/app-management/quickstart-app-settings).
+
+1. On the **OAuth & Permissions** page, add these
+   [app scopes](https://docs.slack.dev/app-management/quickstart-app-settings#scopes):
+
+- `chat:write`: Post messages as the Slack bot
+- `chat:write.public`: Post in public channels without being a member
+- `channels:read`: Look up channel IDs
+
+1. [Install the app](https://docs.slack.dev/app-management/quickstart-app-settings#installing).
+
+1. Get the following app credentials:
+
+   - [Slack bot token](https://api.slack.com/authentication/token-types#bot): On the
+     the **OAuth & Permissions** page. Bot tokens begin with `xoxb-`.
+   - [Signing secret](https://api.slack.com/authentication/verifying-requests-from-slack):
+     From the **Basic Info** section.
+   - The Slack channel ID: In the channel details. These IDs start with `C`.
+
+1. For private channels:
+   To allow the app to post messages,
+   [add it to the channel](https://slack.com/help/articles/201398103-Add-an-app-to-a-channel).
+   For public channels, the `chat:write.public` scope lets the bot post without being a member.
+
+## Enable Slack notifications in DataHub
+
+1. In your DataHub service, go to the **DataHub resources** section.
+1. Open the Aiven App that ends in `-actions`.
+1. In the **Environment variables** section, click **Edit**.
+1. On the **Secrets** tab, add the following secrets:
+
+   | Key | Value |
+   |-----|-------|
+   | `DATAHUB_ACTIONS_SLACK_BOT_TOKEN` | Your Slack bot token. |
+   | `DATAHUB_ACTIONS_SLACK_SIGNING_SECRET` | Your signing secret. |
+
+1. On the **Variables** tab, add the following variables:
+
+   | Key | Value |
+   |-----|-------|
+   | `DATAHUB_ACTIONS_SLACK_ENABLED` | `true` |
+   | `DATAHUB_ACTIONS_SLACK_CHANNEL` | Your Slack channel ID. |
+   | `DATAHUB_ACTIONS_SLACK_DATAHUB_BASE_URL` | The DataHub **Application URL** from the **Connection information**. Adds links in messages. |
+   | `DATAHUB_ACTIONS_SLACK_SUPPRESS_SYSTEM_ACTIVITY` | Optional. To get low level system activity notifications such as datasets being ingested, set to `false`. Defaults to `true`. |
+
+After setting the variables, the actions app restarts automatically.
+
+<RelatedPages/>
+- [Configure Teams notifications](/docs/products/datahub/configure-teams-notifications)

--- a/docs/products/datahub/configure-teams-notifications.md
+++ b/docs/products/datahub/configure-teams-notifications.md
@@ -11,11 +11,6 @@ Get activity notifications for your DataHub service in a Microsoft Teams channel
 You can enable Teams notifications by creating a Power Automate flow in Teams
 and setting environment variables on the actions app.
 
-:::note
-Teams webhook delivery is rate-limited to about one message per second.
-If many changes happen at once, they queue and might arrive with a slight delay.
-:::
-
 ## Prerequisites
 
 - A Microsoft Teams team and channel where you can add workflows.
@@ -61,6 +56,8 @@ If many changes happen at once, they queue and might arrive with a slight delay.
    |-----|-------|
    | `DATAHUB_ACTIONS_TEAMS_ENABLED` | `true` |
    | `DATAHUB_ACTIONS_TEAMS_DATAHUB_BASE_URL` | The DataHub **Application URL** from the **Connection information**. Adds links in messages. Defaults to `http://localhost:9002`. |
+
+1. Click **Save**.
 
 After setting the variables, the actions app restarts automatically.
 

--- a/docs/products/datahub/configure-teams-notifications.md
+++ b/docs/products/datahub/configure-teams-notifications.md
@@ -1,0 +1,68 @@
+---
+title: Configure Teams notifications for DataHub activity
+sidebar_label: Configure Teams notifications
+limited: true
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Get activity notifications for your DataHub service in a Microsoft Teams channel, including new datasets, ownership changes, tags, and glossary updates.
+
+You can enable Teams notifications by creating a Power Automate flow in Teams
+and setting environment variables on the actions app.
+
+:::note
+Teams webhook delivery is rate-limited to about one message per second.
+If many changes happen at once, they queue and might arrive with a slight delay.
+:::
+
+## Prerequisites
+
+- A Microsoft Teams team and channel where you can add workflows.
+- Permission to create and manage Power Automate flows in that team.
+
+## Create a workflow in Teams
+
+1. In Teams, open the channel to send notifications to.
+
+1. In the channel menu, click **Workflows** >
+   **Post to a channel when a webhook request is received**.
+
+1. Enter a name for the workflow and confirm the team and channel.
+
+1. Open the workflow and configure it:
+
+   - **Trigger**: When a Teams webhook request is received
+   - **Action**: Post message in a chat or channel
+   - **Message body expression**: `coalesce(triggerBody()?['text'], string(triggerBody()))`
+
+1. Copy the generated webhook URL.
+   :::important
+   Treat the webhook URL as a secret. If the URL is exposed,
+   rotate it by deleting and recreating the workflow.
+   :::
+
+1. In the Power Automate flow settings, set **Who can trigger the flow?** to **Anyone**.
+
+## Enable Teams notifications in DataHub
+
+1. In your DataHub service, go to the **DataHub resources** section.
+1. Open the Aiven App that ends in `-actions`.
+1. In the **Environment variables** section, click **Edit**.
+1. On the **Secrets** tab, add the following secret:
+
+   | Key | Value |
+   |-----|-------|
+   | `DATAHUB_ACTIONS_TEAMS_WEBHOOK_URL` | The generated webhook URL. |
+
+1. On the **Variables** tab, add the following variables:
+
+   | Key | Value |
+   |-----|-------|
+   | `DATAHUB_ACTIONS_TEAMS_ENABLED` | `true` |
+   | `DATAHUB_ACTIONS_TEAMS_DATAHUB_BASE_URL` | The DataHub **Application URL** from the **Connection information**. Adds links in messages. Defaults to `http://localhost:9002`. |
+
+After setting the variables, the actions app restarts automatically.
+
+<RelatedPages/>
+- [Configure Slack notifications](/docs/products/datahub/configure-slack-notifications)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1284,6 +1284,14 @@ const sidebars: SidebarsConfig = {
               items: [
                 'products/datahub/manage-datahub-users',
                 'products/datahub/enable-oidc-auth-datahub',
+                {
+                  type: 'category',
+                  label: 'Notifications',
+                  items: [
+                    'products/datahub/configure-slack-notifications',
+                    'products/datahub/configure-teams-notifications',
+                  ],
+                },
               ],
             },
           ],


### PR DESCRIPTION
Adds instructions for enabling Slack and Teams notifications for DataHub.

- Preview of [Slack notification instructions](https://doc-1858-staceys-datahub-not.aiven-docs.pages.dev/docs/products/datahub/configure-slack-notifications)
- Preview of [Teams notification instructions](https://doc-1858-staceys-datahub-not.aiven-docs.pages.dev/docs/products/datahub/configure-teams-notifications)