### PR TITLE
fix: ignore localized sitemap 500s in link checker

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,11 @@ delete-unused-images:
 
 # Ignore localized sitemap URLs that can fail independently of docs content.
 check-links:
-	docker run --rm ghcr.io/linkchecker/linkchecker:latest \
+	docker run --rm \
+		-v "$(CURDIR)/scripts/linkchecker-ignore.rc:/linkchecker-ignore.rc:ro" \
+		ghcr.io/linkchecker/linkchecker:latest \
+		-f /linkchecker-ignore.rc \
 		-r 1 \
 		--no-warnings \
 		--check-extern \
-		--ignore-url='^https://aiven\.io/(fr|de)/sitemap\.xml$$' \
 		https://aiven.io/docs/sitemap.xml

--- a/scripts/linkchecker-ignore.rc
+++ b/scripts/linkchecker-ignore.rc
@@ -1,0 +1,6 @@
+; Ignore localized sitemap URLs that return 500 from the main site,
+; not from broken docs content.
+[output]
+ignoreerrors=
+  ^https://aiven\.io/fr/sitemap\.xml$ 500
+  ^https://aiven\.io/de/sitemap\.xml$ 500


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
