### PR TITLE
feat: Query Kafka topic data in ClickHouse

### DIFF
--- a/docs/products/clickhouse/concepts/query-kafka-topic-data.md
+++ b/docs/products/clickhouse/concepts/query-kafka-topic-data.md
@@ -1,0 +1,82 @@
+---
+title: Query Kafka topic data in Aiven for ClickHouse®
+sidebar_label: Query Kafka topic data
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Query Kafka topic data in Aiven for ClickHouse® by connecting an Aiven for Apache Kafka® topic.
+Analyze live or historical event data with SQL without manually creating a Kafka engine
+table, materialized view, or destination ClickHouse table.
+
+To set up the integration in the Aiven Console, see
+[Set up Kafka topic querying in Aiven for ClickHouse®](/docs/products/clickhouse/howto/set-up-kafka-topic-querying).
+
+## When to use it
+
+Query Kafka topic data when you want to:
+
+- Run SQL queries against live or historical event data from a Kafka topic.
+- Build dashboards from Kafka topic data.
+- Store event data in ClickHouse for analytics or reporting.
+- Replace a manually configured Kafka-to-ClickHouse ingestion setup with a managed setup.
+
+## How it works
+
+When you connect Kafka topic data to ClickHouse, Aiven creates a managed integration
+between the Kafka service and the ClickHouse service. The setup uses the selected Kafka
+topic as the source and a destination MergeTree table in ClickHouse.
+
+Automated schema mapping requires Avro messages and Aiven for Apache Kafka® Schema
+Registry. Aiven reads the schema from Schema Registry using the topic name strategy and
+maps the fields to ClickHouse column types.
+
+During setup, you can review and edit the suggested schema and table configuration before
+deployment. If Aiven cannot find a compatible schema, define the ClickHouse table columns
+manually.
+
+You can start the setup from the Aiven Console. The available entry points can vary
+depending on your service configuration.
+
+## Ingestion and the Kafka table engine
+
+Kafka topic data ingestion uses the ClickHouse Kafka table engine, which is also used in
+[manual Kafka integration](/docs/products/clickhouse/howto/integrate-kafka).
+
+Aiven creates and manages the Kafka engine table, materialized view, and destination
+MergeTree table. You query the MergeTree table in ClickHouse and do not need to create
+the ingestion pipeline manually.
+
+## Choose where ingestion starts
+
+During setup, you can choose whether ingestion starts from new messages only or from an
+earlier point in the topic, when available.
+
+If you start from new messages only, Aiven ingests messages produced after you deploy the
+setup.
+
+If you start from an earlier point, Aiven includes existing topic data based on the
+selected start point.
+
+## Limitations
+
+- The Kafka service and the ClickHouse service must be in the same cloud region.
+- If data does not appear in the destination table after deployment, check the ClickHouse
+  service logs for ingestion errors.
+- Failed messages are not sent to a separate dead letter queue.
+- You cannot change some table settings, such as the sorting key, after table creation.
+- Automated schema mapping requires Avro messages and Aiven for Apache Kafka® Schema
+  Registry using the topic name strategy. Without a compatible schema, define ClickHouse
+  columns manually or use
+  [manual Kafka integration](/docs/products/clickhouse/howto/integrate-kafka).
+- Automatic schema evolution is not supported. If the Kafka topic schema changes, the
+  ClickHouse resources might need to be updated manually or the integration might need to
+  be recreated. New Avro fields are ignored unless matching columns are added to the
+  ClickHouse table. Removed or incompatible fields can cause ingestion errors.
+- High-throughput topics can generate additional network transfer costs if the Kafka and
+  ClickHouse services run in different availability zones.
+
+<RelatedPages/>
+
+- [Set up Kafka topic querying in Aiven for ClickHouse®](/docs/products/clickhouse/howto/set-up-kafka-topic-querying)
+- [Connect Apache Kafka® to Aiven for ClickHouse®](/docs/products/clickhouse/howto/integrate-kafka)

--- a/docs/products/clickhouse/concepts/query-kafka-topic-data.md
+++ b/docs/products/clickhouse/concepts/query-kafka-topic-data.md
@@ -69,7 +69,8 @@ event analysis, historical reporting, and high-volume log or metrics analysis.
 
 ## Limitations
 
