### PR TITLE
update: MirrorMaker 2 configuration parameters

### DIFF
--- a/docs/products/clickhouse/howto/integrate-kafka.md
+++ b/docs/products/clickhouse/howto/integrate-kafka.md
@@ -119,7 +119,7 @@ on a table level either in the [Aiven Console](https://console.aiven.io/) or the
      ```
 
 1.  Run
-    [avn service integration-update](/docs/tools/cli/service/integration#avn%20service%20integration-update)
+    [avn service integration-update](/docs/tools/cli/service/integration#avn_service_integration_update)
     with the service integration id and your integration settings. Replace
     `SERVICE_INTEGRATION_ID`, `CONNECTOR_TABLE_NAME`, `DATA_FORMAT` and `CONSUMER_NAME`
     with your values:

--- a/docs/products/clickhouse/howto/integrate-postgresql.md
+++ b/docs/products/clickhouse/howto/integrate-postgresql.md
@@ -69,7 +69,7 @@ steps.
 :::note
 Currently the configurations can be set only with the help of CLI
 command
-[avn service integration-update](/docs/tools/cli/service/integration#avn%20service%20integration-update).
+[avn service integration-update](/docs/tools/cli/service/integration#avn_service_integration_update).
 :::
 
 1.  Get *the service integration id* by requesting the full list of

--- a/docs/products/clickhouse/howto/integrate-postgresql.md
+++ b/docs/products/clickhouse/howto/integrate-postgresql.md
@@ -67,8 +67,7 @@ default these settings are set to the `public` schema in the
 steps.
 
 :::note
-Currently the configurations can be set only with the help of CLI
-command
+These configurations can be set only with the CLI command
 [avn service integration-update](/docs/tools/cli/service/integration#avn_service_integration_update).
 :::
 

--- a/docs/products/kafka/kafka-mirrormaker/concepts/configuration-layers.md
+++ b/docs/products/kafka/kafka-mirrormaker/concepts/configuration-layers.md
@@ -1,9 +1,11 @@
 ---
-title: Configuration layers in Aiven for Apache Kafka® MirrorMaker 2
-sidebar_label: Configuration layers
+title: Configuration and tuning for Aiven for Apache Kafka® MirrorMaker 2
+sidebar_label: Configuration and tuning
 ---
 
-Learn how Aiven for Apache Kafka® MirrorMaker 2 organizes parameters across configuration layers and how changes affect replication behavior and service restarts.
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Learn where Aiven for Apache Kafka® MirrorMaker 2 settings are configured across service, replication-flow, and integration layers, which parameters affect performance, and what restarts when you change them.
 
 ## Configuration layers
 
@@ -95,11 +97,14 @@ being replicated:
 
 ### Producer and consumer settings
 
-These [integration configurations](#integration-configurations) parameters control how
+These [integration configuration](#integration-configurations) parameters control how
 MirrorMaker 2 producers and consumers communicate with the source and target Kafka
 clusters. Set them on the service integration resource. If you do not set a parameter,
 Kafka applies its built-in default. These settings apply to MirrorMaker 2 integrations
 with both Aiven for Apache Kafka services and external Kafka clusters.
+
+To update these settings, see
+[Update integration configurations](/docs/products/kafka/kafka-mirrormaker/howto/update-integration-configurations).
 
 | Parameter | Description | Maximum value |
 |-----------|-------------|---------------|
@@ -114,3 +119,11 @@ with both Aiven for Apache Kafka services and external Kafka clusters.
 | `producer_max_request_size` | Maximum size of a single producer request, in bytes. | — |
 | `producer_request_timeout_ms` | Timeout for producer requests to the broker, in milliseconds. | 600,000 ms (10 minutes) |
 | `producer_send_buffer_bytes` | Size of the TCP send buffer for the producer, in bytes. A value of `-1` uses the OS default. | 100 MiB |
+
+<RelatedPages/>
+
+- [Update integration configurations](/docs/products/kafka/kafka-mirrormaker/howto/update-integration-configurations)
+- [Advanced parameters for Aiven for Apache Kafka® MirrorMaker 2](/docs/products/kafka/kafka-mirrormaker/reference/advanced-params)
+- [Set up an Apache Kafka® MirrorMaker 2 replication flow](/docs/products/kafka/kafka-mirrormaker/howto/setup-replication-flow)
+- [Topics included in a replication flow](/docs/products/kafka/kafka-mirrormaker/concepts/replication-flow-topics-regex)
+- [Known issues](/docs/products/kafka/kafka-mirrormaker/reference/known-issues)

--- a/docs/products/kafka/kafka-mirrormaker/concepts/mirrormaker2-tuning.md
+++ b/docs/products/kafka/kafka-mirrormaker/concepts/mirrormaker2-tuning.md
@@ -95,7 +95,7 @@ being replicated:
 
 ### Producer and consumer settings
 
-These [integration configuration](#integration-configurations) parameters control how
+These [integration configurations](#integration-configurations) parameters control how
 MirrorMaker 2 producers and consumers communicate with the source and target Kafka
 clusters. Set them on the service integration resource. If you do not set a parameter,
 Kafka applies its built-in default. These settings apply to MirrorMaker 2 integrations

--- a/docs/products/kafka/kafka-mirrormaker/concepts/mirrormaker2-tuning.md
+++ b/docs/products/kafka/kafka-mirrormaker/concepts/mirrormaker2-tuning.md
@@ -1,28 +1,29 @@
 ---
-title: Configuration parameters for Aiven for Apache Kafka® MirrorMaker 2
+title: Configuration layers in Aiven for Apache Kafka® MirrorMaker 2
+sidebar_label: Configuration layers
 ---
 
-Learn about the service, replication-flow, and integration configuration layers in Aiven for Apache Kafka® MirrorMaker 2 and how they affect replication performance.
+Learn how Aiven for Apache Kafka® MirrorMaker 2 organizes parameters across configuration layers and how changes affect replication behavior and service restarts.
 
 ## Configuration layers
 
-Aiven for Apache Kafka® MirrorMaker 2 uses three configuration layers:
+Aiven for Apache Kafka® MirrorMaker 2 uses three configuration layers. Each layer
+controls a different part of the replication process and has a different restart impact.
 
 - **Service configurations**
 - **Replication-flow configurations**
 - **Integration configurations**
 
-Each layer manages a specific part of the replication process.
-
 ### Service configurations
 
-Service configurations control the behavior of nodes and workers in the MirrorMaker 2 cluster.
+Service configurations control the behavior of nodes and workers in the MirrorMaker 2
+cluster.
 
 **Example**
 
-- **Parameter:** [`kafka_mirrormaker.emit_checkpoints_enabled`](https://aiven.io/docs/products/kafka/kafka-mirrormaker/reference/advanced-params#kafka_mirrormaker_emit_checkpoints_enabled)
+- **Parameter:** [`kafka_mirrormaker.emit_checkpoints_enabled`](/docs/products/kafka/kafka-mirrormaker/reference/advanced-params#kafka_mirrormaker_emit_checkpoints_enabled)
 - **Description:** Enables or disables periodic emission of consumer group offset
-  checkpoints to the target cluster
+  checkpoints to the target cluster.
 - **Impact:**
   - Restarts workers
   - Restarts all connectors and tasks
@@ -36,7 +37,7 @@ Checkpoint, and Heartbeat connectors.
 
 - **Parameter:** [`topics`](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/mirrormaker_replication_flow)
 - **Description:** Specifies a list of topics or regular expressions to replicate.
-  For details, see
+  For more information, see
   [Topics included in a replication flow](/docs/products/kafka/kafka-mirrormaker/concepts/replication-flow-topics-regex).
 - **Impact:**
   - Restarts the affected connectors
@@ -49,7 +50,7 @@ Integration configurations refine how producers and consumers behave within conn
 **Example**
 
 - **Parameter:** [`consumer_fetch_min_bytes`](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/service_integration#nested-schema-for-kafka_mirrormaker_user_configkafka_mirrormaker)
-- **Description:** Sets the minimum amount of data the server returns for a fetch request
+- **Description:** Sets the minimum amount of data the server returns for a fetch request.
 - **Impact:**
   - Restarts workers
   - Restarts all connectors and tasks
@@ -59,44 +60,57 @@ Many configuration parameters originate from
 [KIP-382: MirrorMaker 2.0 configuration properties](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=95650722#KIP382:MirrorMaker2.0-ConnectorConfigurationProperties).
 :::
 
-## Common parameters
+## Common performance-related parameters
 
-Use these commonly adjusted parameters to improve replication performance and consistency.
+Some configuration parameters are commonly adjusted to improve replication throughput,
+consistency, or topic selection. The configuration layer determines where the parameter
+is set and what restarts when the value changes.
 
-### Optimize task allocation
+### Task allocation
 
-Increase the value of
+Increasing the value of
 [`kafka_mirrormaker.tasks_max_per_cpu`](/docs/products/kafka/kafka-mirrormaker/reference/advanced-params#kafka_mirrormaker_tasks_max_per_cpu)
-in the advanced configuration.
+in the advanced configuration can improve throughput. Set this value close to the
+number of partitions when you need more parallelism.
 
-Setting this value close to the number of partitions can improve throughput.
+### Interval settings
 
-### Align interval settings
-
-Align interval-based settings to keep replication activity consistent.
+Aligning interval-based settings keeps replication activity consistent.
 
 - **Advanced configurations:**
   - [`kafka_mirrormaker.emit_checkpoints_interval_seconds`](/docs/products/kafka/kafka-mirrormaker/reference/advanced-params#kafka_mirrormaker_emit_checkpoints_interval_seconds)
   - [`kafka_mirrormaker.sync_group_offsets_interval_seconds`](/docs/products/kafka/kafka-mirrormaker/reference/advanced-params#kafka_mirrormaker_sync_group_offsets_interval_seconds)
 - **Replication flow:**
-  - Sync interval in seconds
+  - [`sync_group_offsets_interval_seconds`](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/mirrormaker_replication_flow#sync_group_offsets_interval_seconds-1)
 
-### Exclude internal topics
+### Topic exclusion
 
-Add these patterns to the topic blacklist to avoid replicating internal or system topics:
+Adding these patterns to the topic exclusion list prevents internal and system topics from
+being replicated:
 
 - `.*[\-\.]internal`
 - `.*\.replica`
 - `__.*`
 - `connect.*`
 
-### Adjust integration parameters
+### Producer and consumer settings
 
-Tune these integration parameters based on your workload to optimize producer and
-consumer behavior:
+These [integration configuration](#integration-configurations) parameters control how
+MirrorMaker 2 producers and consumers communicate with the source and target Kafka
+clusters. Set them on the service integration resource. If you do not set a parameter,
+Kafka applies its built-in default. These settings apply to MirrorMaker 2 integrations
+with both Aiven for Apache Kafka services and external Kafka clusters.
 
-- `consumer_fetch_min_bytes`
-- `producer_batch_size`
-- `producer_buffer_memory`
-- `producer_linger_ms`
-- `producer_max_request_size`
+| Parameter | Description | Maximum value |
+|-----------|-------------|---------------|
+| `consumer_fetch_min_bytes` | Minimum amount of data the server returns for a fetch request. Higher values reduce fetch frequency. | — |
+| `consumer_fetch_max_bytes` | Maximum amount of data the server returns for a fetch request. | 100 MiB |
+| `consumer_max_partition_fetch_bytes` | Maximum amount of data per partition the server returns in a single fetch response. | 100 MiB |
+| `consumer_receive_buffer_bytes` | Size of the TCP receive buffer for the consumer. A value of `-1` uses the OS default. | 100 MiB |
+| `consumer_request_timeout_ms` | Timeout for consumer requests to the broker, in milliseconds. | 600,000 ms (10 minutes) |
+| `producer_batch_size` | Maximum size of a record batch sent to a single partition, in bytes. | — |
+| `producer_buffer_memory` | Total memory available to the producer for buffering records, in bytes. | — |
+| `producer_linger_ms` | Time the producer waits for additional records before sending a batch, in milliseconds. | — |
+| `producer_max_request_size` | Maximum size of a single producer request, in bytes. | — |
+| `producer_request_timeout_ms` | Timeout for producer requests to the broker, in milliseconds. | 600,000 ms (10 minutes) |
+| `producer_send_buffer_bytes` | Size of the TCP send buffer for the producer, in bytes. A value of `-1` uses the OS default. | 100 MiB |

--- a/docs/products/kafka/kafka-mirrormaker/howto/update-integration-configurations.md
+++ b/docs/products/kafka/kafka-mirrormaker/howto/update-integration-configurations.md
@@ -60,8 +60,8 @@ to update producer and consumer settings on a MirrorMaker 2 integration.
    ```bash
    avn service integration-update SERVICE_INTEGRATION_ID \
      --project PROJECT_NAME \
-     -c consumer_fetch_min_bytes=1024 \
-     -c producer_linger_ms=100
+     -c kafka_mirrormaker.consumer_fetch_min_bytes=1024 \
+     -c kafka_mirrormaker.producer_linger_ms=100
    ```
 
 Parameters:
@@ -150,15 +150,45 @@ Check that the updated values are applied.
 <Tabs groupId="update-method">
 <TabItem value="cli" label="Aiven CLI" default>
 
-1. Retrieve the MirrorMaker 2 service configuration:
+1. List each `kafka_mirrormaker` integration and its `user_config`:
 
    ```bash
    avn service get MIRRORMAKER_SERVICE_NAME \
-     --project PROJECT_NAME --json
+     --project PROJECT_NAME --json | \
+     jq '[.service_integrations[] | select(.integration_type == "kafka_mirrormaker") | {service_integration_id, user_config}]'
    ```
 
-1. In the output, under `service_integrations`, find the `kafka_mirrormaker` integration
-   and confirm that the `user_config` values match your update.
+   Example output:
+
+   ```json
+   [
+     {
+       "service_integration_id": "1c2c30f8-413b-4c7c-b393-97165d875952",
+       "user_config": {
+         "cluster_alias": "my-kafka-endpoint-sasl"
+       }
+     },
+     {
+       "service_integration_id": "57042a2e-aae3-4be3-bcfc-e2c1294b1af3",
+       "user_config": {
+         "cluster_alias": "my-kafka"
+       }
+     },
+     {
+       "service_integration_id": "a89ca005-e9f1-46a9-9ffb-9f85c517323a",
+       "user_config": {
+         "cluster_alias": "my-kafka-endpoint-ssl",
+         "kafka_mirrormaker": {
+           "consumer_fetch_min_bytes": 1024,
+           "producer_linger_ms": 100
+         }
+       }
+     }
+   ]
+   ```
+
+1. Find the `service_integration_id` you updated and confirm that the
+   `kafka_mirrormaker` block under `user_config` contains your updated values.
 
 </TabItem>
 <TabItem value="terraform" label="Terraform">

--- a/docs/products/kafka/kafka-mirrormaker/howto/update-integration-configurations.md
+++ b/docs/products/kafka/kafka-mirrormaker/howto/update-integration-configurations.md
@@ -37,7 +37,7 @@ Kafka® service or to an external Kafka cluster through an integration endpoint.
 <Tabs groupId="update-method">
 <TabItem value="cli" label="Aiven CLI" default>
 
-Use [`avn service integration-update`](/docs/tools/cli/service/integration#avn-service-integration-update)
+Use [`avn service integration-update`](/docs/tools/cli/service/integration#avn_service_integration_update)
 to update producer and consumer settings on a MirrorMaker 2 integration.
 
 1. List the service integrations for the MirrorMaker 2 service:

--- a/docs/products/kafka/kafka-mirrormaker/howto/update-integration-configurations.md
+++ b/docs/products/kafka/kafka-mirrormaker/howto/update-integration-configurations.md
@@ -1,0 +1,188 @@
+---
+title: Update integration configurations for Aiven for Apache Kafka® MirrorMaker 2
+sidebar_label: Update integration configurations
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Update the producer and consumer settings on a MirrorMaker 2 service integration to control how MirrorMaker 2 communicates with the source and target Kafka clusters.
+
+Integration configurations are set on the service integration resource. For more
+information about available parameters and restart impact, see
+[Configuration and tuning for Aiven for Apache Kafka® MirrorMaker 2](/docs/products/kafka/kafka-mirrormaker/concepts/configuration-layers).
+
+:::note
+Integration configurations are not available in the Aiven Console. Use the Aiven CLI,
+Aiven API, or Aiven Provider for Terraform to update them.
+:::
+
+## Prerequisites
+
+- An Aiven for Apache Kafka® MirrorMaker 2 service.
+- An existing integration between the MirrorMaker 2 service and a source or target Kafka
+  cluster.
+- Access to one of the following:
+  - [Aiven CLI](/docs/tools/cli)
+  - [Aiven API](https://api.aiven.io/)
+  - [Aiven Provider for Terraform](https://registry.terraform.io/providers/aiven/aiven/latest/docs)
+
+## Update integration configurations
+
+Producer and consumer settings are stored on each `kafka_mirrormaker` service
+integration, whether that integration connects MirrorMaker 2 to an Aiven for Apache
+Kafka® service or to an external Kafka cluster through an integration endpoint.
+
+<Tabs groupId="update-method">
+<TabItem value="cli" label="Aiven CLI" default>
+
+Use [`avn service integration-update`](/docs/tools/cli/service/integration#avn-service-integration-update)
+to update producer and consumer settings on a MirrorMaker 2 integration.
+
+1. List the service integrations for the MirrorMaker 2 service:
+
+   ```bash
+   avn service integration-list MIRRORMAKER_SERVICE_NAME \
+     --project PROJECT_NAME
+   ```
+
+1. Copy the service integration ID for the `kafka_mirrormaker` integration that connects
+   MirrorMaker 2 to the source or target cluster you want to configure.
+
+1. Update the integration configuration.
+
+   To update settings, use `-c KEY=VALUE` for individual parameters or
+   `--user-config-json` for a JSON payload. Pass multiple `-c` options to update
+   several settings at once. Do not use `-c` and `--user-config-json` in the same
+   command.
+
+   ```bash
+   avn service integration-update SERVICE_INTEGRATION_ID \
+     --project PROJECT_NAME \
+     -c consumer_fetch_min_bytes=1024 \
+     -c producer_linger_ms=100
+   ```
+
+Parameters:
+
+- `PROJECT_NAME`: Your Aiven project name
+- `MIRRORMAKER_SERVICE_NAME`: Your Aiven for Apache Kafka MirrorMaker 2 service name
+- `SERVICE_INTEGRATION_ID`: The `kafka_mirrormaker` service integration ID
+
+</TabItem>
+<TabItem value="terraform" label="Terraform">
+
+1. Update the `kafka_mirrormaker_user_config` block in your
+   [`aiven_service_integration`](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/service_integration)
+   resource:
+
+   ```hcl
+   resource "aiven_service_integration" "mirrormaker" {
+     project                  = "PROJECT_NAME"
+     integration_type         = "kafka_mirrormaker"
+     source_service_name      = "KAFKA_SERVICE_NAME"
+     destination_service_name = "MIRRORMAKER_SERVICE_NAME"
+
+     kafka_mirrormaker_user_config {
+       kafka_mirrormaker {
+         consumer_fetch_min_bytes = 1024
+         producer_linger_ms       = 100
+       }
+     }
+   }
+   ```
+
+   Parameters:
+
+   - `PROJECT_NAME`: Your Aiven project name
+   - `KAFKA_SERVICE_NAME`: The Aiven for Apache Kafka® service connected to MirrorMaker 2.
+     For an external Kafka cluster, use `source_endpoint_id` instead of `source_service_name`.
+   - `MIRRORMAKER_SERVICE_NAME`: Your Aiven for Apache Kafka MirrorMaker 2 service name
+
+1. Run `terraform plan` and `terraform apply` to apply the changes.
+
+</TabItem>
+<TabItem value="api" label="Aiven API">
+
+1. List the service integrations for the MirrorMaker 2 service using the
+   [ServiceIntegrationList](https://api.aiven.io/doc/#tag/Service_Integrations/operation/ServiceIntegrationList)
+   endpoint and copy the `service_integration_id` for the `kafka_mirrormaker`
+   integration.
+
+1. Call the
+   [ServiceIntegrationUpdate](https://api.aiven.io/doc/#tag/Service_Integrations/operation/ServiceIntegrationUpdate)
+   endpoint to update the integration configuration:
+
+   ```bash
+   curl --request PUT \
+     --url https://api.aiven.io/v1/project/PROJECT_NAME/integration/INTEGRATION_ID \
+     --header "Authorization: Bearer API_TOKEN" \
+     --header "Content-Type: application/json" \
+     --data-raw '{
+     "user_config": {
+       "kafka_mirrormaker": {
+         "consumer_fetch_min_bytes": 1024,
+         "producer_linger_ms": 100
+       }
+     }
+   }'
+   ```
+
+   Parameters:
+
+   - `PROJECT_NAME`: Your Aiven project name
+   - `INTEGRATION_ID`: The service integration ID
+   - `API_TOKEN`: Your [personal token](/docs/platform/howto/create_authentication_token)
+
+   For the full request schema and supported parameters, see the
+   [Aiven API reference](https://api.aiven.io/doc/#tag/Service_Integrations/operation/ServiceIntegrationUpdate)
+   and the
+   [`kafka_mirrormaker_user_config` Terraform schema](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/service_integration#nested-schema-for-kafka_mirrormaker_user_configkafka_mirrormaker).
+
+</TabItem>
+</Tabs>
+
+## Verify the configuration
+
+Check that the updated values are applied.
+
+<Tabs groupId="update-method">
+<TabItem value="cli" label="Aiven CLI" default>
+
+1. Retrieve the MirrorMaker 2 service configuration:
+
+   ```bash
+   avn service get MIRRORMAKER_SERVICE_NAME \
+     --project PROJECT_NAME --json
+   ```
+
+1. In the output, under `service_integrations`, find the `kafka_mirrormaker` integration
+   and confirm that the `user_config` values match your update.
+
+</TabItem>
+<TabItem value="terraform" label="Terraform">
+
+Run `terraform plan` and confirm that Terraform reports no changes:
+
+```bash
+terraform plan
+```
+
+</TabItem>
+<TabItem value="api" label="Aiven API">
+
+Use the
+[ServiceIntegrationGet](https://api.aiven.io/doc/#tag/Service_Integrations/operation/ServiceIntegrationGet)
+endpoint to retrieve the service integration and confirm that the updated values are
+applied.
+
+</TabItem>
+</Tabs>
+
+<RelatedPages/>
+
+- [Configuration and tuning for Aiven for Apache Kafka® MirrorMaker 2](/docs/products/kafka/kafka-mirrormaker/concepts/configuration-layers)
+- [Producer and consumer settings](/docs/products/kafka/kafka-mirrormaker/concepts/configuration-layers#producer-and-consumer-settings)
+- [Aiven CLI service integration commands](/docs/tools/cli/service/integration)
+- [`aiven_service_integration` Terraform resource](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/service_integration)

--- a/docs/products/kafka/kafka-mirrormaker/howto/update-integration-configurations.md
+++ b/docs/products/kafka/kafka-mirrormaker/howto/update-integration-configurations.md
@@ -31,8 +31,9 @@ Aiven API, or Aiven Provider for Terraform to update them.
 ## Update integration configurations
 
 Producer and consumer settings are stored on each `kafka_mirrormaker` service
-integration, whether that integration connects MirrorMaker 2 to an Aiven for Apache
-Kafka® service or to an external Kafka cluster through an integration endpoint.
+integration. This applies whether the integration connects MirrorMaker 2 to an
+Aiven for Apache Kafka® service or to an external Kafka cluster through an
+integration endpoint.
 
 <Tabs groupId="update-method">
 <TabItem value="cli" label="Aiven CLI" default>

--- a/docs/products/kafka/kafka-mirrormaker/reference/known-issues.md
+++ b/docs/products/kafka/kafka-mirrormaker/reference/known-issues.md
@@ -6,7 +6,7 @@ title: Known issues
 
 The following are known issues that are expected to be resolved in
 version 3.3.0. See
-[recommended tuning parameters](/docs/products/kafka/kafka-mirrormaker/concepts/mirrormaker2-tuning) to mitigate the impact of these issues.
+[recommended tuning parameters](/docs/products/kafka/kafka-mirrormaker/concepts/configuration-layers) to mitigate the impact of these issues.
 
 -   **MirrorMaker 2 offset sync is incorrect if the target partition is
     empty**: [https://issues.apache.org/jira/browse/KAFKA-12635](https://issues.apache.org/jira/browse/KAFKA-12635)

--- a/docs/products/opensearch/howto/opensearch-log-integration.md
+++ b/docs/products/opensearch/howto/opensearch-log-integration.md
@@ -343,7 +343,7 @@ You can change the configuration of the `index prefix` and
    in columns `SOURCE` and `DEST`.
 
 1. Use the
-   [avn service integration-update](/docs/tools/cli/service/integration#avn%20service%20integration-update)
+   [avn service integration-update](/docs/tools/cli/service/integration#avn_service_integration_update)
    command to update the log integration configuration:
 
    ```bash {3-4}

