### PR TITLE
update: kafka oidc also supports outbound identity federation

### DIFF
--- a/docs/products/kafka/howto/enable-oidc.md
+++ b/docs/products/kafka/howto/enable-oidc.md
@@ -11,7 +11,7 @@ import RelatedPages from "@site/src/components/RelatedPages";
 
 Aiven for Apache Kafka® supports OAuth 2.0/OIDC authentication for Kafka clients.
 Use OAuth 2.0/OIDC authentication to let clients authenticate with tokens issued by an
-identity provider.
+identity provider, or by an identity broker such as Outbound Identity Federation.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Describe your changes

Extend existing documentation "OAuth 2.0/OIDC authentication for Apache Kafka®" to the support of Outbound Identity Federation.

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