-- The Kafka service and the ClickHouse service must be in the same cloud region.
+- The Kafka service and the ClickHouse service must be in the same cloud region to
+  reduce network latency and data transfer costs.
 - If data does not appear in the destination table after deployment, check the ClickHouse
   service logs for ingestion errors.
 - Failed messages are not sent to a separate dead letter queue.

--- a/docs/products/clickhouse/concepts/query-kafka-topic-data.md
+++ b/docs/products/clickhouse/concepts/query-kafka-topic-data.md
@@ -5,9 +5,10 @@ sidebar_label: Query Kafka topic data
 
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Query Kafka topic data in Aiven for ClickHouse® by connecting an Aiven for Apache Kafka® topic.
-Analyze live or historical event data with SQL without manually creating a Kafka engine
-table, materialized view, or destination ClickHouse table.
+Query Kafka topic data in Aiven for ClickHouse® by connecting an Aiven for Apache Kafka® topic to a ClickHouse table.
+Use this managed setup to store Kafka topic data in ClickHouse and analyze live or
+historical event data with SQL, without manually creating a Kafka engine table,
+materialized view, or destination ClickHouse table.
 
 To set up the integration in the Aiven Console, see
 [Set up Kafka topic querying in Aiven for ClickHouse®](/docs/products/clickhouse/howto/set-up-kafka-topic-querying).
@@ -16,47 +17,55 @@ To set up the integration in the Aiven Console, see
 
 Query Kafka topic data when you want to:
 
-- Run SQL queries against live or historical event data from a Kafka topic.
-- Build dashboards from Kafka topic data.
-- Store event data in ClickHouse for analytics or reporting.
-- Replace a manually configured Kafka-to-ClickHouse ingestion setup with a managed setup.
+- Analyze live or historical Kafka topic data using SQL.
+- Build dashboards or reports from Kafka topic data stored in ClickHouse.
+- Reduce the manual setup required to ingest Kafka data into ClickHouse.
 
 ## How it works
 
-When you connect Kafka topic data to ClickHouse, Aiven creates a managed integration
-between the Kafka service and the ClickHouse service. The setup uses the selected Kafka
-topic as the source and a destination MergeTree table in ClickHouse.
+When you connect a Kafka topic to ClickHouse, Aiven creates a managed integration
+between the two services. The setup uses the selected Kafka topic as the source and
+writes the data to a destination ClickHouse table that uses the MergeTree engine.
 
-Automated schema mapping requires Avro messages and Aiven for Apache Kafka® Schema
-Registry. Aiven reads the schema from Schema Registry using the topic name strategy and
-maps the fields to ClickHouse column types.
+You can start the setup from a Kafka topic in the Aiven Console. During setup, select an
+existing ClickHouse service or create one, then review and edit the schema and table
+configuration before deployment.
 
-During setup, you can review and edit the suggested schema and table configuration before
-deployment. If Aiven cannot find a compatible schema, define the ClickHouse table columns
-manually.
+### Schema mapping
 
-You can start the setup from the Aiven Console. The available entry points can vary
-depending on your service configuration.
+Automated schema mapping is available for Avro messages with Aiven for Apache Kafka®
+Schema Registry. The schema must be registered using the topic name strategy, such as
+`<topic-name>-value`.
 
-## Ingestion and the Kafka table engine
+When a compatible Avro schema is available, Aiven maps the Avro fields to ClickHouse
+column types and shows them in the schema preview.
 
-Kafka topic data ingestion uses the ClickHouse Kafka table engine, which is also used in
-[manual Kafka integration](/docs/products/clickhouse/howto/integrate-kafka).
+Before deployment, you can review the mapped columns. If Aiven cannot find a compatible
+Avro schema, you can define the ClickHouse table columns during setup.
 
-Aiven creates and manages the Kafka engine table, materialized view, and destination
-MergeTree table. You query the MergeTree table in ClickHouse and do not need to create
-the ingestion pipeline manually.
+### Ingestion start point
 
-## Choose where ingestion starts
-
-During setup, you can choose whether ingestion starts from new messages only or from an
-earlier point in the topic, when available.
+During setup, choose whether ingestion starts from new messages only or from an earlier
+point in the topic, when available.
 
 If you start from new messages only, Aiven ingests messages produced after you deploy the
