### PR TITLE
feat: integrate posthog with docs

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -156,6 +156,19 @@ const config: Config = {
     './src/plugins/svg-fix/index.ts',
     'docusaurus-plugin-image-zoom',
     [
+      'posthog-docusaurus',
+      {
+        apiKey: process.env.POSTHOG_PUBLIC_KEY,
+        appUrl: 'https://eu.i.posthog.com',
+        autocapture: false,
+        capture_pageview: false,
+        capture_pageleave: false,
+        capture_heatmaps: false,
+        disable_session_recording: true,
+        opt_out_capturing_by_default: true,
+      },
+    ],
+    [
       '@signalwire/docusaurus-plugin-llms-txt',
       {
         siteTitle: 'Aiven docs',
@@ -309,6 +322,9 @@ const config: Config = {
             {
               label: 'Security',
               href: 'https://aiven.io/security-compliance',
+            },
+            {
+              html: '<button type="button" class="optanon-toggle-display footer__link-item" aria-label="Click here to change cookie settings" style="background:none;border:0;padding:0;color:inherit;font:inherit;cursor:pointer;text-align:left;">Cookie settings</button>',
             },
           ],
         },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "handlebars": "^4.7.9",
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1",
+    "posthog-docusaurus": "^2.0.5",
     "prism-react-renderer": "^2.4.1",
     "raw-loader": "^4.0.2",
     "react": "^18.0.0",

--- a/static/page_scripts/onetrust.js
+++ b/static/page_scripts/onetrust.js
@@ -11,4 +11,5 @@ function OptanonWrapper() {
     // enable fully anonymous tracking
     snowplow('clearUserData', {preserveSession: true});
   }
+  window.dispatchEvent(new Event('OneTrustGroupsUpdated'));
 }

--- a/static/page_scripts/tracking.ts
+++ b/static/page_scripts/tracking.ts
@@ -3,7 +3,31 @@ import type {ClientModule} from '@docusaurus/types';
 declare global {
   interface Window {
     snowplow: (arg: string) => void;
+    posthog?: {
+      startSessionRecording: (opts?: {sampling: boolean}) => void;
+      stopSessionRecording: () => void;
+      opt_in_capturing: () => void;
+      opt_out_capturing: () => void;
+    };
+    OnetrustActiveGroups?: string;
   }
+}
+
+function applyPosthogConsent() {
+  if (!window.posthog) return;
+  const groups = window.OnetrustActiveGroups || '';
+  if (groups.includes('115')) {
+    window.posthog.opt_in_capturing();
+    window.posthog.startSessionRecording({sampling: false});
+  } else {
+    window.posthog.opt_out_capturing();
+    window.posthog.stopSessionRecording();
+  }
+}
+
+if (typeof window !== 'undefined') {
+  applyPosthogConsent();
+  window.addEventListener('OneTrustGroupsUpdated', applyPosthogConsent);
 }
 
 const module: ClientModule = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7201,6 +7201,7 @@ __metadata:
     handlebars: "npm:^4.7.9"
     lodash: "npm:^4.18.1"
     lodash-es: "npm:^4.18.1"
+    posthog-docusaurus: "npm:^2.0.5"
     prism-react-renderer: "npm:^2.4.1"
     raw-loader: "npm:^4.0.2"
     react: "npm:^18.0.0"
@@ -14787,6 +14788,13 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/48138207cf5ef5581be1bfe2cb65ccfe0ac75e43888ba045afc8ed6043d7b56aeb3b9a9fe5b353ff554be943cd0cc15d826ccb991525159175971e5ee8ab0237
+  languageName: node
+  linkType: hard
+
+"posthog-docusaurus@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "posthog-docusaurus@npm:2.0.5"
+  checksum: 10c0/280bf8762cde093faaf8f7d195fcb8d767dbb88fe8813f552f044fb58e0b78758ee9fb058af2f7d004654554c3e0b3899e5aef5e932abb7f75edeabc40267242
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Integrate Posthog with Docs:

  - Integrate PostHog event tracking and session replay into the docs site, gated by OneTrust cookie consent.
  - Tracking is disabled by default and only enabled if the user accepts cookies via OneTrust group 115 (UX/Functional cookies).
  - Add a "Cookie settings" link in the footer so users can revisit their consent choices (matches the marketing site).