--- a/docs/tools/cli/service/integration.md
+++ b/docs/tools/cli/service/integration.md
@@ -238,7 +238,7 @@ schema_registry_proxy            Proxy Schema Registry requests                 
 signalfx                         Receive service metrics from service                                  signalfx                         Send service metrics to SignalFX                            kafka
 ```
 
-### `avn service integration-update` {#avn service integration-update}
+### `avn service integration-update` {#avn_service_integration_update}
 
 Updates an existing service integration.
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1076,7 +1076,7 @@ const sidebars: SidebarsConfig = {
                       ],
                     },
                     'products/kafka/kafka-mirrormaker/concepts/replication-flow-topics-regex',
-                    'products/kafka/kafka-mirrormaker/concepts/mirrormaker2-tuning',
+                    'products/kafka/kafka-mirrormaker/concepts/configuration-layers',
                     'products/kafka/kafka-mirrormaker/concepts/permissions-internal-topics',
                   ],
                 },
@@ -1085,6 +1085,7 @@ const sidebars: SidebarsConfig = {
                   label: 'How to',
                   items: [
                     'products/kafka/kafka-mirrormaker/howto/setup-replication-flow',
+                    'products/kafka/kafka-mirrormaker/howto/update-integration-configurations',
                     'products/kafka/kafka-mirrormaker/howto/monitor-replication-execution',
                     'products/kafka/kafka-mirrormaker/howto/remove-mirrormaker-prefix',
                     'products/kafka/kafka-mirrormaker/howto/datadog-customised-metrics',

--- a/static/_redirects
+++ b/static/_redirects
@@ -229,6 +229,7 @@
 /products/kafka/kafka-mirrormaker/concepts                 /docs/products/kafka/kafka-mirrormaker/concepts/disaster-recovery-migration  301
 /products/kafka/kafka-mirrormaker/howto/integrate-external-kafka-cluster   /docs/products/kafka/howto/integrate-external-kafka-cluster  301
 /products/kafka/kafka-mirrormaker/howto/setup-mirrormaker-monitoring   /docs/products/kafka/kafka-mirrormaker/howto/setup-replication-flow  301
+/products/kafka/kafka-mirrormaker/concepts/mirrormaker2-tuning         /docs/products/kafka/kafka-mirrormaker/concepts/configuration-layers  301
 /products/kafka/kafka-mirrormaker/reference                            /docs/products/kafka/kafka-mirrormaker/reference/advanced-params  301
 /products/kafka/karapace/concepts                                      /docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins  301
 /products/kafka/karapace/howto                                         /docs/products/kafka/karapace/howto/enable-karapace  301


### PR DESCRIPTION
## Describe your changes

Documents 6 new Kafka client settings added to the `kafka_mirrormaker` integration user configs in KCON-431:

- `consumer.fetch.max.bytes`
- `consumer.max.partition.fetch.bytes`
- `consumer.receive.buffer.bytes`
- `consumer.request.timeout.ms`
- `producer.request.timeout.ms`
- `producer.send.buffer.bytes`

Also updates the page structure, headings, and wording to align with the Google style guide.

https://aiven.atlassian.net/browse/KCON-436

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
