### PR TITLE
fix: allow ON CLUSTER and drop outdated limitations

### DIFF
--- a/docs/products/clickhouse/howto/query-databases.md
+++ b/docs/products/clickhouse/howto/query-databases.md
@@ -13,8 +13,8 @@ ClickHouse® takes care of running queries in the distributed mode over
 the entire cluster. In the standard ClickHouse, the queries `CREATE`,
 `ALTER`, `RENAME` and `DROP` only affect the server where they are run.
 In contrast, we ensure the proper distribution across all cluster
-machines behind the scenes. You don't need to remember using
-`ON CLUSTER` for every query.
+machines behind the scenes. You don't need to use `ON CLUSTER` for data
+definition queries against a `Replicated` database.
 
 :::important
 There are limitations on the number of concurrent queries and the number of concurrent

--- a/docs/products/clickhouse/reference/limitations.md
+++ b/docs/products/clickhouse/reference/limitations.md
@@ -44,16 +44,6 @@ a
       <td>N/A</td>
     </tr>
     <tr>
-      <td>Service integrations</td>
-        <ul>
-          <li>You can integrate your Aiven for ClickHouse service with PostgreSQL®
-          and Apache Kafka® only.</li>
-          <li>[Integrations of Aiven for ClickHouse and Apache Kafka](/docs/products/clickhouse/howto/integrate-kafka)
-          support the maximum of 400 virtual connector tables.</li>
-        </ul>
-      <td>N/A</td>
-    </tr>
-    <tr>
       <td>Table engines support</td>
       <td>
         <ul>
@@ -117,17 +107,6 @@ a
       <td>
           Use a distributed table with sharded plans. See
           <a href="/docs/products/clickhouse/howto/use-shards-with-distributed-table">Query data across shards</a>.
-      </td>
-    </tr>
-    <tr>
-      <td>ON CLUSTER queries</td>
-      <td>
-          Aiven for ClickHouse doesn't support ON CLUSTER queries because it
-          actually runs each data definition query on all the servers of the
-          cluster without using <code>ON CLUSTER</code>.
-      </td>
-      <td>
-          Run queries without <code>ON CLUSTER</code >.
       </td>
     </tr>
     <tr>

--- a/docs/products/clickhouse/reference/supported-interfaces-drivers.md
+++ b/docs/products/clickhouse/reference/supported-interfaces-drivers.md
@@ -15,6 +15,7 @@ interfaces (protocols):
 -   `HTTPS`
 -   `Native TCP`
 -   `MySQL Interface`
+-   `Arrow Flight`
 
 :::note
 For security reasons, TLS is required to connect to Aiven for ClickHouse.

--- a/static/includes/config-clickhouse.md
+++ b/static/includes/config-clickhouse.md
@@ -36,7 +36,7 @@ import Link from '@docusaurus/Link'
         <p className="title">Allow access to selected service ports from private networks</p>
         <table className="service-param-children">
           <tbody>
-          
+
           <tr><td><div className="param"><p className="name"><Link id="private_access_clickhouse"/><Link to="#private_access_clickhouse"><strong>private_access.clickhouse</strong></Link></p><p><code className="type">boolean</code></p></div><p className="title">Allow clients to connect to clickhouse with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations</p></td></tr>
           <tr><td><div className="param"><p className="name"><Link id="private_access_clickhouse_arrowflight"/><Link to="#private_access_clickhouse_arrowflight"><strong>private_access.clickhouse_arrowflight</strong></Link></p><p><code className="type">boolean</code></p></div><p className="title">Allow clients to connect to clickhouse_arrowflight with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations</p></td></tr>
           <tr><td><div className="param"><p className="name"><Link id="private_access_clickhouse_https"/><Link to="#private_access_clickhouse_https"><strong>private_access.clickhouse_https</strong></Link></p><p><code className="type">boolean</code></p></div><p className="title">Allow clients to connect to clickhouse_https with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations</p></td></tr>
@@ -52,7 +52,7 @@ import Link from '@docusaurus/Link'
         <p className="title">Allow access to selected service components through Privatelink</p>
         <table className="service-param-children">
           <tbody>
