### PR TITLE
update: add AWS KMS support for BYOK

### DIFF
--- a/docs/platform/howto/bring-your-own-key.md
+++ b/docs/platform/howto/bring-your-own-key.md
@@ -342,7 +342,7 @@ az keyvault update \
 
 #### Step 3: Create an RSA key
 
-Create an RSA key with the **Encrypt** and **Decrypt** operations enabled.
+Create an RSA key with the **wrapKey** and **unwrapKey** operations enabled.
 
 Software-protected key:
 
@@ -352,27 +352,33 @@ az keyvault key create \
   --name <key-name> \
   --kty RSA \
   --size 2048 \
-  --ops encrypt decrypt
+  --ops wrapKey unwrapKey
 ```
 
 HSM-backed key (for higher security requirements):
 
+:::note
+HSM-backed keys require an Azure Managed HSM, which must be provisioned separately
+before creating keys. Provisioning takes a few minutes and incurs an hourly cost.
+See the [Azure Managed HSM quickstart](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/quick-create-cli)
+for setup instructions.
+:::
+
 ```bash
 az keyvault key create \
-  --vault-name <vault-name> \
+  --hsm-name <hsm-name> \
   --name <key-name> \
   --kty RSA-HSM \
   --size 2048 \
-  --ops encrypt decrypt
+  --ops wrapKey unwrapKey
 ```
 
 Supported key sizes are `2048`, `3072`, and `4096`.
 
 Record the key URL, which becomes the resource identifier you register with Aiven:
 
-```txt
-https://<vault-name>.vault.azure.net/keys/<key-name>
-```
+- Software-protected key: `https://<vault-name>.vault.azure.net/keys/<key-name>`
+- HSM-backed key: `https://<hsm-name>.vault.azure.net/keys/<key-name>`
 
 If you include a specific version in the URL, Aiven uses that version exclusively.
 Omitting the version means Aiven always uses the latest active version.
@@ -385,8 +391,8 @@ Find the object ID of the Aiven service principal in your tenant:
 az ad sp show --id <aiven-application-id> --query id -o tsv
 ```
 
-Assign the **Key Vault Crypto User** built-in role to the Aiven service principal.
-This role grants only cryptographic permissions (`encrypt`, `decrypt`) — Aiven cannot
+**Software-protected key** — assign the **Key Vault Crypto User** built-in role to the
+Aiven service principal. This role grants only key wrapping permissions — Aiven cannot
 manage, rotate, or delete your key.
 
 Scope to the specific key (recommended):
@@ -405,6 +411,28 @@ az role assignment create \
   --assignee <aiven-service-principal-object-id> \
   --role "Key Vault Crypto User" \
   --scope "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.KeyVault/vaults/<vault-name>"
+```
+
+**HSM-backed key** — use the Managed HSM CLI command and assign the **Managed HSM Crypto User** role instead:
+
+Scope to the specific key (recommended):
+
+```bash
+az keyvault role assignment create \
+  --hsm-name <hsm-name> \
+  --role "Managed HSM Crypto User" \
+  --assignee-object-id <aiven-service-principal-object-id> \
+  --scope /keys/<key-name>
+```
+
+Or scope to all keys in the HSM:
+
+```bash
+az keyvault role assignment create \
+  --hsm-name <hsm-name> \
+  --role "Managed HSM Crypto User" \
+  --assignee-object-id <aiven-service-principal-object-id> \
+  --scope /keys
 ```
 
 :::note
@@ -547,7 +575,6 @@ Register a customer managed key resource identifier for an Aiven project.
 |-----------|--------|----------|-------------|
 | `provider`   | String | True     | Cloud provider hosting the KMS: `gcp`, `oci`, `azure`, or `aws` |
 | `resource` | String | True     | CMK reference (key identifier of max 512 characters). Format depends on provider: GCP resource name, OCI OCID, Azure Key Vault key URL, or AWS KMS key ARN |
-| `tenant_id` | String | Conditional | Azure AD tenant ID of your Azure subscription. Required when `provider` is `azure` |
 | `default_cmk` | Boolean | False | Mark this key as default for new service creation |
 
 #### Sample request (Google Cloud)
@@ -591,7 +618,6 @@ curl -X POST https://api.aiven.io/v1/project/PROJECT_ID/secrets/cmks \
   -d '{
         "provider": "azure",
         "resource": "https://my-vault.vault.azure.net/keys/my-cmk-key",
