### PR TITLE
update: Clarify Kafka OAuth2/OIDC setup and SASL mechanism configuration

### DIFF
--- a/docs/products/kafka/howto/enable-oidc.md
+++ b/docs/products/kafka/howto/enable-oidc.md
@@ -38,13 +38,11 @@ for JWKS URL, issuer, and audience values.
 
 ## Configure OAuth 2.0/OIDC settings
 
-To use OAuth 2.0/OIDC only, enable SASL authentication, set
-`kafka.sasl_oauthbearer_jwks_endpoint_url`, and disable `PLAIN`, `SCRAM-SHA-256`, and
-`SCRAM-SHA-512`.
+Set `kafka.sasl_oauthbearer_jwks_endpoint_url` to enable `OAUTHBEARER`.
 
-Set `kafka.sasl_oauthbearer_jwks_endpoint_url` to enable `OAUTHBEARER`. Optionally
-[disable PLAIN, SCRAM-SHA-256, and SCRAM-SHA-512](/docs/products/kafka/howto/kafka-sasl-auth#configure-sasl-mechanisms)
-if clients authenticate only with OAuth 2.0/OIDC.
+To use only OAuth 2.0/OIDC authentication, enable SASL authentication, set
+`kafka.sasl_oauthbearer_jwks_endpoint_url`, and
+[disable PLAIN, SCRAM-SHA-256, and SCRAM-SHA-512](/docs/products/kafka/howto/kafka-sasl-auth#configure-sasl-mechanisms).
 
 :::note
 When SASL authentication is enabled, at least one SASL mechanism must be available.
@@ -52,7 +50,7 @@ When SASL authentication is enabled, at least one SASL mechanism must be availab
 `kafka.sasl_oauthbearer_jwks_endpoint_url` is set.
 :::
 
-Enable OAuth 2.0/OIDC authentication using one of the following methods.
+Configure OAuth 2.0/OIDC authentication using one of the following methods.
 
 <Tabs groupId="config-methods">
 <TabItem value="console" label="Aiven Console" default>
@@ -83,7 +81,7 @@ Enable OAuth 2.0/OIDC authentication using one of the following methods.
 </TabItem>
 <TabItem value="cli" label="CLI">
 
-To enable OAuth 2.0/OIDC authentication for your Aiven for Apache Kafka service
+To configure OAuth 2.0/OIDC authentication for your Aiven for Apache Kafka service
 using the [Aiven CLI](/docs/tools/cli):
 
 Each `avn service update` that changes OIDC or SASL settings triggers a rolling
@@ -114,10 +112,11 @@ when applying multiple changes.
    This enables the `OAUTHBEARER` mechanism. `PLAIN`, `SCRAM-SHA-256`, and
    `SCRAM-SHA-512` remain enabled by default.
 
-   **Optional:** Add issuer, audience, and subject claim verification, or set
-   `PLAIN`, `SCRAM-SHA-256`, and `SCRAM-SHA-512` to `false` to use only OAuth 2.0/OIDC
-   authentication. Example with issuer, audience, subject claim verification, and
-   OAuth-only SASL configuration:
+   **Optional:** Add issuer, audience, and subject claim verification. To use only
+   OAuth 2.0/OIDC authentication, set `kafka_sasl_mechanisms.plain`,
+   `kafka_sasl_mechanisms.scram_sha_256`, and `kafka_sasl_mechanisms.scram_sha_512` to
+   `false`. Example with issuer, audience, subject claim verification, and OAuth-only
+   SASL configuration:
 
    ```bash
    avn service update SERVICE_NAME \

--- a/docs/products/kafka/howto/enable-oidc.md
+++ b/docs/products/kafka/howto/enable-oidc.md
@@ -1,5 +1,6 @@
 ---
-title: Enable OAuth2/OIDC authentication for Apache Kafka®
+title: Enable OAuth 2.0/OIDC authentication for Apache Kafka®
+sidebar_label: Enable OAuth 2.0/OIDC authentication
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,43 +9,56 @@ import ConsoleLabel from "@site/src/components/ConsoleIcons"
 import ConsoleIcon from "@site/src/components/ConsoleIcons"
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Aiven for Apache Kafka® supports OAuth2/OIDC authentication for Kafka clients.
-Use OAuth2/OIDC authentication to let clients authenticate with tokens issued by an
+Aiven for Apache Kafka® supports OAuth 2.0/OIDC authentication for Kafka clients.
+Use OAuth 2.0/OIDC authentication to let clients authenticate with tokens issued by an
 identity provider.
-
-:::note
-To use the `OAUTHBEARER` mechanism, you must enable `kafka_authentication_methods.sasl`.
-Other SASL mechanisms (PLAIN, SCRAM-SHA-256, and SCRAM-SHA-512) are optional and can be
-disabled independently. See
-[Enable and configure SASL authentication with Aiven for Apache Kafka®](/docs/products/kafka/howto/kafka-sasl-auth).
-:::
 
 ## Prerequisites
 
 Before you begin, make sure you have:
 
-- An [Aiven for Apache Kafka®](/docs/products/kafka/get-started/create-kafka-service)
+- An [Aiven for Apache Kafka](/docs/products/kafka/get-started/create-kafka-service)
   service.
+- [SASL authentication](/docs/products/kafka/howto/kafka-sasl-auth#enable-sasl-authentication)
+  enabled on the service. OAuth 2.0/OIDC uses the `OAUTHBEARER` SASL mechanism.
 - Access to an OIDC provider, such as Auth0, Okta, Google Identity Platform,
   Azure, or another OIDC-compliant provider.
-- Required configuration details from your OIDC provider:
-  - **JWKS endpoint URL**: URL to retrieve the JSON Web Key Set (JWKS).
-  - **Subject claim name**: Typically `sub`, but this can vary depending on your
-    OIDC provider.
-  - **Issuer URL or identifier**: Identifies and verifies the JWT issuer.
-  - **Audience identifiers**: Validates the JWT's intended recipients. For
-    multiple audiences, make a note of all.
+- Configuration details from your OIDC provider:
+  - **JWKS endpoint URL:** Required. HTTPS URL to retrieve the JSON Web Key Set, or
+    JWKS.
+  - **Issuer URL or identifier:** Required by most OIDC providers. Identifies and
+    verifies the JWT issuer.
+  - **Audience identifiers:** Required by most OIDC providers. Validates the JWT's
+    intended recipients. For multiple audiences, note each value.
+  - **Subject claim name:** Optional. Typically `sub`, but this can vary depending on
+    your OIDC provider.
 
 Configuration steps vary by identity provider. See your provider's documentation
 for JWKS URL, issuer, and audience values.
 
-## Enable OAuth2/OIDC for Apache Kafka®
+## Configure OAuth 2.0/OIDC settings
+
+To use OAuth 2.0/OIDC only, enable SASL authentication, set
+`kafka.sasl_oauthbearer_jwks_endpoint_url`, and disable `PLAIN`, `SCRAM-SHA-256`, and
+`SCRAM-SHA-512`.
+
+Set `kafka.sasl_oauthbearer_jwks_endpoint_url` to enable `OAUTHBEARER`. Optionally
+[disable PLAIN, SCRAM-SHA-256, and SCRAM-SHA-512](/docs/products/kafka/howto/kafka-sasl-auth#configure-sasl-mechanisms)
+if clients authenticate only with OAuth 2.0/OIDC.
+
+:::note
+When SASL authentication is enabled, at least one SASL mechanism must be available.
+`OAUTHBEARER` satisfies this requirement when
+`kafka.sasl_oauthbearer_jwks_endpoint_url` is set.
+:::
+
+Enable OAuth 2.0/OIDC authentication using one of the following methods.
 
 <Tabs groupId="config-methods">
 <TabItem value="console" label="Aiven Console" default>
 
 1. In the [Aiven Console](https://console.aiven.io/), select your
-   project and choose your Aiven for Apache Kafka® service.
+   project and choose your Aiven for Apache Kafka service.
 
 1. Click <ConsoleLabel name="Service settings"/>.
 1. Scroll to **Advanced configuration** and click **Configure**.
@@ -54,19 +68,27 @@ for JWKS URL, issuer, and audience values.
    **Enabled**.
 1. Configure the JWKS endpoint by setting
    `kafka.sasl_oauthbearer_jwks_endpoint_url` to your provider's JWKS URL.
+
+   This enables the `OAUTHBEARER` mechanism. `PLAIN`, `SCRAM-SHA-256`, and
+   `SCRAM-SHA-512` remain enabled by default.
+
 1. Optional: Configure other OIDC parameters, such as expected issuer,
    expected audience, and subject claim. See
    [OIDC parameters](#oidc-parameters) for details.
-1. Optional: For OAuth/OIDC-only authentication, disable
+1. Optional: To use only OAuth 2.0/OIDC authentication, set
    `kafka_sasl_mechanisms.plain`, `kafka_sasl_mechanisms.scram_sha_256`, and
-   `kafka_sasl_mechanisms.scram_sha_512`.
+   `kafka_sasl_mechanisms.scram_sha_512` to **Disabled**.
 1. Click **Save configurations**.
 
 </TabItem>
 <TabItem value="cli" label="CLI">
 
-To enable OAuth2/OIDC authentication for your Aiven for Apache Kafka
-service using [Aiven CLI](/docs/tools/cli):
+To enable OAuth 2.0/OIDC authentication for your Aiven for Apache Kafka service
+using the [Aiven CLI](/docs/tools/cli):
+
+Each `avn service update` that changes OIDC or SASL settings triggers a rolling
+restart of Apache Kafka brokers. Combine the `-c` flags you need in a single command
+when applying multiple changes.
 
 1. Get the name of your Aiven for Apache Kafka service:
 
@@ -76,23 +98,45 @@ service using [Aiven CLI](/docs/tools/cli):
 
    Note the `SERVICE_NAME` corresponding to your Aiven for Apache Kafka service.
 
-1. Enable OAuth2/OIDC authentication for your service. The following example enables
-   OAuth2/OIDC authentication and disables PLAIN and SCRAM mechanisms:
+1. Enable SASL authentication and configure the JWKS endpoint:
+
+   Run a single `avn service update` command. Include the required flags below, and add
+   any optional flags to the same command.
+
+   **Required:**
 
    ```bash
-   avn service update <SERVICE_NAME> \
+   avn service update SERVICE_NAME \
+       -c kafka_authentication_methods.sasl=true \
+       -c kafka.sasl_oauthbearer_jwks_endpoint_url="https://my-jwks-endpoint.example.com/jwks"
+   ```
+
+   This enables the `OAUTHBEARER` mechanism. `PLAIN`, `SCRAM-SHA-256`, and
+   `SCRAM-SHA-512` remain enabled by default.
+
+   **Optional:** Add issuer, audience, and subject claim verification, or set
+   `PLAIN`, `SCRAM-SHA-256`, and `SCRAM-SHA-512` to `false` to use only OAuth 2.0/OIDC
+   authentication. Example with issuer, audience, subject claim verification, and
+   OAuth-only SASL configuration:
+
+   ```bash
+   avn service update SERVICE_NAME \
        -c kafka_authentication_methods.sasl=true \
        -c kafka.sasl_oauthbearer_jwks_endpoint_url="https://my-jwks-endpoint.example.com/jwks" \
        -c kafka.sasl_oauthbearer_expected_issuer="https://my-issuer.example.com" \
        -c kafka.sasl_oauthbearer_expected_audience="my-audience" \
+       -c kafka.sasl_oauthbearer_sub_claim_name="sub" \
        -c kafka_sasl_mechanisms.plain=false \
        -c kafka_sasl_mechanisms.scram_sha_256=false \
        -c kafka_sasl_mechanisms.scram_sha_512=false
    ```
 
-   To keep PLAIN or SCRAM mechanisms enabled, omit the corresponding
-   `kafka_sasl_mechanisms` settings. Optional issuer and audience settings can also
-   be omitted.
+   Omit optional flags you do not need. Do not run the required and optional examples
+   as separate commands.
+
+   Replace the following:
+
+   - `SERVICE_NAME`: name of your Aiven for Apache Kafka service.
 
 For details about the OIDC parameters, see [OIDC parameters](#oidc-parameters).
 
@@ -101,26 +145,25 @@ For details about the OIDC parameters, see [OIDC parameters](#oidc-parameters).
 
 ## OIDC parameters {#oidc-parameters}
 
-Set the following OIDC parameters:
+Configure the following OIDC parameters:
 
 - `kafka.sasl_oauthbearer_jwks_endpoint_url`
-  - **Description**: Endpoint for retrieving the JSON Web Key Set
-    (JWKS), which enables OIDC authentication. Corresponds to
+  - **Description**: Endpoint for retrieving the JSON Web Key Set, or JWKS, which
+    enables OIDC authentication. Corresponds to
     the Apache Kafka parameter
     `sasl.oauthbearer.jwks.endpoint.url`.
-  - **Value**: Enter the JWKS endpoint URL provided by your OIDC
-    provider.
+  - **Value**: Enter the HTTPS JWKS endpoint URL provided by your OIDC provider.
 
     :::note
-    Starting with Apache Kafka 4.0, the broker checks that the JWKS endpoint used for
-    OAuth authentication is explicitly listed in the system
-    property `org.apache.kafka.sasl.oauthbearer.allowed.urls`. If it is not, the broker
-    fails to start.
-    Aiven automatically sets this property based on the value
-    of `kafka.sasl_oauthbearer_jwks_endpoint_url`. No additional configuration is needed.
+    Starting with Apache Kafka 4.0, the broker verifies that the JWKS endpoint URL for
+    OAuth authentication matches an entry in the system property
+    `org.apache.kafka.sasl.oauthbearer.allowed.urls`. Aiven sets this property from
+    the value of `kafka.sasl_oauthbearer_jwks_endpoint_url`. You do not need additional
+    configuration.
     :::
 
-- `kafka.sasl_oauthbearer_sub_claim_name` (optional)
+- `kafka.sasl_oauthbearer_sub_claim_name`
+  - **Optional**
   - **Description**: Name of the JWT's subject claim for broker
     verification. It is typically set to `sub`.
     Corresponds to the Apache Kafka parameter
@@ -133,33 +176,34 @@ Set the following OIDC parameters:
     supported.
     :::
 
-- `kafka.sasl_oauthbearer_expected_issuer` (optional)
+- `kafka.sasl_oauthbearer_expected_issuer`
+  - **Optional**
   - **Description**: Specifies the JWT's issuer for the broker to
     verify. Corresponds to the Apache Kafka parameter
     `sasl.oauthbearer.expected.issuer`.
   - **Value**: Enter the issuer URL or identifier provided by your
     OIDC provider.
-- `kafka.sasl_oauthbearer_expected_audience` (optional)
+- `kafka.sasl_oauthbearer_expected_audience`
+  - **Optional**
   - **Description**: Validates the intended JWT audience for the
     broker. Corresponds to the Apache Kafka parameter
-    `sasl.oauthbearer.expected.audience`. It is used if your OIDC provider
+    `sasl.oauthbearer.expected.audience`. Use this parameter when your OIDC provider
     specifies an audience.
   - **Value**: Enter the audience identifiers given by your OIDC
     provider. If there are multiple audiences, separate them
     with commas.
 
-For more information on each corresponding Apache Kafka parameter,
+For more information about each corresponding Apache Kafka parameter,
 see [Apache Kafka documentation](https://kafka.apache.org/documentation/) on
 configuration options starting with `sasl.oauthbearer`.
 
 :::warning
-Changing OIDC settings, such as enabling, disabling, or modifying settings, can
-lead to a rolling restart of Apache Kafka brokers. As a result, the brokers may
-temporarily operate with different configurations. To reduce operational impact,
-apply these changes during a maintenance window.
+Changing OIDC settings triggers a rolling restart of Apache Kafka brokers. As a
+result, the brokers temporarily operate with different configurations. To reduce
+operational impact, apply these changes during a maintenance window.
 :::
 
 <RelatedPages/>
 
-- [Enable OAuth2/OIDC support for Apache Kafka® REST proxy](/docs/products/kafka/karapace/howto/enable-oauth-oidc-kafka-rest-proxy)
-- [Enable and configure SASL authentication with Aiven for Apache Kafka](/docs/products/kafka/howto/kafka-sasl-auth)
+- [Enable OAuth 2.0/OIDC support for Apache Kafka REST proxy](/docs/products/kafka/karapace/howto/enable-oauth-oidc-kafka-rest-proxy)
+- [Enable and configure SASL authentication](/docs/products/kafka/howto/kafka-sasl-auth)

--- a/docs/products/kafka/howto/enable-oidc.md
+++ b/docs/products/kafka/howto/enable-oidc.md
@@ -1,5 +1,5 @@
 ---
-title: Enable OAUTH2/OIDC authentication for Apache Kafka®
+title: Enable OAuth2/OIDC authentication for Apache Kafka®
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,13 +8,9 @@ import ConsoleLabel from "@site/src/components/ConsoleIcons"
 import ConsoleIcon from "@site/src/components/ConsoleIcons"
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Aiven for Apache Kafka® enables secure client authentication using OIDC/OAuth2, allowing clients to verify users through an authorization server.
-
-By activating this, you can use
-token-based authentication and integrate with identity providers.
-Setting the JSON Web Key Set (JWKS) JWKS endpoint via the Aiven console
-activates the OIDC mechanism for Kafka, which triggers a rolling restart
-of the Kafka brokers. This restart does not cause service downtime.
+Aiven for Apache Kafka® supports OAuth2/OIDC authentication for Kafka clients.
+Use OAuth2/OIDC authentication to let clients authenticate with tokens issued by an
+identity provider.
 
 :::note
 To use the `OAUTHBEARER` mechanism, you must enable `kafka_authentication_methods.sasl`.
@@ -25,25 +21,22 @@ disabled independently. See
 
 ## Prerequisites
 
-Aiven for Apache Kafka integrates with a wide range of OpenID Connect
-identity providers (IdPs). However, the exact configuration steps can
-differ based on your chosen IdP. Refer to your Identity Provider's
-official documentation for specific configuration guidelines.
+Before you begin, make sure you have:
 
-Before proceeding with the setup, ensure you have:
-
-- [Aiven for Apache Kafka®](/docs/products/kafka/get-started/create-kafka-service) service running.
-- **Access to an OIDC provider**: Options include Auth0, Okta, Google
-  Identity Platform, Azure, or any other OIDC compliant provider.
+- An [Aiven for Apache Kafka®](/docs/products/kafka/get-started/create-kafka-service)
+  service.
+- Access to an OIDC provider, such as Auth0, Okta, Google Identity Platform,
+  Azure, or another OIDC-compliant provider.
 - Required configuration details from your OIDC provider:
-  - **JWKS Endpoint URL**: URL to retrieve the JSON Web Key Set
-    (JWKS).
-  - **Subject Claim Name**: Typically `sub`, but this can vary depending
-    on your OIDC provider.
-  - **Issuer URL or Identifier**: Identifies and verifies the JWT
-    issuer.
-  - **Audience identifiers**: Validates the JWT's intended
-    recipients. For multiple audiences, make a note of all.
+  - **JWKS endpoint URL**: URL to retrieve the JSON Web Key Set (JWKS).
+  - **Subject claim name**: Typically `sub`, but this can vary depending on your
+    OIDC provider.
+  - **Issuer URL or identifier**: Identifies and verifies the JWT issuer.
+  - **Audience identifiers**: Validates the JWT's intended recipients. For
+    multiple audiences, make a note of all.
+
+Configuration steps vary by identity provider. See your provider's documentation
+for JWKS URL, issuer, and audience values.
 
 ## Enable OAuth2/OIDC for Apache Kafka®
 
@@ -57,7 +50,16 @@ Before proceeding with the setup, ensure you have:
 1. Scroll to **Advanced configuration** and click **Configure**.
 1. In the **Advanced configuration** window, click
    <ConsoleIcon name="Add config options"/>.
-1. Set the OIDC parameters as detailed in the [OIDC Parameters](#oidc-parameters) section.
+1. Enable SASL authentication by setting `kafka_authentication_methods.sasl` to
+   **Enabled**.
+1. Configure the JWKS endpoint by setting
+   `kafka.sasl_oauthbearer_jwks_endpoint_url` to your provider's JWKS URL.
+1. Optionally, configure other OIDC parameters, such as expected issuer,
+   expected audience, and subject claim. See
+   [OIDC parameters](#oidc-parameters) for details.
+1. Optional: For OAuth/OIDC-only authentication, disable
+   `kafka_sasl_mechanisms.plain`, `kafka_sasl_mechanisms.scram_sha_256`, and
+   `kafka_sasl_mechanisms.scram_sha_512`.
 1. Click **Save configurations**.
 
 </TabItem>
@@ -74,18 +76,25 @@ service using [Aiven CLI](/docs/tools/cli):
 
    Note the `SERVICE_NAME` corresponding to your Aiven for Apache Kafka service.
 
-1. Enable OAuth2/OIDC authentication for your service:
+1. Enable OAuth2/OIDC authentication for your service. The following example enables
+   OAuth2/OIDC authentication and disables PLAIN and SCRAM mechanisms:
 
    ```bash
    avn service update <SERVICE_NAME> \
-       -c kafka.sasl_oauthbearer_expected_audience="my-audience, another-audience" \
-       -c kafka.sasl_oauthbearer_expected_issuer="https://my-issuer.example.com" \
+       -c kafka_authentication_methods.sasl=true \
        -c kafka.sasl_oauthbearer_jwks_endpoint_url="https://my-jwks-endpoint.example.com/jwks" \
-       -c kafka.sasl_oauthbearer_sub_claim_name="custom-sub"
+       -c kafka.sasl_oauthbearer_expected_issuer="https://my-issuer.example.com" \
+       -c kafka.sasl_oauthbearer_expected_audience="my-audience" \
+       -c kafka_sasl_mechanisms.plain=false \
+       -c kafka_sasl_mechanisms.scram_sha_256=false \
+       -c kafka_sasl_mechanisms.scram_sha_512=false
    ```
 
-For detailed explanations on the OIDC parameters, see the
-[OIDC Parameters](#oidc-parameters) section.
+   To keep PLAIN or SCRAM mechanisms enabled, omit the corresponding
+   `kafka_sasl_mechanisms` settings. Optional issuer and audience settings can also
+   be omitted.
+
+For details about the OIDC parameters, see [OIDC parameters](#oidc-parameters).
 
 </TabItem>
 </Tabs>
@@ -111,8 +120,7 @@ Set the following OIDC parameters:
     of `kafka.sasl_oauthbearer_jwks_endpoint_url`. No additional configuration is needed.
     :::
 
-
-- Optional: `kafka.sasl_oauthbearer_sub_claim_name`
+- `kafka.sasl_oauthbearer_sub_claim_name` (optional)
   - **Description**: Name of the JWT's subject claim for broker
     verification. It is typically set to `sub`.
     Corresponds to the Apache Kafka parameter
@@ -125,18 +133,18 @@ Set the following OIDC parameters:
     supported.
     :::
 
-- Optional: `kafka.sasl_oauthbearer_expected_issuer`
+- `kafka.sasl_oauthbearer_expected_issuer` (optional)
   - **Description**: Specifies the JWT's issuer for the broker to
     verify. Corresponds to the Apache Kafka parameter
     `sasl.oauthbearer.expected.issuer`.
   - **Value**: Enter the issuer URL or identifier provided by your
     OIDC provider.
-- Optional: `kafka.sasl_oauthbearer_expected_audience`
+- `kafka.sasl_oauthbearer_expected_audience` (optional)
   - **Description**: Validates the intended JWT audience for the
     broker. Corresponds to the Apache Kafka parameter
     `sasl.oauthbearer.expected.audience`. It is used if your OIDC provider
     specifies an audience.
-  - **Value**: Input the audience identifiers given by your OIDC
+  - **Value**: Enter the audience identifiers given by your OIDC
     provider. If there are multiple audiences, separate them
     with commas.
 
@@ -145,11 +153,10 @@ see [Apache Kafka documentation](https://kafka.apache.org/documentation/) on
 configuration options starting with `sasl.oauthbearer`.
 
 :::warning
-Adjusting OIDC configurations, such as enabling, disabling, or
-modifying settings, can lead to a rolling restart of Apache Kafka brokers.
-As a result, the brokers may temporarily operate with different configurations. To
-minimize any operational disruptions, plan to implement these changes during a
-maintenance window or at a time that ensures a minimal impact on your operations.
+Changing OIDC settings, such as enabling, disabling, or modifying settings, can
+lead to a rolling restart of Apache Kafka brokers. As a result, the brokers may
+temporarily operate with different configurations. To reduce operational impact,
+apply these changes during a maintenance window.
 :::
 
 <RelatedPages/>

--- a/docs/products/kafka/howto/enable-oidc.md
+++ b/docs/products/kafka/howto/enable-oidc.md
@@ -54,7 +54,7 @@ for JWKS URL, issuer, and audience values.
    **Enabled**.
 1. Configure the JWKS endpoint by setting
    `kafka.sasl_oauthbearer_jwks_endpoint_url` to your provider's JWKS URL.
-1. Optionally, configure other OIDC parameters, such as expected issuer,
+1. Optional: Configure other OIDC parameters, such as expected issuer,
    expected audience, and subject claim. See
    [OIDC parameters](#oidc-parameters) for details.
 1. Optional: For OAuth/OIDC-only authentication, disable

--- a/docs/products/kafka/howto/kafka-sasl-auth.md
+++ b/docs/products/kafka/howto/kafka-sasl-auth.md
@@ -17,20 +17,20 @@ Aiven for Apache Kafka® provides [multiple authentication methods](/docs/produc
 <Tabs groupId="config-methods">
 <TabItem value="console" label="Aiven Console" default>
 
-1. Access the [Aiven Console](https://console.aiven.io) and select your
-   Aiven for Apache Kafka service.
+1. In the [Aiven Console](https://console.aiven.io), select your
+   Aiven for Apache Kafka® service.
 1. Click <ConsoleLabel name="Service settings"/>.
 1. Scroll to **Advanced configuration** and click **Configure**.
 1. Click <ConsoleIcon name="Add config options"/>.
 1. Select `kafka_authentication_methods.sasl` from the list and set the value to **Enabled**.
 1. Click **Save configurations**.
 
-The **Connection information** in the <ConsoleLabel name="overview"/> page now
-allows connections via SASL or Client certificate.
+The **Connection information** on the <ConsoleLabel name="overview"/> page now
+allows connections using SASL or client certificate authentication.
 
 :::note
-Although these connections use a different port, the host, CA, and user
-credentials remain consistent.
+SASL and client certificate connections use different ports. The host, CA, and user
+credentials remain the same.
 :::
 
 </TabItem>
@@ -94,23 +94,47 @@ Set the `kafka_authentication_methods.sasl` attribute in [your `aiven_kafka` res
 
 ## Configure SASL mechanisms
 
-After [enabling SASL authentication](#enable-sasl-authentication), fine-tune the active SASL mechanisms for your
-Aiven for Apache Kafka service. By default, all mechanisms (PLAIN, SCRAM-SHA-256,
-SCRAM-SHA-512) are enabled. Configure these settings only to disable any mechanisms.
+After [enabling SASL authentication](#enable-sasl-authentication), configure the SASL
+mechanisms that clients can use.
+
+Aiven for Apache Kafka® supports the following SASL mechanisms:
+
+- **PLAIN**
+- **SCRAM-SHA-256**
+- **SCRAM-SHA-512**
+- **OAUTHBEARER**
+
+Use `kafka_sasl_mechanisms` to enable or disable **PLAIN**, **SCRAM-SHA-256**, and
+**SCRAM-SHA-512**. These three mechanisms are enabled by default. Configure these
+settings only to disable mechanisms that you do not need.
+
+To enable **OAUTHBEARER**, set `kafka.sasl_oauthbearer_jwks_endpoint_url`. For optional
+OIDC settings, see
+[Enable OAuth2/OIDC authentication for Apache Kafka®](/docs/products/kafka/howto/enable-oidc).
+
+You can use **OAUTHBEARER** with **PLAIN**, **SCRAM-SHA-256**, and **SCRAM-SHA-512**, or
+use **OAUTHBEARER** as the only SASL mechanism.
 
 <Tabs groupId="config-methods">
 <TabItem value="console" label="Aiven Console" default>
 
-1. Access the [Aiven Console](https://console.aiven.io) and select your
+1. In the [Aiven Console](https://console.aiven.io), select your
    Aiven for Apache Kafka® service.
 1. Click <ConsoleLabel name="Service settings"/>.
 1. Scroll to **Advanced configuration** and click **Configure**.
-1. In the **Advanced configuration** window, set the corresponding
-   `kafka_sasl_mechanisms` value to either `Enabled` or `Disabled`:
+1. In the **Advanced configuration** window, configure one or more SASL mechanisms:
 
-   - **PLAIN**: `kafka_sasl_mechanisms.plain`
-   - **SCRAM-SHA-256**: `kafka_sasl_mechanisms.scram_sha_256`
-   - **SCRAM-SHA-512**: `kafka_sasl_mechanisms.scram_sha_512`
+   - To enable or disable **PLAIN**, set `kafka_sasl_mechanisms.plain` to **Enabled**
+     or **Disabled**.
+   - To enable or disable **SCRAM-SHA-256**, set `kafka_sasl_mechanisms.scram_sha_256`
+     to **Enabled** or **Disabled**.
+   - To enable or disable **SCRAM-SHA-512**, set `kafka_sasl_mechanisms.scram_sha_512`
+     to **Enabled** or **Disabled**.
+   - To enable **OAUTHBEARER**, set `kafka.sasl_oauthbearer_jwks_endpoint_url` to your
+     provider's JWKS URL.
+
+   Optional: For OAuth/OIDC-only authentication, disable `kafka_sasl_mechanisms.plain`,
+   `kafka_sasl_mechanisms.scram_sha_256`, and `kafka_sasl_mechanisms.scram_sha_512`.
 
 1. Click **Save configurations**.
 
@@ -126,9 +150,10 @@ Configure SASL mechanisms for your Aiven for Apache Kafka service using
    avn service list
    ```
 
-  Note the `SERVICE_NAME` corresponding to your Aiven for Apache Kafka service.
+   Note the `SERVICE_NAME` of your Aiven for Apache Kafka® service.
 
-1. Configure specific mechanisms:
+1. Configure **PLAIN** and **SCRAM** mechanisms. By default, all three are enabled; set
+   a mechanism to `false` to disable it:
 
    ```bash
    avn service update SERVICE_NAME             \
@@ -140,17 +165,32 @@ Configure SASL mechanisms for your Aiven for Apache Kafka service using
    Parameters:
 
    - `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
-   - `kafka_sasl_mechanisms.plain`: Set to `true` to enable the **PLAIN** mechanism.
-   - `kafka_sasl_mechanisms.scram_sha_256`: Set to `true` to enable the
-     **SCRAM-SHA-256** mechanism.
-   - `kafka_sasl_mechanisms.scram_sha_512`: Set to `true` to enable the
-     **SCRAM-SHA-512** mechanism.
+   - `kafka_sasl_mechanisms.plain`: Set to `true` or `false` to enable or disable
+     **PLAIN**.
+   - `kafka_sasl_mechanisms.scram_sha_256`: Set to `true` or `false` to enable or
+     disable **SCRAM-SHA-256**.
+   - `kafka_sasl_mechanisms.scram_sha_512`: Set to `true` or `false` to enable or
+     disable **SCRAM-SHA-512**.
+
+1. To enable **OAUTHBEARER**, set `kafka.sasl_oauthbearer_jwks_endpoint_url`. The
+   following example enables OAuth/OIDC-only authentication:
+
+   ```bash
+   avn service update SERVICE_NAME \
+       -c kafka.sasl_oauthbearer_jwks_endpoint_url="https://my-jwks-endpoint.example.com/jwks" \
+       -c kafka_sasl_mechanisms.plain=false \
+       -c kafka_sasl_mechanisms.scram_sha_256=false \
+       -c kafka_sasl_mechanisms.scram_sha_512=false
+   ```
+
+   To keep **PLAIN** or **SCRAM** mechanisms enabled, omit the corresponding
+   `kafka_sasl_mechanisms` settings. SASL must already be enabled on the service.
 
 </TabItem>
 <TabItem value="api" label="API">
 
 Use the [ServiceUpdate](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
-API to enable SASL authentication on an existing service:
+API to configure SASL mechanisms on an existing service:
 
 ```bash
 curl -X PUT "https://console.aiven.io/v1/project/{project_name}/service/{service_name}" \
@@ -160,6 +200,14 @@ curl -X PUT "https://console.aiven.io/v1/project/{project_name}/service/{service
            "user_config": {
              "kafka_authentication_methods": {
                "sasl": true
+             },
+             "kafka": {
+               "sasl_oauthbearer_jwks_endpoint_url": "https://my-jwks-endpoint.example.com/jwks"
+             },
+             "kafka_sasl_mechanisms": {
+               "plain": false,
+               "scram_sha_256": false,
+               "scram_sha_512": false
              }
            }
          }'
@@ -170,43 +218,57 @@ Parameters:
 - `project_name`: Name of your Aiven project.
 - `service_name`: Name of your Aiven for Apache Kafka service.
 - `API_TOKEN`: API token for authentication.
-- `kafka_sasl_mechanisms.plain`: Set to `true` or `false` to enable or disable the
-  **PLAIN** mechanism.
+- `kafka_authentication_methods.sasl`: Set to `true` if SASL is not already enabled.
+- `kafka.sasl_oauthbearer_jwks_endpoint_url`: JWKS endpoint URL; enables
+  **OAUTHBEARER** when set.
+- `kafka_sasl_mechanisms.plain`: Set to `true` or `false` to enable or disable
+  **PLAIN**.
 - `kafka_sasl_mechanisms.scram_sha_256`: Set to `true` or `false` to enable or disable
-  the **SCRAM-SHA-256** mechanism.
+  **SCRAM-SHA-256**.
 - `kafka_sasl_mechanisms.scram_sha_512`: Set to `true` or `false` to enable or disable
-  the **SCRAM-SHA-512** mechanism.
+  **SCRAM-SHA-512**.
+
+To keep **PLAIN** or **SCRAM** mechanisms enabled, omit the `kafka_sasl_mechanisms`
+block or set the values to `true`.
 
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
 Use the `kafka_sasl_mechanisms` attribute in [your `aiven_kafka` resource](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/kafka#kafka_sasl_mechanisms)
-and set the value to either `Enabled` or `Disabled`:
+to enable or disable SASL mechanisms. Set each mechanism to `true` or `false`:
 
 - **PLAIN**: `kafka_sasl_mechanisms.plain`
 - **SCRAM-SHA-256**: `kafka_sasl_mechanisms.scram_sha_256`
 - **SCRAM-SHA-512**: `kafka_sasl_mechanisms.scram_sha_512`
+
+To enable **OAUTHBEARER**, set `sasl_oauthbearer_jwks_endpoint_url` in the `kafka`
+block of `user_config`. See
+[Enable OAuth2/OIDC authentication for Apache Kafka®](/docs/products/kafka/howto/enable-oidc).
 
 </TabItem>
 </Tabs>
 
 :::note
 
-- At least one SASL mechanism must remain enabled. Disabling all results in an error.
-- `OAUTHBEARER` is enabled if `sasl_oauthbearer_jwks_endpoint_url` is specified.
+At least one SASL mechanism must be available when SASL authentication is enabled.
+**OAUTHBEARER** is available when `kafka.sasl_oauthbearer_jwks_endpoint_url` is set.
+**PLAIN**, **SCRAM-SHA-256**, and **SCRAM-SHA-512** can be disabled independently.
+
+Disabling all three `kafka_sasl_mechanisms` options without setting a JWKS URL results
+in an error.
 
 :::
 
 ## Enable public CA for SASL authentication
 
-After [enabling SASL authentication](#enable-sasl-authentication), enable the public CA
-if Kafka clients cannot install or trust the default project CA.
+After you enable SASL authentication, you can enable the public CA for clients that
+cannot install or trust the default project CA.
 
 <Tabs groupId="config-methods">
 <TabItem value="console" label="Aiven Console" default>
 
-1. Access the [Aiven Console](https://console.aiven.io) and select your
-   Aiven for Apache Kafka service.
+1. In the [Aiven Console](https://console.aiven.io), select your
+   Aiven for Apache Kafka® service.
 1. Click <ConsoleLabel name="Service settings"/>.
 1. Go to the **Cloud and network** section, click <ConsoleLabel name="actions" /> >
   **More network configurations**.
@@ -263,7 +325,9 @@ curl -X PUT "https://console.aiven.io/v1/project/{project_name}/service/{service
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
-This example creates a Kafka service with SASL authentication enabled and configures SCRAM-SHA-256 as the SASL mechanism. It also includes a data source to output the port number for SASL authentication using a public CA.
+This Terraform example enables SASL authentication and public CA for SASL on a Kafka
+service. It configures SCRAM-SHA-256 and includes a data source that outputs the SASL
+port for connections that use the public CA.
 
 The complete example is available in the [Aiven Terraform Provider repository](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/kafka/kafka_sasl_authentication) on GitHub.
 
@@ -278,7 +342,7 @@ The complete example is available in the [Aiven Terraform Provider repository](h
 
 - The public certificate is issued and validated by [Let's Encrypt](https://letsencrypt.org),
   a widely trusted certification authority. For details, see
-  [How It Works](https://letsencrypt.org/how-it-works)
+  [How it works](https://letsencrypt.org/how-it-works).
 
 - When enabling the public CA over a PrivateLink connection, network configuration may
   take several minutes before clients can connect. A new port must be allocated and the
@@ -288,5 +352,5 @@ The complete example is available in the [Aiven Terraform Provider repository](h
 
 <RelatedPages/>
 
-- [Enable OAUTH2/OIDC authentication for Aiven for Apache Kafka](/docs/products/kafka/howto/enable-oidc)
+- [Enable OAuth2/OIDC authentication for Aiven for Apache Kafka®](/docs/products/kafka/howto/enable-oidc)
 - [Authentication types](/docs/products/kafka/concepts/auth-types)

--- a/docs/products/kafka/howto/kafka-sasl-auth.md
+++ b/docs/products/kafka/howto/kafka-sasl-auth.md
@@ -1,7 +1,8 @@
 ---
-title: Enable and configure SASL authentication
-
+title: Enable and configure SASL authentication for Apache Kafka®
+sidebar_label: Enable SASL authentication
 ---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TerraformSample from '@site/src/components/CodeSamples/TerraformSample';
@@ -10,15 +11,18 @@ import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import ConsoleIcon from "@site/src/components/ConsoleIcons";
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Aiven for Apache Kafka® provides [multiple authentication methods](/docs/products/kafka/concepts/auth-types) to secure Kafka data, including Simple Authentication and Security Layer ([SASL](https://en.wikipedia.org/wiki/Simple_Authentication_and_Security_Layer)) over SSL.
+Aiven for Apache Kafka® supports [multiple authentication methods](/docs/products/kafka/concepts/auth-types), including Simple Authentication and Security Layer ([SASL](https://en.wikipedia.org/wiki/Simple_Authentication_and_Security_Layer)) over SSL.
 
 ## Enable SASL authentication
+
+To allow clients to authenticate with SASL, enable `kafka_authentication_methods.sasl`
+on your Aiven for Apache Kafka service.
 
 <Tabs groupId="config-methods">
 <TabItem value="console" label="Aiven Console" default>
 
 1. In the [Aiven Console](https://console.aiven.io), select your
-   Aiven for Apache Kafka® service.
+   Aiven for Apache Kafka service.
 1. Click <ConsoleLabel name="Service settings"/>.
 1. Scroll to **Advanced configuration** and click **Configure**.
 1. Click <ConsoleIcon name="Add config options"/>.
@@ -26,7 +30,7 @@ Aiven for Apache Kafka® provides [multiple authentication methods](/docs/produc
 1. Click **Save configurations**.
 
 The **Connection information** on the <ConsoleLabel name="overview"/> page now
-allows connections using SASL or client certificate authentication.
+shows connection details for SASL and client certificate authentication.
 
 :::note
 SASL and client certificate connections use different ports. The host, CA, and user
@@ -64,8 +68,8 @@ Enable SASL authentication for your Aiven for Apache Kafka service using
 Use the [ServiceUpdate](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
 API to enable SASL authentication on an existing service:
 
-  ```bash
-   curl -X PUT "https://console.aiven.io/v1/project/{project_name}/service/{service_name}" \
+```bash
+curl -X PUT "https://api.aiven.io/v1/project/{project_name}/service/{service_name}" \
      -H "Authorization: Bearer <API_TOKEN>" \
      -H "Content-Type: application/json" \
      -d '{
@@ -73,16 +77,16 @@ API to enable SASL authentication on an existing service:
              "kafka_authentication_methods": {
                "sasl": true
              }
-          }
-       }'
-   ```
+           }
+         }'
+```
 
-   Parameters:
+Parameters:
 
-   - `project_name`: Name of your Aiven project.
-   - `service_name`: Name of your Aiven for Apache Kafka service.
-   - `API_TOKEN`: Personal Aiven [token](/docs/platform/howto/create_authentication_token).
-   - `kafka_authentication_methods.sasl`: Set to `true` to enable SASL authentication.
+- `project_name`: Name of your Aiven project.
+- `service_name`: Name of your Aiven for Apache Kafka service.
+- `API_TOKEN`: Personal Aiven [token](/docs/platform/howto/create_authentication_token).
+- `kafka_authentication_methods.sasl`: Set to `true` to enable SASL authentication.
 
 </TabItem>
 <TabItem value="terraform" label="Terraform">
@@ -94,35 +98,53 @@ Set the `kafka_authentication_methods.sasl` attribute in [your `aiven_kafka` res
 
 ## Configure SASL mechanisms
 
-After [enabling SASL authentication](#enable-sasl-authentication), configure the SASL
-mechanisms that clients can use.
+After [enabling SASL authentication](#enable-sasl-authentication), choose which SASL
+mechanisms clients can use.
 
-Aiven for Apache Kafka® supports the following SASL mechanisms:
+### Supported mechanisms
 
-- **PLAIN**
-- **SCRAM-SHA-256**
-- **SCRAM-SHA-512**
-- **OAUTHBEARER**
+Aiven for Apache Kafka supports the following SASL mechanisms:
 
-Use `kafka_sasl_mechanisms` to enable or disable **PLAIN**, **SCRAM-SHA-256**, and
-**SCRAM-SHA-512**. These three mechanisms are enabled by default. Configure these
-settings only to disable mechanisms that you do not need.
+- **PLAIN**: Enabled by default. Controlled by `kafka_sasl_mechanisms.plain`.
+- **SCRAM-SHA-256**: Enabled by default. Controlled by
+  `kafka_sasl_mechanisms.scram_sha_256`.
+- **SCRAM-SHA-512**: Enabled by default. Controlled by
+  `kafka_sasl_mechanisms.scram_sha_512`.
+- **OAUTHBEARER**: Set `kafka.sasl_oauthbearer_jwks_endpoint_url` to enable
+  [OAuth 2.0/OIDC authentication](/docs/products/kafka/howto/enable-oidc).
+  `PLAIN`, `SCRAM-SHA-256`, and `SCRAM-SHA-512` remain enabled by default.
+  Each client selects one SASL mechanism when it connects.
 
-To enable **OAUTHBEARER**, set `kafka.sasl_oauthbearer_jwks_endpoint_url`. For optional
-OIDC settings, see
-[Enable OAuth2/OIDC authentication for Apache Kafka®](/docs/products/kafka/howto/enable-oidc).
+  To allow only OAuth 2.0/OIDC authentication, disable `kafka_sasl_mechanisms.plain`,
+  `kafka_sasl_mechanisms.scram_sha_256`, and `kafka_sasl_mechanisms.scram_sha_512`.
 
-You can use **OAUTHBEARER** with **PLAIN**, **SCRAM-SHA-256**, and **SCRAM-SHA-512**, or
-use **OAUTHBEARER** as the only SASL mechanism.
+  Optional OIDC parameters include `kafka.sasl_oauthbearer_expected_issuer`,
+  `kafka.sasl_oauthbearer_expected_audience`, and
+  `kafka.sasl_oauthbearer_sub_claim_name`.
+
+:::note
+When SASL authentication is enabled, at least one SASL mechanism must be available.
+`OAUTHBEARER` satisfies this requirement when
+`kafka.sasl_oauthbearer_jwks_endpoint_url` is set. If you disable PLAIN,
+SCRAM-SHA-256, and SCRAM-SHA-512 without setting
+`kafka.sasl_oauthbearer_jwks_endpoint_url`, the update fails because no SASL mechanism
+is available.
+:::
+
+### Enable or disable PLAIN, SCRAM-SHA-256, and SCRAM-SHA-512
+
+Use `kafka_sasl_mechanisms` to enable or disable these mechanisms using one of the
+following methods.
 
 <Tabs groupId="config-methods">
 <TabItem value="console" label="Aiven Console" default>
 
 1. In the [Aiven Console](https://console.aiven.io), select your
-   Aiven for Apache Kafka® service.
+   Aiven for Apache Kafka service.
 1. Click <ConsoleLabel name="Service settings"/>.
 1. Scroll to **Advanced configuration** and click **Configure**.
-1. In the **Advanced configuration** window, configure one or more SASL mechanisms:
+1. In the **Advanced configuration** window, configure **PLAIN**, **SCRAM-SHA-256**,
+   and **SCRAM-SHA-512**:
 
    - To enable or disable **PLAIN**, set `kafka_sasl_mechanisms.plain` to **Enabled**
      or **Disabled**.
@@ -130,11 +152,6 @@ use **OAUTHBEARER** as the only SASL mechanism.
      to **Enabled** or **Disabled**.
    - To enable or disable **SCRAM-SHA-512**, set `kafka_sasl_mechanisms.scram_sha_512`
      to **Enabled** or **Disabled**.
-   - To enable **OAUTHBEARER**, set `kafka.sasl_oauthbearer_jwks_endpoint_url` to your
-     provider's JWKS URL.
-
-   Optional: For OAuth2/OIDC-only authentication, disable `kafka_sasl_mechanisms.plain`,
-   `kafka_sasl_mechanisms.scram_sha_256`, and `kafka_sasl_mechanisms.scram_sha_512`.
 
 1. Click **Save configurations**.
 
@@ -150,18 +167,18 @@ Configure SASL mechanisms for your Aiven for Apache Kafka service using
    avn service list
    ```
 
-   Note the `SERVICE_NAME` of your Aiven for Apache Kafka® service.
+   Note the `SERVICE_NAME` corresponding to your Aiven for Apache Kafka service.
 
-1. Configure **PLAIN** and **SCRAM** mechanisms. By default, **PLAIN**,
-   **SCRAM-SHA-256**, and **SCRAM-SHA-512** are enabled; set a mechanism
-   to `false` to disable it:
+1. Disable the SASL mechanisms that clients do not use. By default, **PLAIN**,
+   **SCRAM-SHA-256**, and **SCRAM-SHA-512** are enabled. For example, to disable
+   **PLAIN** authentication:
 
    ```bash
-   avn service update SERVICE_NAME             \
-    -c kafka_sasl_mechanisms.plain=true          \
-    -c kafka_sasl_mechanisms.scram_sha_256=true  \
-    -c kafka_sasl_mechanisms.scram_sha_512=true
+   avn service update SERVICE_NAME \
+       -c kafka_sasl_mechanisms.plain=false
    ```
+
+   **SCRAM-SHA-256** and **SCRAM-SHA-512** remain enabled unless you disable them.
 
    Parameters:
 
@@ -173,42 +190,22 @@ Configure SASL mechanisms for your Aiven for Apache Kafka service using
    - `kafka_sasl_mechanisms.scram_sha_512`: Set to `true` or `false` to enable or
      disable **SCRAM-SHA-512**.
 
-1. To enable **OAUTHBEARER**, set `kafka.sasl_oauthbearer_jwks_endpoint_url`. The
-   following example enables OAuth2/OIDC-only authentication:
-
-   ```bash
-   avn service update SERVICE_NAME \
-       -c kafka.sasl_oauthbearer_jwks_endpoint_url="https://my-jwks-endpoint.example.com/jwks" \
-       -c kafka_sasl_mechanisms.plain=false \
-       -c kafka_sasl_mechanisms.scram_sha_256=false \
-       -c kafka_sasl_mechanisms.scram_sha_512=false
-   ```
-
-   To keep **PLAIN** or **SCRAM** mechanisms enabled, omit the corresponding
-   `kafka_sasl_mechanisms` settings. SASL must already be enabled on the service.
-
 </TabItem>
 <TabItem value="api" label="API">
 
 Use the [ServiceUpdate](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
-API to configure SASL mechanisms on an existing service:
+API to configure **PLAIN** and **SCRAM** mechanisms on an existing service:
 
 ```bash
-curl -X PUT "https://console.aiven.io/v1/project/{project_name}/service/{service_name}" \
+curl -X PUT "https://api.aiven.io/v1/project/{project_name}/service/{service_name}" \
      -H "Authorization: Bearer <API_TOKEN>" \
      -H "Content-Type: application/json" \
      -d '{
            "user_config": {
-             "kafka_authentication_methods": {
-               "sasl": true
-             },
-             "kafka": {
-               "sasl_oauthbearer_jwks_endpoint_url": "https://my-jwks-endpoint.example.com/jwks"
-             },
              "kafka_sasl_mechanisms": {
                "plain": false,
-               "scram_sha_256": false,
-               "scram_sha_512": false
+               "scram_sha_256": true,
+               "scram_sha_512": true
              }
            }
          }'
@@ -218,10 +215,7 @@ Parameters:
 
 - `project_name`: Name of your Aiven project.
 - `service_name`: Name of your Aiven for Apache Kafka service.
-- `API_TOKEN`: API token for authentication.
-- `kafka_authentication_methods.sasl`: Set to `true` if SASL is not already enabled.
-- `kafka.sasl_oauthbearer_jwks_endpoint_url`: JWKS endpoint URL; enables
-  **OAUTHBEARER** when set.
+- `API_TOKEN`: Personal Aiven [token](/docs/platform/howto/create_authentication_token).
 - `kafka_sasl_mechanisms.plain`: Set to `true` or `false` to enable or disable
   **PLAIN**.
 - `kafka_sasl_mechanisms.scram_sha_256`: Set to `true` or `false` to enable or disable
@@ -229,50 +223,35 @@ Parameters:
 - `kafka_sasl_mechanisms.scram_sha_512`: Set to `true` or `false` to enable or disable
   **SCRAM-SHA-512**.
 
-To keep **PLAIN** or **SCRAM** mechanisms enabled, omit the `kafka_sasl_mechanisms`
-block or set the values to `true`.
-
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
 Use the `kafka_sasl_mechanisms` attribute in [your `aiven_kafka` resource](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/kafka#kafka_sasl_mechanisms)
-to enable or disable SASL mechanisms. Set each mechanism to `true` or `false`:
+to enable or disable **PLAIN**, **SCRAM-SHA-256**, and **SCRAM-SHA-512**. Set each
+mechanism to `true` or `false`:
 
 - **PLAIN**: `kafka_sasl_mechanisms.plain`
 - **SCRAM-SHA-256**: `kafka_sasl_mechanisms.scram_sha_256`
 - **SCRAM-SHA-512**: `kafka_sasl_mechanisms.scram_sha_512`
 
-To enable **OAUTHBEARER**, set `sasl_oauthbearer_jwks_endpoint_url` in the `kafka`
-block of `user_config`. See
-[Enable OAuth2/OIDC authentication for Apache Kafka®](/docs/products/kafka/howto/enable-oidc).
-
 </TabItem>
 </Tabs>
 
-:::note
+## Enable public CA certificates for SASL authentication
 
-At least one SASL mechanism must be available when SASL authentication is enabled.
-**OAUTHBEARER** is available when `kafka.sasl_oauthbearer_jwks_endpoint_url` is set.
-**PLAIN**, **SCRAM-SHA-256**, and **SCRAM-SHA-512** can be disabled independently.
+After you enable SASL authentication, you can enable public CA certificates for clients
+that cannot install or trust the default project CA.
 
-Disabling all three `kafka_sasl_mechanisms` options without setting a JWKS URL results
-in an error.
-
-:::
-
-## Enable public CA for SASL authentication
-
-After you enable SASL authentication, you can enable the public CA for clients that
-cannot install or trust the default project CA.
+Enable public CA certificates using one of the following methods.
 
 <Tabs groupId="config-methods">
 <TabItem value="console" label="Aiven Console" default>
 
 1. In the [Aiven Console](https://console.aiven.io), select your
-   Aiven for Apache Kafka® service.
+   Aiven for Apache Kafka service.
 1. Click <ConsoleLabel name="Service settings"/>.
-1. Go to the **Cloud and network** section, click <ConsoleLabel name="actions" /> >
-  **More network configurations**.
+1. Go to the **Cloud and network** section and click <ConsoleLabel name="actions" /> >
+   **More network configurations**.
 1. In the **Network configuration** dialog:
 
    1. Click <ConsoleIcon name="Add config options"/>.
@@ -287,41 +266,49 @@ supports SASL connections using either Project CA or Public CA.
 </TabItem>
 <TabItem value="cli" label="CLI">
 
-Enable the public CA for SASL authentication using the [Aiven CLI](/docs/tools/cli):
+Enable the public CA certificates for SASL authentication using the [Aiven CLI](/docs/tools/cli):
 
-1. List the services in your project to find the Kafka service name:
+1. List the services in your project to find your Aiven for Apache Kafka service name:
 
    ```bash
    avn service list
    ```
 
-   Note the `SERVICE_NAME` for the Kafka service.
+   Note the `SERVICE_NAME` corresponding to your Aiven for Apache Kafka service.
 
-1. Enable public CA for SASL authentication:
+1. Enable public CA certificates for SASL authentication:
 
    ```bash
-   avn service update SERVICE_NAME -c CONFIG_NAME=true
+   avn service update SERVICE_NAME -c letsencrypt_sasl=true
    ```
+
+   For PrivateLink, use `-c letsencrypt_sasl_privatelink=true` instead.
 
    Parameters:
 
    - `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
-   - `CONFIG_NAME`: Name of the configuration parameter to set. Use `letsencrypt_sasl`
-   for enabling public CA for SASL authentication via regular routes or
-   `letsencrypt_sasl_privatelink` via PrivateLink connection.
 
 </TabItem>
 <TabItem value="api" label="API">
 
 Use the [ServiceUpdate](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
-API to enable public CA for SASL authentication on an existing service:
+API to enable public CA certificates for SASL authentication on an existing service:
 
 ```bash
-curl -X PUT "https://console.aiven.io/v1/project/{project_name}/service/{service_name}" \
+curl -X PUT "https://api.aiven.io/v1/project/{project_name}/service/{service_name}" \
      -H "Authorization: Bearer <API_TOKEN>" \
      -H "Content-Type: application/json" \
-     -d '{"user_config": {"letsencrypt_sasl": true}}'   # or letsencrypt_sasl_privatelink for PrivateLink
+     -d '{"user_config": {"letsencrypt_sasl": true}}'
 ```
+
+For PrivateLink, use `letsencrypt_sasl_privatelink` instead of `letsencrypt_sasl`.
+
+Parameters:
+
+- `project_name`: Name of your Aiven project.
+- `service_name`: Name of your Aiven for Apache Kafka service.
+- `API_TOKEN`: Personal Aiven [token](/docs/platform/howto/create_authentication_token).
+- `letsencrypt_sasl`: Set to `true` to enable public CA certificates for SASL authentication.
 
 </TabItem>
 <TabItem value="terraform" label="Terraform">
@@ -353,5 +340,5 @@ The complete example is available in the [Aiven Terraform Provider repository](h
 
 <RelatedPages/>
 
-- [Enable OAuth2/OIDC authentication for Aiven for Apache Kafka®](/docs/products/kafka/howto/enable-oidc)
+- [Enable OAuth 2.0/OIDC authentication for Apache Kafka](/docs/products/kafka/howto/enable-oidc)
 - [Authentication types](/docs/products/kafka/concepts/auth-types)

--- a/docs/products/kafka/howto/kafka-sasl-auth.md
+++ b/docs/products/kafka/howto/kafka-sasl-auth.md
@@ -133,7 +133,7 @@ use **OAUTHBEARER** as the only SASL mechanism.
    - To enable **OAUTHBEARER**, set `kafka.sasl_oauthbearer_jwks_endpoint_url` to your
      provider's JWKS URL.
 
-   Optional: For OAuth/OIDC-only authentication, disable `kafka_sasl_mechanisms.plain`,
+   Optional: For OAuth2/OIDC-only authentication, disable `kafka_sasl_mechanisms.plain`,
    `kafka_sasl_mechanisms.scram_sha_256`, and `kafka_sasl_mechanisms.scram_sha_512`.
 
 1. Click **Save configurations**.
@@ -152,8 +152,9 @@ Configure SASL mechanisms for your Aiven for Apache Kafka service using
 
    Note the `SERVICE_NAME` of your Aiven for Apache Kafka® service.
 
-1. Configure **PLAIN** and **SCRAM** mechanisms. By default, all three are enabled; set
-   a mechanism to `false` to disable it:
+1. Configure **PLAIN** and **SCRAM** mechanisms. By default, **PLAIN**,
+   **SCRAM-SHA-256**, and **SCRAM-SHA-512** are enabled; set a mechanism
+   to `false` to disable it:
 
    ```bash
    avn service update SERVICE_NAME             \
@@ -173,7 +174,7 @@ Configure SASL mechanisms for your Aiven for Apache Kafka service using
      disable **SCRAM-SHA-512**.
 
 1. To enable **OAUTHBEARER**, set `kafka.sasl_oauthbearer_jwks_endpoint_url`. The
-   following example enables OAuth/OIDC-only authentication:
+   following example enables OAuth2/OIDC-only authentication:
 
    ```bash
    avn service update SERVICE_NAME \


### PR DESCRIPTION
## Describe your changes

Clarifies Kafka OAuth2/OIDC and SASL authentication setup, including how to enable OAUTHBEARER and configure it with or without PLAIN and SCRAM mechanisms.

Preview: 

- https://kcon-420-update-kafka-sasl-a.aiven-docs.pages.dev/docs/products/kafka/howto/enable-oidc
- https://kcon-420-update-kafka-sasl-a.aiven-docs.pages.dev/docs/products/kafka/howto/kafka-sasl-auth

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