-          
+
           <tr><td><div className="param"><p className="name"><Link id="privatelink_access_clickhouse"/><Link to="#privatelink_access_clickhouse"><strong>privatelink_access.clickhouse</strong></Link></p><p><code className="type">boolean</code></p></div><p className="title">Enable clickhouse</p></td></tr>
           <tr><td><div className="param"><p className="name"><Link id="privatelink_access_clickhouse_arrowflight"/><Link to="#privatelink_access_clickhouse_arrowflight"><strong>privatelink_access.clickhouse_arrowflight</strong></Link></p><p><code className="type">boolean</code></p></div><p className="title">Enable clickhouse_arrowflight</p></td></tr>
           <tr><td><div className="param"><p className="name"><Link id="privatelink_access_clickhouse_https"/><Link to="#privatelink_access_clickhouse_https"><strong>privatelink_access.clickhouse_https</strong></Link></p><p><code className="type">boolean</code></p></div><p className="title">Enable clickhouse_https</p></td></tr>
@@ -68,7 +68,7 @@ import Link from '@docusaurus/Link'
         <p className="title">Allow access to selected service ports from the public Internet</p>
         <table className="service-param-children">
           <tbody>
-          
+
           <tr><td><div className="param"><p className="name"><Link id="public_access_clickhouse"/><Link to="#public_access_clickhouse"><strong>public_access.clickhouse</strong></Link></p><p><code className="type">boolean</code></p></div><p className="title">Allow clients to connect to clickhouse from the public internet for service nodes that are in a project VPC or another type of private network</p></td></tr>
           <tr><td><div className="param"><p className="name"><Link id="public_access_clickhouse_arrowflight"/><Link to="#public_access_clickhouse_arrowflight"><strong>public_access.clickhouse_arrowflight</strong></Link></p><p><code className="type">boolean</code></p></div><p className="title">Allow clients to connect to clickhouse_arrowflight from the public internet for service nodes that are in a project VPC or another type of private network</p></td></tr>
           <tr><td><div className="param"><p className="name"><Link id="public_access_clickhouse_https"/><Link to="#public_access_clickhouse_https"><strong>public_access.clickhouse_https</strong></Link></p><p><code className="type">boolean</code></p></div><p className="title">Allow clients to connect to clickhouse_https from the public internet for service nodes that are in a project VPC or another type of private network</p></td></tr>
@@ -126,7 +126,7 @@ import Link from '@docusaurus/Link'
         <div className="description"><p>ClickHouse server settings, which can be found in the `system.server_settings` table.</p></div>
         <table className="service-param-children">
           <tbody>
-          
+
           <tr><td><div className="param"><p className="name"><Link id="server_settings_vector_similarity_index_cache_size"/><Link to="#server_settings_vector_similarity_index_cache_size"><strong>server_settings.vector_similarity_index_cache_size</strong></Link></p><p><code className="type">number</code></p></div><div className="constraints"><ul><li>max: <code>0.5</code></li><li>default: <code>0.07</code></li></ul></div><p className="title">vector_similarity_index_cache_size</p><div className="description"><p>Fraction of total server memory allocated to the vector similarity index cache. 0 disables the cache. Default is 0.07 (7% of server memory). Only effective on ClickHouse 25.8+.</p></div></td></tr>
           </tbody>
         </table>
@@ -138,7 +138,7 @@ import Link from '@docusaurus/Link'
         <div className="description"><p>ClickHouse session settings, which can be found in the `system.settings` table.</p></div>
         <table className="service-param-children">
           <tbody>
-          
+
           <tr><td><div className="param"><p className="name"><Link id="session_settings_compatibility"/><Link to="#session_settings_compatibility"><strong>session_settings.compatibility</strong></Link></p><p><code className="type">string,null</code></p></div><div className="description"><p>When set, ClickHouse applies backward-compatible behavior from the specified version. Automatically set to the previous version on major version upgrade. Set to null to disable compatibility mode once all incompatibilities have been resolved. Takes effect after the next service restart/upgrade.</p></div></td></tr>
           </tbody>
         </table>
@@ -146,4 +146,3 @@ import Link from '@docusaurus/Link'
     </tr>
   </tbody>
 </table>
-    


### PR DESCRIPTION
- Note ON CLUSTER is supported but unnecessary for Replicated databases
- Remove ON CLUSTER limitation row from the limitations table
- Remove outdated service integrations limitation (PostgreSQL/Kafka only)
- Strip trailing whitespace in static/includes/config-clickhouse.md

## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
