### PR TITLE
update: PG controlled switchover

### DIFF
--- a/docs/products/postgresql/howto/pg-controlled-switchover.md
+++ b/docs/products/postgresql/howto/pg-controlled-switchover.md
@@ -246,7 +246,7 @@ The `controlled_switchover` object includes the following fields:
 - `completed_at`: The time when switchover completed. Can be `null` if switchover
   has not completed.
 - `termination_reason`: The reason for switchover completion, such as
-  `Controlled switchover` or `old generation node timed out`. Can be `null`.
+  `old generation node timed out`. Can be `null`.
 
 State values:
 

--- a/docs/products/postgresql/howto/pg-controlled-switchover.md
+++ b/docs/products/postgresql/howto/pg-controlled-switchover.md
@@ -228,12 +228,25 @@ In the response, inspect `maintenance.controlled_switchover`:
   "maintenance": {
     "controlled_switchover": {
       "enabled": true,
-      "state": "SCHEDULED",
-      "scheduled_start_time": "2026-02-27T10:01:00.000000Z"
+      "state": "COMPLETED",
+      "scheduled_start_time": "2026-02-27T10:01:00.000000Z",
+      "completed_at": "2026-02-27T10:02:00.000000Z",
+      "termination_reason": "Controlled switchover"
     }
   }
 }
 ```
+
+The `controlled_switchover` object includes the following fields:
+
+- `enabled`: Whether controlled switchover is configured for the service.
+- `state`: The current switchover state. See the state values that follow.
+- `scheduled_start_time`: The time when switchover is scheduled to start. Can be
+  `null` for some states.
+- `completed_at`: The time when switchover completed. Can be `null` if switchover
+  has not completed.
+- `termination_reason`: The reason for switchover completion, such as
+  `Controlled switchover` or `old generation node timed out`. Can be `null`.
 
 State values:
 
@@ -241,9 +254,13 @@ State values:
 - `PENDING`: Maintenance started, and new nodes are not ready.
 - `SCHEDULED`: New nodes are ready, and switchover is scheduled.
 - `RUNNING`: Switchover is in progress.
-- `COMPLETED`: Switchover finished.
+- `COMPLETED`: Switchover finished within a controlled switchover window.
+- `COMPLETED_EARLY`: Switchover finished outside a controlled switchover window,
+  for example when the old primary node failed during the wait.
 
-`scheduled_start_time` can be `null` for some states.
+If the old service nodes time out or fail outside a configured window, Aiven
+promotes the new primary and completes the switchover early, without waiting for
+the next window. In this case, `state` is `COMPLETED_EARLY`.
 
 ## Best practices
 


### PR DESCRIPTION
https://aiven.atlassian.net/browse/OPD-1109

CHANGES

- COMPLETED_EARLY state added to the state-values list — switchover that finishes outside a controlled window (for example, when the old primary fails during the wait).
- completed_at field — time the switchover completed; can be null.
- termination_reason field — reason for completion, such as Controlled switchover or old generation node timed out; can be null.
- Early-completion clarification — a sentence explaining that if old nodes time out or fail outside a configured window, Aiven promotes and completes early without waiting, setting state to COMPLETED_EARLY.
- Added a short field-reference list describing the whole controlled_switchover object (it previously only explained scheduled_start_time), and updated the JSON example to a COMPLETED response showing the two new fields populated.