-        "tenant_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
         "default_cmk": true
       }'
 ```
@@ -669,7 +695,6 @@ avn project cmks create --project PROJECT_NAME --provider PROVIDER --resource RE
 | `--project`   | String | True     | Project name |
 | `--provider`   | String | True     | Cloud provider hosting the KMS: `gcp`, `oci`, `azure`, or `aws` |
 | `--resource` | String | True     | CMK reference. Format depends on provider: GCP resource name, OCI OCID, Azure Key Vault key URL, or AWS KMS key ARN |
-| `--tenant-id` | String | Conditional | Azure AD tenant ID. Required when `--provider` is `azure` |
 | `--default-cmk` | Flag | False | Mark this key as default for new service creation |
 | `--json`     | Flag   | False    | Output in JSON format |
 
@@ -706,7 +731,6 @@ avn project cmks create \
   --project my-project \
   --provider azure \
   --resource "https://my-vault.vault.azure.net/keys/my-cmk-key" \
-  --tenant-id "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" \
   --default-cmk
 ```
 

--- a/docs/platform/howto/bring-your-own-key.md
+++ b/docs/platform/howto/bring-your-own-key.md
@@ -8,10 +8,7 @@ import TabItem from '@theme/TabItem';
 import TerraformSample from '@site/src/components/CodeSamples/TerraformSample';
 import TerraformApply from "@site/static/includes/terraform-apply-changes.md";
 
-Register, list, update, or delete your customer managed keys (CMKs), associate CMKs
-with services, and view CMK usage across services in Aiven projects using the
-[Aiven Provider for Terraform](/docs/tools/terraform), [Aiven API](/docs/tools/api),
-or the [Aiven CLI](/docs/tools/cli).
+Register, list, update, or delete your customer managed keys (CMKs), associate CMKs with services, and view CMK usage across services in Aiven projects using the [Aiven Provider for Terraform](/docs/tools/terraform), [Aiven API](/docs/tools/api), or the [Aiven CLI](/docs/tools/cli).
 
 :::important
 Bring your own key (BYOK) is a [BYOC](/docs/platform/concepts/byoc) enterprise feature.
@@ -34,6 +31,7 @@ BYOK encrypts the following using your CMKs:
   - **Google Cloud KMS**: asymmetric RSA 2048 or RSA 4096 keys
   - **Oracle Cloud Infrastructure (OCI) Vault**: AES keys
   - **AWS KMS**: symmetric encryption keys (`ENCRYPT_DECRYPT`)
+
 <!-- AZURE (not yet supported - re-enable when Azure BYOK is live):
   - **Azure Key Vault**: RSA keys (software-protected or HSM-backed)
 -->
