### PR TITLE
fix: set correct path for font

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -43,11 +43,28 @@ const config: Config = {
       tagName: 'link',
       attributes: {
         rel: 'preload',
-        href: '/fonts/Inter/InterVariable.woff2',
+        href: `${baseUrl}fonts/Inter/InterVariable.woff2`,
         as: 'font',
         type: 'font/woff2',
         crossorigin: 'anonymous',
       },
+    },
+    {
+      tagName: 'style',
+      attributes: {
+        type: 'text/css',
+        rel: 'stylesheet',
+      },
+      innerHTML: `
+        @font-face {
+          font-family: 'Inter';
+          font-style: normal;
+          font-weight: 100 900;
+          font-display: swap;
+          src: url(${baseUrl}fonts/Inter/InterVariable.woff2) format('woff2');
+        }
+      `,
+
     },
     {
       tagName: 'link',
@@ -76,7 +93,6 @@ const config: Config = {
         },
         theme: {
           customCss: [
-            './src/css/fonts.css',
             './src/css/colors.css',
             './src/css/navbar.css',
             './src/css/admonitions.css',

--- a/src/css/fonts.css
+++ b/src/css/fonts.css
@@ -1,7 +1,0 @@
-@font-face {
-  font-family: 'Inter';
-  font-style: normal;
-  font-weight: 100 900;
-  font-display: swap;
-  src: url(/fonts/Inter/InterVariable.woff2) format('woff2');
-}


### PR DESCRIPTION
## Describe your changes

`baseURL` changes depending on the environment. the current font path did not take that into account. 
moved css styles into the head directly to set the correct baseurl for the path

https://aiven.atlassian.net/browse/BRCOM-1264

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
