### PR TITLE
update: load PostHog only when key is set

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -10,6 +10,22 @@ const isJune = currentMonth === 5;
 const baseUrl = process.env.BASEURL || '/docs/';
 const llmsTxtUrl = `${baseUrl.replace(/\/$/, '')}/llms.txt`;
 
+const posthogPlugin = process.env.POSTHOG_PUBLIC_KEY
+  ? [
+      'posthog-docusaurus',
+      {
+        apiKey: process.env.POSTHOG_PUBLIC_KEY,
+        appUrl: 'https://eu.i.posthog.com',
+        autocapture: false,
+        capture_pageview: false,
+        capture_pageleave: false,
+        capture_heatmaps: false,
+        disable_session_recording: true,
+        opt_out_capturing_by_default: true,
+      },
+    ]
+  : null;
+
 const config: Config = {
   // Testing faster build
   future: {},
@@ -183,19 +199,7 @@ const config: Config = {
   plugins: [
     './src/plugins/svg-fix/index.ts',
     'docusaurus-plugin-image-zoom',
-    [
-      'posthog-docusaurus',
-      {
-        apiKey: process.env.POSTHOG_PUBLIC_KEY,
-        appUrl: 'https://eu.i.posthog.com',
-        autocapture: false,
-        capture_pageview: false,
-        capture_pageleave: false,
-        capture_heatmaps: false,
-        disable_session_recording: true,
-        opt_out_capturing_by_default: true,
-      },
-    ],
+    posthogPlugin,
     [
       '@signalwire/docusaurus-plugin-llms-txt',
       {
@@ -209,7 +213,7 @@ const config: Config = {
         },
       },
     ],
-  ],
+  ].filter(Boolean),
   themeConfig: {
     image: 'images/site-preview.png',
     navbar: {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,5 +1,5 @@
 import {themes as prismThemes} from 'prism-react-renderer';
-import type {Config} from '@docusaurus/types';
+import type {Config, PluginConfig} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
@@ -10,7 +10,7 @@ const isJune = currentMonth === 5;
 const baseUrl = process.env.BASEURL || '/docs/';
 const llmsTxtUrl = `${baseUrl.replace(/\/$/, '')}/llms.txt`;
 
-const posthogPlugin = process.env.POSTHOG_PUBLIC_KEY
+const posthogPlugin: PluginConfig = process.env.POSTHOG_PUBLIC_KEY
   ? [
       'posthog-docusaurus',
       {
@@ -213,7 +213,7 @@ const config: Config = {
         },
       },
     ],
-  ].filter(Boolean),
+  ],
   themeConfig: {
     image: 'images/site-preview.png',
     navbar: {


### PR DESCRIPTION
## Describe your changes

**Fix local Docusaurus startup failure caused by required PostHog API key**
PostHog requires an API key to initialize, which isn't set locally, so yarn start failed for anyone running the docs locally. The plugin now loads only when POSTHOG_PUBLIC_KEY is present, leaving CI/prod unchanged.

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