@@ -176,10 +174,12 @@ Use the accessor values returned by this endpoint when granting Aiven access to 
   IAM policies.
 - **AWS KMS**: Use the `role_arn` as the trusted principal in your KMS key policy (see
   [AWS KMS setup](#aws-kms-setup)).
+
 <!-- AZURE (not yet supported - re-enable when Azure BYOK is live):
 - **Azure Key Vault**: Use the `app_id` to create a service principal in your
   Azure AD tenant (see [Azure Key Vault setup](#azure-key-vault-setup)).
 -->
+
 :::
 
 ## Set up customer-managed keys on your cloud provider

--- a/docs/platform/howto/bring-your-own-key.md
+++ b/docs/platform/howto/bring-your-own-key.md
@@ -29,8 +29,12 @@ BYOK encrypts the following using your CMKs:
 
 ## Prerequisites
 
-- **Key management service** (KMS) that supports asymmetric RSA 2048 or RSA 4096
-  keys in Google Cloud or Oracle Cloud Infrastructure (OCI)
+- **Key management service** (KMS) that supports customer-managed keys in one of the
+  supported cloud providers:
+  - **Google Cloud KMS**: asymmetric RSA 2048 or RSA 4096 keys
+  - **Oracle Cloud Infrastructure (OCI) Vault**: AES keys
+  - **Azure Key Vault**: RSA keys (software-protected or HSM-backed)
+  - **AWS KMS**: symmetric encryption keys (`ENCRYPT_DECRYPT`)
 
 - [**Authentication token**](/docs/platform/howto/create_authentication_token) to use
   the [Aiven API](/docs/tools/api)
@@ -91,6 +95,13 @@ for each provider, for example:
     "oci": {
       "access_group": "ocid1.group.oc1..abcdABCD....",
       "access_tenant": "ocid1.tenancy.oc1..abcdABCD...."
+    },
+    "azure": {
+      "application_id": "12345678-1234-1234-1234-123456789abc",
+      "tenant_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    },
+    "aws": {
+      "role_arn": "arn:aws:iam::123456789012:role/aiven-cmk-anchor"
     }
   }
 }
@@ -129,6 +140,13 @@ The output is always in the JSON format:
     "oci": {
       "access_group": "ocid1.group.oc1..abcdABCD....",
       "access_tenant": "ocid1.tenancy.oc1..abcdABCD...."
+    },
+    "azure": {
+      "application_id": "12345678-1234-1234-1234-123456789abc",
+      "tenant_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    },
+    "aws": {
+      "role_arn": "arn:aws:iam::123456789012:role/aiven-cmk-anchor"
     }
 }
 ```
@@ -137,8 +155,16 @@ The output is always in the JSON format:
 </Tabs>
 
 :::note
-For Google Cloud Key Management Service keys, grant the group in the `access_group`
-parameter the `roles/cloudkms.cryptoOperator` role.
+Use the accessor values returned by this endpoint when granting Aiven access to your key:
+
+- **Google Cloud KMS**: Grant the `access_group` email address the
+  `roles/cloudkms.cryptoOperator` role on your key.
+- **OCI Vault**: Use `access_tenant` and `access_group` OCIDs to create cross-tenancy
+  IAM policies.
+- **Azure Key Vault**: Use the `application_id` to create a service principal in your
+  Azure AD tenant (see [Azure Key Vault setup](#azure-key-vault-setup)).
+- **AWS KMS**: Use the `role_arn` as the trusted principal in your KMS key policy (see
+  [AWS KMS setup](#aws-kms-setup)).
 :::
 
 ## Set up customer-managed keys on your cloud provider
@@ -273,6 +299,223 @@ Record the key OCID:
 ocid1.key.oc1.<region>.<hash>
 ```
 
+### Azure Key Vault setup
+
+Aiven authenticates to your Azure Key Vault using a multi-tenant application registered
+in Aiven's Azure AD tenant. You grant access by creating a service principal from
+Aiven's application in your tenant and assigning it the **Key Vault Crypto User** role
+on your key.
+
+#### Step 1: Create a service principal for Aiven's application
+
+Get Aiven's `application_id` and `tenant_id` using
+[List CMK accessors](#list-cmk-accessors), then register Aiven's application as a
+service principal in your Azure AD tenant:
+
+```bash
+az ad sp create --id <aiven-application-id>
+```
+
+This allows Aiven to authenticate into your Azure AD tenant using its multi-tenant
+application.
+
+#### Step 2: Create a Key Vault with Azure RBAC
+
+The Key Vault must use **Azure RBAC** for its authorization model (not the legacy access
+policy model):
+
+```bash
+az keyvault create \
+  --name <vault-name> \
+  --resource-group <resource-group> \
+  --location <region> \
+  --enable-rbac-authorization true
+```
+
+If you are using an existing Key Vault, ensure RBAC authorization is enabled:
+
+```bash
+az keyvault update \
+  --name <vault-name> \
+  --enable-rbac-authorization true
+```
+
+#### Step 3: Create an RSA key
+
+Create an RSA key with the **Encrypt** and **Decrypt** operations enabled.
+
+Software-protected key:
+
+```bash
+az keyvault key create \
+  --vault-name <vault-name> \
+  --name <key-name> \
+  --kty RSA \
+  --size 2048 \
+  --ops encrypt decrypt
+```
+
+HSM-backed key (for higher security requirements):
+
+```bash
+az keyvault key create \
+  --vault-name <vault-name> \
+  --name <key-name> \
+  --kty RSA-HSM \
+  --size 2048 \
+  --ops encrypt decrypt
+```
+
+Supported key sizes are `2048`, `3072`, and `4096`.
+
+Record the key URL, which becomes the resource identifier you register with Aiven:
+
+```txt
+https://<vault-name>.vault.azure.net/keys/<key-name>
+```
+
+If you include a specific version in the URL, Aiven uses that version exclusively.
+Omitting the version means Aiven always uses the latest active version.
+
+#### Step 4: Grant Aiven access to the key
+
+Find the object ID of the Aiven service principal in your tenant:
+
+```bash
+az ad sp show --id <aiven-application-id> --query id -o tsv
+```
+
+Assign the **Key Vault Crypto User** built-in role to the Aiven service principal.
+This role grants only cryptographic permissions (`encrypt`, `decrypt`) — Aiven cannot
+manage, rotate, or delete your key.
+
+Scope to the specific key (recommended):
+
+```bash
+az role assignment create \
+  --assignee <aiven-service-principal-object-id> \
+  --role "Key Vault Crypto User" \
+  --scope "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.KeyVault/vaults/<vault-name>/keys/<key-name>"
+```
+
+Or scope to the entire vault:
+
+```bash
+az role assignment create \
+  --assignee <aiven-service-principal-object-id> \
+  --role "Key Vault Crypto User" \
+  --scope "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.KeyVault/vaults/<vault-name>"
+```
+
+:::note
+You can revoke Aiven's access at any time by removing the role assignment or deleting
+the service principal from your tenant. This immediately prevents any further
+cryptographic operations by Aiven.
+:::
+
+### AWS KMS setup
+
+Aiven authenticates to your AWS KMS key using cross-account IAM access. You grant
+access by adding Aiven's IAM role ARN as a trusted principal in your KMS key policy.
+No resources need to be created in Aiven's AWS account — everything is controlled
+through your key policy.
+
+#### Step 1: Create a KMS key
+
+Create a symmetric encryption key in the AWS region where your Aiven services
+will run:
+
+```bash
+aws kms create-key \
+  --description "Aiven CMK for data-at-rest encryption" \
+  --key-usage ENCRYPT_DECRYPT \
+  --origin AWS_KMS
+```
+
+Record the key ARN from the output:
+
+```txt
+arn:aws:kms:<region>:<account-id>:key/<key-id>
+```
+
+#### Step 2: Create a key alias (optional but recommended)
+
+```bash
+aws kms create-alias \
+  --alias-name alias/aiven-cmk \
+  --target-key-id <key-id>
+```
+
+#### Step 3: Grant Aiven access via the key policy
+
+Get Aiven's IAM role ARN using [List CMK accessors](#list-cmk-accessors) (`role_arn`),
+then update your KMS key policy to allow Aiven to perform encrypt and decrypt
+operations.
+
+The key policy must include the following statement:
+
+```json
+{
+  "Sid": "Allow Aiven to use this key for CMK operations",
+  "Effect": "Allow",
+  "Principal": {
+    "AWS": "<aiven-role-arn>"
+  },
+  "Action": [
+    "kms:Encrypt",
+    "kms:Decrypt"
+  ],
+  "Resource": "*"
+}
+```
+
+The full key policy must also retain the root account statement so that your IAM
+policies can still manage the key:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Enable IAM policies for key management",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::<your-account-id>:root"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "Allow Aiven to use this key for CMK operations",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "<aiven-role-arn>"
+      },
+      "Action": [
+        "kms:Encrypt",
+        "kms:Decrypt"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Apply the key policy:
+
+```bash
+aws kms put-key-policy \
+  --key-id <key-id> \
+  --policy-name default \
+  --policy file://key-policy.json
+```
+
+:::note
+You can revoke Aiven's access at any time by removing the Aiven principal from the key
+policy, or by disabling or deleting the key. All KMS operations performed by Aiven are
+logged in your AWS CloudTrail, giving you a full audit trail.
+:::
+
 ## Manage a project CMK
 
 Use the Aiven Provider for Terraform, Aiven API, or Aiven CLI to manage customer managed
@@ -302,8 +545,9 @@ Register a customer managed key resource identifier for an Aiven project.
 
 | Parameter | Type   | Required | Description |
 |-----------|--------|----------|-------------|
-| `provider`   | String | True     | Cloud provider hosting the KMS: `gcp` or `oci` |
-| `resource` | String | True     | CMK reference (key identifier of max 512 characters: OCI OCID or Google Cloud resource name) |
+| `provider`   | String | True     | Cloud provider hosting the KMS: `gcp`, `oci`, `azure`, or `aws` |
+| `resource` | String | True     | CMK reference (key identifier of max 512 characters). Format depends on provider: GCP resource name, OCI OCID, Azure Key Vault key URL, or AWS KMS key ARN |
+| `tenant_id` | String | Conditional | Azure AD tenant ID of your Azure subscription. Required when `provider` is `azure` |
 | `default_cmk` | Boolean | False | Mark this key as default for new service creation |
 
 #### Sample request (Google Cloud)
@@ -338,12 +582,71 @@ the newly registered CMK configuration, for example:
 }
 ```
 
+#### Sample request (Azure)
+
+```bash
+curl -X POST https://api.aiven.io/v1/project/PROJECT_ID/secrets/cmks \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer AIVEN_API_TOKEN" \
+  -d '{
+        "provider": "azure",
+        "resource": "https://my-vault.vault.azure.net/keys/my-cmk-key",
+        "tenant_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "default_cmk": true
+      }'
+```
+
+#### Sample response (Azure)
+
+```json
+{
+  "cmk": {
+    "id": "12345678-1234-1234-1234-12345678abcd",
+    "provider": "azure",
+    "default_cmk": true,
+    "resource": "https://my-vault.vault.azure.net/keys/my-cmk-key",
+    "status": "current",
+    "created_at": "YYYY-MM-DDTHH:MM:SSZ",
+    "updated_at": "YYYY-MM-DDTHH:MM:SSZ"
+  }
+}
+```
+
+#### Sample request (AWS)
+
+```bash
+curl -X POST https://api.aiven.io/v1/project/PROJECT_ID/secrets/cmks \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer AIVEN_API_TOKEN" \
+  -d '{
+        "provider": "aws",
+        "resource": "arn:aws:kms:us-east-1:123456789012:key/mrk-1234abcd12ab34cd56ef1234567890ab",
+        "default_cmk": true
+      }'
+```
+
+#### Sample response (AWS)
+
+```json
+{
+  "cmk": {
+    "id": "12345678-1234-1234-1234-12345678abcd",
+    "provider": "aws",
+    "default_cmk": true,
+    "resource": "arn:aws:kms:us-east-1:123456789012:key/mrk-1234abcd12ab34cd56ef1234567890ab",
+    "status": "current",
+    "created_at": "YYYY-MM-DDTHH:MM:SSZ",
+    "updated_at": "YYYY-MM-DDTHH:MM:SSZ"
+  }
+}
+```
+
 #### Response fields
 
 | Parameter | Description |
 |-----------|-------------|
 | `id` | Identifier of the specific key |
-| `provider` | Provider type, one of `gcp` or `oci` |
+| `provider` | Provider type: `gcp`, `oci`, `azure`, or `aws` |
 | `resource` | CMK reference |
 | `status` | One of `current`, `old`, or `deleted` |
 | `default_cmk` | Whether this CMK has been marked default for new services |
@@ -364,8 +667,9 @@ avn project cmks create --project PROJECT_NAME --provider PROVIDER --resource RE
 | Parameter | Type   | Required | Description |
 |-----------|--------|----------|-------------|
 | `--project`   | String | True     | Project name |
-| `--provider`   | String | True     | Cloud provider hosting the KMS: `gcp` or `oci` |
-| `--resource` | String | True     | CMK reference (key identifier: OCI OCID or Google Cloud resource name) |
+| `--provider`   | String | True     | Cloud provider hosting the KMS: `gcp`, `oci`, `azure`, or `aws` |
+| `--resource` | String | True     | CMK reference. Format depends on provider: GCP resource name, OCI OCID, Azure Key Vault key URL, or AWS KMS key ARN |
+| `--tenant-id` | String | Conditional | Azure AD tenant ID. Required when `--provider` is `azure` |
 | `--default-cmk` | Flag | False | Mark this key as default for new service creation |
 | `--json`     | Flag   | False    | Output in JSON format |
 
@@ -393,6 +697,27 @@ resource      projects/aiven-example/locations/us-central1/keyRings/example-keyr
 status        current
 created_at    YYYY-MM-DDTHH:MM:SSZ
 updated_at    YYYY-MM-DDTHH:MM:SSZ
+```
+
+#### Sample request (Azure)
+
+```bash
+avn project cmks create \
+  --project my-project \
+  --provider azure \
+  --resource "https://my-vault.vault.azure.net/keys/my-cmk-key" \
+  --tenant-id "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" \
+  --default-cmk
+```
+
+#### Sample request (AWS)
+
+```bash
+avn project cmks create \
+  --project my-project \
+  --provider aws \
+  --resource "arn:aws:kms:us-east-1:123456789012:key/mrk-1234abcd12ab34cd56ef1234567890ab" \
+  --default-cmk
 ```
 
 For JSON output, use `--json` flag.
@@ -472,7 +797,7 @@ updated CMK configuration, for example:
 | Parameter | Description |
 |-----------|-------------|
 | `id` | Identifier of the specific key |
-| `provider` | Provider type, one of `gcp` or `oci` |
+| `provider` | Provider type: `gcp`, `oci`, `azure`, or `aws` |
 | `resource` | CMK reference |
 | `status` | One of `current`, `old`, or `deleted` |
 | `default_cmk` | Whether this CMK has been marked default for new services |
@@ -592,6 +917,38 @@ specified CMK configuration, for example:
     "provider": "oci",
     "default_cmk": false,
     "resource": "ocid1.key.oc1.iad.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "status": "current",
+    "created_at": "YYYY-MM-DDTHH:MM:SSZ",
+    "updated_at": "YYYY-MM-DDTHH:MM:SSZ"
+  }
+}
+```
+
+#### Sample response (Azure)
+
+```json
+{
+  "cmk": {
+    "id": "a1b2c3d4-e5f6-4789-a0b1-c2d3e4f5a6b7",
+    "provider": "azure",
+    "default_cmk": false,
+    "resource": "https://my-vault.vault.azure.net/keys/my-cmk-key",
+    "status": "current",
+    "created_at": "YYYY-MM-DDTHH:MM:SSZ",
+    "updated_at": "YYYY-MM-DDTHH:MM:SSZ"
+  }
+}
+```
+
+#### Sample response (AWS)
+
+```json
+{
+  "cmk": {
+    "id": "a1b2c3d4-e5f6-4789-a0b1-c2d3e4f5a6b7",
+    "provider": "aws",
+    "default_cmk": false,
+    "resource": "arn:aws:kms:us-east-1:123456789012:key/mrk-1234abcd12ab34cd56ef1234567890ab",
     "status": "current",
     "created_at": "YYYY-MM-DDTHH:MM:SSZ",
     "updated_at": "YYYY-MM-DDTHH:MM:SSZ"

--- a/docs/platform/howto/bring-your-own-key.md
+++ b/docs/platform/howto/bring-your-own-key.md
@@ -97,8 +97,7 @@ for each provider, for example:
       "access_tenant": "ocid1.tenancy.oc1..abcdABCD...."
     },
     "azure": {
-      "application_id": "12345678-1234-1234-1234-123456789abc",
-      "tenant_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+      "app_id": "12345678-1234-1234-1234-123456789abc"
     },
     "aws": {
       "role_arn": "arn:aws:iam::123456789012:role/aiven-cmk-anchor"
@@ -142,8 +141,7 @@ The output is always in the JSON format:
       "access_tenant": "ocid1.tenancy.oc1..abcdABCD...."
     },
     "azure": {
-      "application_id": "12345678-1234-1234-1234-123456789abc",
-      "tenant_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+      "app_id": "12345678-1234-1234-1234-123456789abc"
     },
     "aws": {
       "role_arn": "arn:aws:iam::123456789012:role/aiven-cmk-anchor"
@@ -161,7 +159,7 @@ Use the accessor values returned by this endpoint when granting Aiven access to 
   `roles/cloudkms.cryptoOperator` role on your key.
 - **OCI Vault**: Use `access_tenant` and `access_group` OCIDs to create cross-tenancy
   IAM policies.
-- **Azure Key Vault**: Use the `application_id` to create a service principal in your
+- **Azure Key Vault**: Use the `app_id` to create a service principal in your
   Azure AD tenant (see [Azure Key Vault setup](#azure-key-vault-setup)).
 - **AWS KMS**: Use the `role_arn` as the trusted principal in your KMS key policy (see
   [AWS KMS setup](#aws-kms-setup)).
@@ -308,7 +306,7 @@ on your key.
 
 #### Step 1: Create a service principal for Aiven's application
 
-Get Aiven's `application_id` and `tenant_id` using
+Get Aiven's `app_id` using
 [List CMK accessors](#list-cmk-accessors), then register Aiven's application as a
 service principal in your Azure AD tenant:
 

--- a/docs/platform/howto/bring-your-own-key.md
+++ b/docs/platform/howto/bring-your-own-key.md
@@ -33,8 +33,10 @@ BYOK encrypts the following using your CMKs:
   supported cloud providers:
   - **Google Cloud KMS**: asymmetric RSA 2048 or RSA 4096 keys
   - **Oracle Cloud Infrastructure (OCI) Vault**: AES keys
-  - **Azure Key Vault**: RSA keys (software-protected or HSM-backed)
   - **AWS KMS**: symmetric encryption keys (`ENCRYPT_DECRYPT`)
+<!-- AZURE (not yet supported - re-enable when Azure BYOK is live):
+  - **Azure Key Vault**: RSA keys (software-protected or HSM-backed)
+-->
 
 - [**Authentication token**](/docs/platform/howto/create_authentication_token) to use
   the [Aiven API](/docs/tools/api)
@@ -96,15 +98,25 @@ for each provider, for example:
       "access_group": "ocid1.group.oc1..abcdABCD....",
       "access_tenant": "ocid1.tenancy.oc1..abcdABCD...."
     },
-    "azure": {
-      "app_id": "12345678-1234-1234-1234-123456789abc"
-    },
     "aws": {
       "role_arn": "arn:aws:iam::123456789012:role/aiven-cmk-anchor"
     }
   }
 }
 ```
+
+<!-- AZURE (not yet supported - re-enable when Azure BYOK is live):
+```json
+{
+  "accessors": {
+    ...
+    "azure": {
+      "app_id": "12345678-1234-1234-1234-123456789abc"
+    },
+    ...
+  }
+}
+-->
 
 </TabItem>
 <TabItem value="cli" label="CLI">
@@ -140,14 +152,17 @@ The output is always in the JSON format:
       "access_group": "ocid1.group.oc1..abcdABCD....",
       "access_tenant": "ocid1.tenancy.oc1..abcdABCD...."
     },
-    "azure": {
-      "app_id": "12345678-1234-1234-1234-123456789abc"
-    },
     "aws": {
       "role_arn": "arn:aws:iam::123456789012:role/aiven-cmk-anchor"
     }
 }
 ```
+
+<!-- AZURE (not yet supported - re-enable when Azure BYOK is live):
+    "azure": {
+      "app_id": "12345678-1234-1234-1234-123456789abc"
+    },
+-->
 
 </TabItem>
 </Tabs>
@@ -159,10 +174,12 @@ Use the accessor values returned by this endpoint when granting Aiven access to 
   `roles/cloudkms.cryptoOperator` role on your key.
 - **OCI Vault**: Use `access_tenant` and `access_group` OCIDs to create cross-tenancy
   IAM policies.
-- **Azure Key Vault**: Use the `app_id` to create a service principal in your
-  Azure AD tenant (see [Azure Key Vault setup](#azure-key-vault-setup)).
 - **AWS KMS**: Use the `role_arn` as the trusted principal in your KMS key policy (see
   [AWS KMS setup](#aws-kms-setup)).
+<!-- AZURE (not yet supported - re-enable when Azure BYOK is live):
+- **Azure Key Vault**: Use the `app_id` to create a service principal in your
+  Azure AD tenant (see [Azure Key Vault setup](#azure-key-vault-setup)).
+-->
 :::
 
 ## Set up customer-managed keys on your cloud provider
@@ -296,6 +313,8 @@ Record the key OCID:
 ```txt
 ocid1.key.oc1.<region>.<hash>
 ```
+
+<!-- AZURE (not yet supported - re-enable when Azure BYOK is live):
 
 ### Azure Key Vault setup
 
@@ -439,6 +458,8 @@ the service principal from your tenant. This immediately prevents any further
 cryptographic operations by Aiven.
 :::
 
+-->
+
 ### AWS KMS setup
 
 Aiven authenticates to your AWS KMS key using cross-account IAM access. You grant
@@ -571,8 +592,8 @@ Register a customer managed key resource identifier for an Aiven project.
 
 | Parameter | Type   | Required | Description |
 |-----------|--------|----------|-------------|
-| `provider`   | String | True     | Cloud provider hosting the KMS: `gcp`, `oci`, `azure`, or `aws` |
-| `resource` | String | True     | CMK reference (key identifier of max 512 characters). Format depends on provider: GCP resource name, OCI OCID, Azure Key Vault key URL, or AWS KMS key ARN |
+| `provider`   | String | True     | Cloud provider hosting the KMS: `gcp`, `oci`, or `aws` |
+| `resource` | String | True     | CMK reference (key identifier of max 512 characters). Format depends on provider: GCP resource name, OCI OCID, or AWS KMS key ARN |
 | `default_cmk` | Boolean | False | Mark this key as default for new service creation |
 
 #### Sample request (Google Cloud)
@@ -607,6 +628,8 @@ the newly registered CMK configuration, for example:
 }
 ```
 
+<!-- AZURE (not yet supported - re-enable when Azure BYOK is live):
+
 #### Sample request (Azure)
 
 ```bash
@@ -635,6 +658,8 @@ curl -X POST https://api.aiven.io/v1/project/PROJECT_ID/secrets/cmks \
   }
 }
 ```
+
+-->
 
 #### Sample request (AWS)
 
@@ -670,7 +695,7 @@ curl -X POST https://api.aiven.io/v1/project/PROJECT_ID/secrets/cmks \
 | Parameter | Description |
 |-----------|-------------|
 | `id` | Identifier of the specific key |
-| `provider` | Provider type: `gcp`, `oci`, `azure`, or `aws` |
+| `provider` | Provider type: `gcp`, `oci`, or `aws` |
 | `resource` | CMK reference |
 | `status` | One of `current`, `old`, or `deleted` |
 | `default_cmk` | Whether this CMK has been marked default for new services |
@@ -691,8 +716,8 @@ avn project cmks create --project PROJECT_NAME --provider PROVIDER --resource RE
 | Parameter | Type   | Required | Description |
 |-----------|--------|----------|-------------|
 | `--project`   | String | True     | Project name |
-| `--provider`   | String | True     | Cloud provider hosting the KMS: `gcp`, `oci`, `azure`, or `aws` |
-| `--resource` | String | True     | CMK reference. Format depends on provider: GCP resource name, OCI OCID, Azure Key Vault key URL, or AWS KMS key ARN |
+| `--provider`   | String | True     | Cloud provider hosting the KMS: `gcp`, `oci`, or `aws` |
+| `--resource` | String | True     | CMK reference. Format depends on provider: GCP resource name, OCI OCID, or AWS KMS key ARN |
 | `--default-cmk` | Flag | False | Mark this key as default for new service creation |
 | `--json`     | Flag   | False    | Output in JSON format |
 
@@ -722,6 +747,8 @@ created_at    YYYY-MM-DDTHH:MM:SSZ
 updated_at    YYYY-MM-DDTHH:MM:SSZ
 ```
 
+<!-- AZURE (not yet supported - re-enable when Azure BYOK is live):
+
 #### Sample request (Azure)
 
 ```bash
@@ -731,6 +758,8 @@ avn project cmks create \
   --resource "https://my-vault.vault.azure.net/keys/my-cmk-key" \
   --default-cmk
 ```
+
+-->
 
 #### Sample request (AWS)
 
@@ -819,7 +848,7 @@ updated CMK configuration, for example:
 | Parameter | Description |
 |-----------|-------------|
 | `id` | Identifier of the specific key |
-| `provider` | Provider type: `gcp`, `oci`, `azure`, or `aws` |
+| `provider` | Provider type: `gcp`, `oci`, or `aws` |
 | `resource` | CMK reference |
 | `status` | One of `current`, `old`, or `deleted` |
 | `default_cmk` | Whether this CMK has been marked default for new services |
@@ -946,6 +975,8 @@ specified CMK configuration, for example:
 }
 ```
 
+<!-- AZURE (not yet supported - re-enable when Azure BYOK is live):
+
 #### Sample response (Azure)
 
 ```json
@@ -961,6 +992,8 @@ specified CMK configuration, for example:
   }
 }
 ```
+
+-->
 
 #### Sample response (AWS)
 


### PR DESCRIPTION
Extends the BYOK how-to to cover AWS alongside the existing GCP and OCI documentation. Changes include:

- Prerequisites: list all three supported providers with key requirements
- List CMK accessors: aws (role_arn) to sample responses; expand accessor note into per-provider guidance
- New setup sections: AWS KMS (symmetric key creation, key policy with Aiven role ARN)
- Register CMK: add sample requests and responses for azure and aws providers
- Update all provider enumerations throughout to include aws

https://aiven.atlassian.net/browse/IP-938