### PR TITLE
fix: ignore failing localized sitemap URLs in link checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,11 @@ cloud-list:
 delete-unused-images:
 	node "$(SCRIPTS)/delete_unused_images.js"
 
+# Ignore localized sitemap URLs that can fail independently of docs content.
 check-links:
-	docker run --rm ghcr.io/linkchecker/linkchecker:latest  -r 1 --no-warnings --check-extern https://aiven.io/docs/sitemap.xml
+	docker run --rm ghcr.io/linkchecker/linkchecker:latest \
+		-r 1 \
+		--no-warnings \
+		--check-extern \
+		--ignore-url='^https://aiven\.io/(fr|de)/sitemap\.xml$$' \
+		https://aiven.io/docs/sitemap.xml


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