-setup.
+setup. If you start from an earlier point, Aiven includes existing topic data based on
+the selected start point.
 
-If you start from an earlier point, Aiven includes existing topic data based on the
-selected start point.
+### Managed ClickHouse resources
+
+Kafka topic data ingestion uses the ClickHouse Kafka table engine.
+
+Aiven creates and manages the Kafka engine table, materialized view, and destination
+ClickHouse table. This reduces the manual setup required to store Kafka topic data in
+ClickHouse. You query the destination table in ClickHouse and do not need to create the
+ingestion pipeline manually.
+
+## Query data in ClickHouse
+
+After the setup is deployed and data starts flowing, query the destination table using
+ClickHouse SQL. You can use the table for real-time analytics, operational dashboards,
+event analysis, historical reporting, and high-volume log or metrics analysis.
 
 ## Limitations
 
@@ -65,10 +74,10 @@ selected start point.
   service logs for ingestion errors.
 - Failed messages are not sent to a separate dead letter queue.
 - You cannot change some table settings, such as the sorting key, after table creation.
-- Automated schema mapping requires Avro messages and Aiven for Apache Kafka® Schema
-  Registry using the topic name strategy. Without a compatible schema, define ClickHouse
-  columns manually or use
-  [manual Kafka integration](/docs/products/clickhouse/howto/integrate-kafka).
+- Automated schema mapping is available only for Avro messages with Aiven for Apache
+  Kafka® Schema Registry when the schema is registered using the topic name strategy,
+  such as `<topic-name>-value`. Without a compatible Avro schema, define ClickHouse
+  columns during setup.
 - Automatic schema evolution is not supported. If the Kafka topic schema changes, the
   ClickHouse resources might need to be updated manually or the integration might need to
   be recreated. New Avro fields are ignored unless matching columns are added to the

--- a/docs/products/clickhouse/concepts/query-kafka-topic-data.md
+++ b/docs/products/clickhouse/concepts/query-kafka-topic-data.md
@@ -49,8 +49,8 @@ During setup, choose whether ingestion starts from new messages only or from an 
 point in the topic, when available.
 
 If you start from new messages only, Aiven ingests messages produced after you deploy the
-setup. If you start from an earlier point, Aiven includes existing topic data based on
-the selected start point.
+setup. If you start from an earlier point, Aiven includes existing topic data based on the
+start point you select.
 
 ### Managed ClickHouse resources
 
@@ -73,7 +73,9 @@ event analysis, historical reporting, and high-volume log or metrics analysis.
   reduce network latency and data transfer costs.
 - If data does not appear in the destination table after deployment, check the ClickHouse
   service logs for ingestion errors.
-- Failed messages are not sent to a separate dead letter queue.
+- Failed messages are not sent to a dead letter queue by default. To change this, set
+  `handle_error_mode` to `dead_letter_queue` in the Kafka engine advanced configuration. In
+  the Aiven Console, this setting is available under **Databases and tables**.
 - You cannot change some table settings, such as the sorting key, after table creation.
 - Automated schema mapping is available only for Avro messages with Aiven for Apache
   Kafka® Schema Registry when the schema is registered using the topic name strategy,
@@ -83,8 +85,8 @@ event analysis, historical reporting, and high-volume log or metrics analysis.
   ClickHouse resources might need to be updated manually or the integration might need to
   be recreated. New Avro fields are ignored unless matching columns are added to the
   ClickHouse table. Removed or incompatible fields can cause ingestion errors.
-- High-throughput topics can generate additional network transfer costs if the Kafka and
-  ClickHouse services run in different availability zones.
+- The integration is not available for free and developer tier Aiven for Apache Kafka®
+  services.
 
 <RelatedPages/>
 

--- a/docs/products/clickhouse/howto/set-up-kafka-topic-querying.md
+++ b/docs/products/clickhouse/howto/set-up-kafka-topic-querying.md
@@ -1,6 +1,6 @@
 ---
 title: Set up Kafka topic querying in Aiven for ClickHouse®
-sidebar_label: Set up querying
+sidebar_label: Set up Kafka topic querying
 description: Send data from an Aiven for Apache Kafka® topic to Aiven for ClickHouse® and query it with SQL.
 ---
 

--- a/docs/products/clickhouse/howto/set-up-kafka-topic-querying.md
+++ b/docs/products/clickhouse/howto/set-up-kafka-topic-querying.md
@@ -24,8 +24,8 @@ Before you begin, make sure you have:
 - An Aiven for ClickHouse® service in the same cloud region as the Kafka service, or
   permission to create one during setup.
 - [Karapace Schema Registry](/docs/products/kafka/karapace/howto/enable-karapace)
-  enabled, and Avro used for the topic schema and messages to auto-detect ClickHouse
-  columns.
+  is enabled, and Avro is used for the topic schema and messages to auto-detect
+  ClickHouse columns.
 
 :::note
 Query Kafka topic data is not available in every cloud and region. If **Query in ClickHouse**

--- a/docs/products/clickhouse/howto/set-up-kafka-topic-querying.md
+++ b/docs/products/clickhouse/howto/set-up-kafka-topic-querying.md
@@ -1,0 +1,148 @@
+---
+title: Set up Kafka topic querying in Aiven for ClickHouse®
+sidebar_label: Set up querying
+description: Send data from an Aiven for Apache Kafka® topic to Aiven for ClickHouse® and query it with SQL.
+---
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Send data from an Aiven for Apache Kafka® topic to Aiven for ClickHouse® and query it with SQL.
+
+Aiven creates a Kafka-to-ClickHouse integration for the selected topic and opens the
+ClickHouse query editor with a generated query.
+
+For more information about how the integration works, supported schemas, ingestion
+start points, schema changes, and limitations, see
+[Query Kafka topic data in Aiven for ClickHouse®](/docs/products/clickhouse/concepts/query-kafka-topic-data).
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+- An Aiven for Apache Kafka® service with at least one topic.
+- An Aiven for ClickHouse® service in the same cloud region as the Kafka service, or
+  permission to create one during setup.
+- [Karapace Schema Registry](/docs/products/kafka/karapace/howto/enable-karapace)
+  enabled, and Avro used for the topic schema and messages to auto-detect ClickHouse
+  columns.
+
+:::note
+Query Kafka topic data is not available in every cloud and region. If **Query in ClickHouse**
+does not appear on your topic, your Kafka service may be in an unsupported cloud or region.
+:::
+
+## Send topic data to ClickHouse
+
+### Step 1: Start from a Kafka topic
+
+1. In the [Aiven Console](https://console.aiven.io), select your Aiven for Apache Kafka®
+   service.
+1. Click <ConsoleLabel name="topics" />.
+1. Start the setup in one of the following ways:
+
+   - From the topic row, open the <ConsoleLabel name="actions" /> menu and click
+     <ConsoleLabel name="query in clickhouse" />.
+   - From the topic page, in **Analyze your data in minutes**, click
+     <ConsoleLabel name="query in clickhouse" />.
+
+### Step 2: Select a ClickHouse service
+
+Select the Aiven for ClickHouse® service that receives the topic data.
+
+To use an existing service:
+
+1. Select an Aiven for ClickHouse® service with the **Running** status.
+1. Click **Continue**.
+
+To create a service during setup:
+
+1. Select **Create ClickHouse service**.
+1. Enter a service name.
+1. Select a service plan.
+1. Click **Create**.
+
+If you need more configuration options, click **Go to the full service creation**.
+
+### Step 3: Configure the ClickHouse table
+
+1. Select where ingestion starts in the Kafka topic.
+
+   You can send all messages from the first offset, only new messages, or messages from
+   a recent time range. The available options depend on your topic and service
+   configuration.
+
+1. Configure the table schema:
+
+   - **If the Console detects a schema:** Review the schema preview. The Console maps the
+     schema fields to suggested ClickHouse column names and data types.
+
+   - **If the Console does not detect a schema:** Add the ClickHouse columns manually.
+     Enter each column name, select the ClickHouse data type, and set **Nullable** as
+     needed.
+
+1. Optional: If Aiven suggested a schema, enable **Override column definitions** and
+   update the columns.
+
+1. In **Order by**, select the column used to sort the ClickHouse table.
+
+   :::important
+   You cannot change the **Order by** column after the table is created.
+   :::
+
+1. Optional: Expand **Advanced configuration** and review the generated settings.
+
+   You can review or update settings such as the table name, consumer group name, view
+   name, TTL, TTL column, and local disk TTL.
+
+1. Click **Deploy**.
+
+### Step 4: Query the ClickHouse table
+
+1. Wait until deployment completes.
+
+   Aiven creates the Kafka-to-ClickHouse integration and the required ClickHouse
+   resources. The setup page may show a preview of ingested rows when data starts
+   flowing.
+
+1. Click **Query in ClickHouse**.
+
+   The ClickHouse <ConsoleLabel name="queryeditor" /> opens with a generated `SELECT`
+   query for the table created during setup.
+
+1. Review the generated SQL query.
+1. Click **Execute**.
+1. View the integration on the <ConsoleLabel name="integrations" /> page of either the
+   Kafka service or the ClickHouse service.
+
+## Troubleshoot
+
+### ClickHouse service not visible
+
+If you do not see the ClickHouse service you expect, ensure:
+
+- The ClickHouse service has the **Running** status.
+- The ClickHouse service is in the same cloud region as the Kafka service.
+- You have access to the ClickHouse service.
+- ClickHouse is available for the Kafka service cloud and region.
+
+If ClickHouse is not available for the Kafka service cloud or region, migrate the Kafka
+service to a supported cloud or region.
+
+### Data not appearing after deployment
+
+If data does not appear in the ClickHouse table after deployment, check the logs for
+the Aiven for ClickHouse® service. Ingestion errors are reported on the ClickHouse side.
+
+Also ensure the selected ingestion start point includes messages from the topic. For
+example, if you selected **New messages only**, only messages produced after the
+integration was created are sent to ClickHouse.
+
+For more information about ingestion behavior and limitations, see
+[Limitations](/docs/products/clickhouse/concepts/query-kafka-topic-data#limitations).
+
+<RelatedPages/>
+
+- [Query Kafka topic data in Aiven for ClickHouse®](/docs/products/clickhouse/concepts/query-kafka-topic-data)
+- [Connect Apache Kafka® to Aiven for ClickHouse®](/docs/products/clickhouse/howto/integrate-kafka)
+- [Set up Aiven for ClickHouse® data service integrations](/docs/products/clickhouse/howto/data-service-integration)

--- a/docs/products/kafka/howto/create-topic.md
+++ b/docs/products/kafka/howto/create-topic.md
@@ -128,6 +128,13 @@ between classic and diskless topics.
 After creation, the topic appears on the <ConsoleLabel name="topics" /> page.
 The **Topic type** column shows **Classic** or **Diskless**.
 
+:::tip
+Analyze your topic data with SQL by sending it to Aiven for ClickHouse®. From the topic's
+<ConsoleLabel name="actions" /> menu, click **Query in ClickHouse** to set up a managed
+integration. See
+[Query Kafka topic data in Aiven for ClickHouse®](/docs/products/clickhouse/concepts/query-kafka-topic-data).
+:::
+
 </TabItem>
 
 <TabItem value="cli" label="CLI">
@@ -211,3 +218,4 @@ with [`aiven_kafka_topic`](https://registry.terraform.io/providers/aiven/aiven/l
 - [Compare diskless and classic topics](/docs/products/kafka/diskless/concepts/topics-vs-classic)
 - [Automatically create topics](/docs/products/kafka/howto/create-topics-automatically)
 - [Tiered storage](/docs/products/kafka/concepts/kafka-tiered-storage)
+- [Query Kafka topic data in Aiven for ClickHouse®](/docs/products/clickhouse/concepts/query-kafka-topic-data)

--- a/docs/products/kafka/howto/manage-topics-details.md
+++ b/docs/products/kafka/howto/manage-topics-details.md
@@ -77,7 +77,9 @@ for your Aiven for Apache Kafka service to use the **Schemas** tab.
 1. To return to the topic overview page in the Apache Kafka topic catalog,
    click **Open topic catalog**.
 
+
 <RelatedPages/>
 
 - [Aiven for Apache Kafka® topic catalog overview](/docs/products/kafka/concepts/topic-catalog-overview)
 - [View and manage Apache Kafka topic catalog](/docs/products/kafka/howto/view-kafka-topic-catalog)
+- [Query Kafka topic data in Aiven for ClickHouse®](/docs/products/clickhouse/concepts/query-kafka-topic-data)

--- a/docs/products/kafka/kafka-connect/howto/clickhouse-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/clickhouse-sink-connector.md
@@ -9,8 +9,11 @@ import ConsoleLabel from "@site/src/components/ConsoleIcons";
 The ClickHouse sink connector delivers data from Apache Kafka® topics to a ClickHouse database for efficient querying and analysis.
 
 :::tip
-You can also
-[connect Aiven for ClickHouse® with Apache Kafka® or Aiven for Apache Kafka® using ClickHouse Kafka Engine](/docs/products/clickhouse/howto/integrate-kafka).
+You can also:
+
+- [Query Apache Kafka® topic data in Aiven for ClickHouse®](/docs/products/clickhouse/concepts/query-kafka-topic-data)
+  using a managed setup that connects a Kafka topic to a ClickHouse table.
+- [Connect Aiven for ClickHouse® with Apache Kafka® or Aiven for Apache Kafka® using ClickHouse Kafka Engine](/docs/products/clickhouse/howto/integrate-kafka).
 :::
 
 ## Prerequisites

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1319,6 +1319,17 @@ const sidebars: SidebarsConfig = {
               items: [
                 'products/clickhouse/howto/data-service-integration',
                 'products/clickhouse/howto/integration-databases',
+                {
+                  type: 'category',
+                  label: 'Query Kafka topic data',
+                  link: {
+                    type: 'doc',
+                    id: 'products/clickhouse/concepts/query-kafka-topic-data',
+                  },
+                  items: [
+                    'products/clickhouse/howto/set-up-kafka-topic-querying',
+                  ],
+                },
                 'products/clickhouse/howto/integrate-kafka',
                 'products/clickhouse/reference/supported-input-output-formats',
                 'products/clickhouse/howto/integrate-postgresql',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1238,6 +1238,17 @@ const sidebars: SidebarsConfig = {
                     'products/clickhouse/reference/s3-supported-file-formats',
                   ],
                 },
+                {
+                  type: 'category',
+                  label: 'Query Kafka topic data',
+                  link: {
+                    type: 'doc',
+                    id: 'products/clickhouse/concepts/query-kafka-topic-data',
+                  },
+                  items: [
+                    'products/clickhouse/howto/set-up-kafka-topic-querying',
+                  ],
+                },
               ],
             },
             {
@@ -1319,17 +1330,6 @@ const sidebars: SidebarsConfig = {
               items: [
                 'products/clickhouse/howto/data-service-integration',
                 'products/clickhouse/howto/integration-databases',
-                {
-                  type: 'category',
-                  label: 'Query Kafka topic data',
-                  link: {
-                    type: 'doc',
-                    id: 'products/clickhouse/concepts/query-kafka-topic-data',
-                  },
-                  items: [
-                    'products/clickhouse/howto/set-up-kafka-topic-querying',
-                  ],
-                },
                 'products/clickhouse/howto/integrate-kafka',
                 'products/clickhouse/reference/supported-input-output-formats',
                 'products/clickhouse/howto/integrate-postgresql',

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -667,6 +667,13 @@ export default function ConsoleLabel({name}): ReactElement {
           <b>Query editor</b>
         </>
       );
+    case 'queryinclickhouse':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.console} />{' '}
+          <b>Query in ClickHouse</b>
+        </>
+      );
     case 'opensearchindexes':
       return (
         <>


### PR DESCRIPTION
## Describe your changes

Added documentation for querying Kafka topic data in Aiven for ClickHouse.
[FLEECH-319](https://aiven.atlassian.net/browse/FLEECH-319)

Preview: 
- https://fleech-319-query-kafka-topic.aiven-docs.pages.dev/docs/products/clickhouse/concepts/query-kafka-topic-data
- https://fleech-319-query-kafka-topic.aiven-docs.pages.dev/docs/products/clickhouse/howto/set-up-kafka-topic-querying

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.


[FLEECH-319]: https://aiven.atlassian.net/browse/FLEECH-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