### PR TITLE
fix: optimize the mcp server page content and menu placements

### DIFF
--- a/docs/tools/api.md
+++ b/docs/tools/api.md
@@ -17,6 +17,12 @@ Common use cases for the Aiven API:
 - Deploy and tear down development or demo platforms on a schedule.
 - Scale your disks based on specific events.
 
+:::tip
+Want to manage Aiven services from an AI assistant? Use
+[Aiven MCP](/docs/tools/mcp-server) to create, update, and inspect services in
+natural language from clients such as Cursor and Claude Code.
+:::
+
 ## Get started with Aiven API
 
 Use the [Postman workspace](https://www.postman.com/aiven-apis/workspace/aiven/overview)
@@ -146,3 +152,4 @@ authenticated, it returns the standard set of cloud regions.
 - [Personal tokens](/docs/platform/concepts/authentication-tokens)
 - [Aiven Provider for Terraform](https://registry.terraform.io/providers/aiven/aiven/latest/docs)
 - [API reference docs](https://api.aiven.io/doc/)
+- [Aiven MCP](/docs/tools/mcp-server): Manage Aiven services in natural language.

--- a/docs/tools/cli.md
+++ b/docs/tools/cli.md
@@ -9,6 +9,12 @@ The Aiven command line interface (CLI) lets you use the Aiven platform and servi
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::tip
+Want to manage Aiven services from an AI assistant? Use
+[Aiven MCP](/docs/tools/mcp-server) to create, update, and inspect services in
+natural language from clients such as Cursor and Claude Code.
+:::
+
 ## Install the Aiven CLI
 
 1. The `avn` utility is a [Python package](https://pypi.org/project/aiven-client/):
@@ -85,3 +91,4 @@ To get information in JSON format, use the `--json` switch with any command.
 - [Learn how to use the Aiven CLI](https://aiven.io/blog/aiven-cmdline) for common tasks.
 - Watch the [how to get started tutorial](https://www.youtube.com/watch?v=nf3PPn5w6K8).
 - Go to the [aiven-client repository on GitHub](https://github.com/aiven/aiven-client).
+- [Aiven MCP](/docs/tools/mcp-server): Manage Aiven services in natural language.

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -29,7 +29,7 @@ can sign in and authorize MCP access.
 
 ## Install the Aiven MCP {#configure-aiven-mcp}
 
-<Tabs groupId="aiven-mcp-clients">
+<Tabs>
 <TabItem value="claude-code" label="Claude Code" default>
 
 1. Open a terminal.
@@ -41,42 +41,21 @@ can sign in and authorize MCP access.
      configTemplate={(url) => `claude mcp add --transport http aiven "${url}"`}
    />
 
-1. To verify the server is registered, in Claude Code run `/mcp`. The first time
-   you use the server, your browser opens.
-1. Sign in to Aiven and select your organization.
+1. Run `/mcp` and authenticate in your browser when prompted.
+1. Test the connection with a prompt such as `List my Aiven projects.` and
+   approve the tool execution if prompted.
 
 For more information, see the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp).
-
-<br />
-
-#### Verify the connection
-
-1. Run `/mcp` in Claude Code to verify the server is registered.
-1. Try a prompt such as:
-
-   > List my Aiven projects.
-
-1. If your client prompts you to allow tool execution, approve the request.
 
 </TabItem>
 <TabItem value="cursor" label="Cursor">
 
 <CursorConfigTab baseUrl={mcpUrl} />
 
+In Cursor Chat (**Cmd+L** / **Ctrl+L**), test the connection with a prompt such
+as `List my Aiven projects.` and click **Allow** if prompted.
+
 For more information, see the [Cursor MCP documentation](https://cursor.com/docs/mcp).
-
-<br />
-
-#### Verify the connection
-
-1. Open Cursor Chat with **Cmd+L** on macOS or **Ctrl+L** on Windows/Linux.
-1. Try a prompt such as:
-
-   > List my Aiven projects.
-
-1. If prompted to allow tool execution, click **Allow**.
-1. To confirm the server is registered, go to **Settings** > **Tools & MCP** and
-   check that **aiven** appears with a connected status.
 
 </TabItem>
 <TabItem value="claude-desktop" label="Claude Desktop">
@@ -98,20 +77,10 @@ For more information, see the [Cursor MCP documentation](https://cursor.com/docs
    />
 
 1. Save the file and restart Claude Desktop.
+1. In a new conversation, test the connection with a prompt such as
+   `List my Aiven projects.` and click **Allow** if prompted.
 
 For more information, see the [Claude Desktop MCP documentation](https://modelcontextprotocol.io/docs/develop/connect-local-servers).
-
-<br />
-
-#### Verify the connection
-
-1. Open a new conversation.
-1. Verify that the MCP tools icon appears in the input area.
-1. Try a prompt such as:
-
-   > List my Aiven projects.
-
-1. If prompted to allow tool execution, click **Allow**.
 
 </TabItem>
 <TabItem value="vscode" label="VS Code">
@@ -132,25 +101,13 @@ and enabled.
      configTemplate={(url) => ({servers: {aiven: {type: "http", url}}})}
    />
 
-1. Save the file.
-1. Reload VS Code.
-1. Open the Command Palette and run **MCP: List Servers**.
-1. Confirm that **aiven** appears in the list.
+1. Save the file and reload VS Code.
+1. Open the Command Palette, run **MCP: List Servers**, and confirm that
+   **aiven** appears.
+1. In Copilot Chat, test the connection with a prompt such as
+   `List my Aiven projects.` and click **Allow** if prompted.
 
 For more information, see the [VS Code MCP documentation](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
-
-<br />
-
-#### Verify the connection
-
-1. Open Copilot Chat in VS Code.
-1. Open the Command Palette and run **MCP: List Servers**.
-1. Confirm that **aiven** appears in the list.
-1. Try a prompt such as:
-
-   > List my Aiven projects.
-
-1. If prompted to allow tool execution, click **Allow**.
 
 </TabItem>
 <TabItem value="gemini-cli" label="Gemini CLI">
@@ -164,20 +121,10 @@ For more information, see the [VS Code MCP documentation](https://code.visualstu
      configTemplate={(url) => ({mcpServers: {aiven: {httpUrl: url}}})}
    />
 
-1. Save the file.
-1. Run `gemini` to start the CLI.
+1. Save the file and run `gemini` to start the CLI.
 1. Run `/mcp auth aiven` to sign in via your browser.
-1. Run `/mcp list` to confirm the server is connected.
-
-<br />
-
-#### Verify the connection
-
-1. In the Gemini CLI, try a prompt such as:
-
-   > List my Aiven projects.
-
-1. If prompted to allow tool execution, approve the request.
+1. Test the connection with a prompt such as `List my Aiven projects.` and
+   approve the tool execution if prompted.
 
 </TabItem>
 <TabItem value="other" label="Other clients">
@@ -194,20 +141,11 @@ For more information, see the [VS Code MCP documentation](https://code.visualstu
    Most clients use a configuration similar to the above.
 
 1. Save the file and restart your client.
+1. In your AI assistant, test the connection with a prompt such as
+   `List my Aiven projects.` and approve the tool execution if prompted.
 
 Some clients require a transport type, such as `"type": "http"`. If the configuration
 fails, see your client documentation.
-
-<br />
-
-#### Verify the connection
-
-1. Open your AI assistant.
-1. Try a prompt such as:
-
-   > List my Aiven projects.
-
-1. If your client prompts you to allow tool execution, approve the request.
 
 </TabItem>
 <TabItem value="local" label="Local installation">
@@ -216,7 +154,7 @@ Run the server locally using `npx` instead of the hosted server. Requires
 an [Aiven API token](/docs/platform/howto/create_authentication_token). Set
 `AIVEN_READ_ONLY="true"` to enable read-only mode.
 
-<Tabs groupId="aiven-mcp-local-clients">
+<Tabs>
 <TabItem value="claude-code" label="Claude Code" default>
 
 1. Open a terminal.
@@ -324,6 +262,21 @@ an [Aiven API token](/docs/platform/howto/create_authentication_token). Set
 
 </TabItem>
 </Tabs>
+
+## What Aiven MCP can do
+
+After you connect to Aiven MCP, you can work with Aiven resources in natural
+language. For example, you can do the following:
+
+- **View resources**: List projects, services, and integrations, or check the
+  status, plan, and cloud region of a service.
+- **Manage services**: Create, update, and delete services such as PostgreSQL®
+  and Apache Kafka®, and update service plans or configuration. To allow write
+  operations, disable [read-only mode](#configure-aiven-mcp).
+- **Inspect and troubleshoot services**: View service metrics, logs, and
+  configuration to investigate issues.
+- **Use Aiven documentation**: Ask questions and get answers based on the Aiven
+  documentation.
 
 ## Security and responsibility
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -323,6 +323,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'tools',
         'tools/api',
+        'tools/mcp-server',
         {
           type: 'category',
           label: 'Aiven Provider for Terraform',
@@ -377,7 +378,6 @@ const sidebars: SidebarsConfig = {
           ],
         },
         'tools/query-optimizer',
-        'tools/mcp-server',
         'tools/doc-diff-llms',
       ],
     },

--- a/src/components/CursorConfigTab/index.tsx
+++ b/src/components/CursorConfigTab/index.tsx
@@ -22,7 +22,7 @@ export default function CursorConfigTab({ baseUrl }: CursorConfigTabProps): JSX.
   return (
     <div className={styles.container}>
       <p>For one-click installation:</p>
-      <a href={deepLink} className={styles.button} key={`cursor-deeplink-${cacheKey}`}>
+      <a href={deepLink} className={`aiven-btn-link ${styles.button}`} key={`cursor-deeplink-${cacheKey}`}>
         <CursorIcon />
         <span>Add to Cursor</span>
       </a>

--- a/src/components/CursorConfigTab/styles.module.css
+++ b/src/components/CursorConfigTab/styles.module.css
@@ -9,28 +9,42 @@
   align-items: center;
   gap: 10px;
   padding: 10px 20px;
-  background-color: var(--aiven-grey-90);
-  color: white;
+  background-color: var(--aiven-grey-0);
+  color: var(--aiven-grey-90);
   border-radius: var(--aiven-radius);
   text-decoration: none;
   font-size: 16px;
   font-weight: 500;
-  border: none;
+  border: 1px solid var(--aiven-grey-20);
   line-height: 20px;
   width: fit-content;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s, border-color 0.2s;
 }
 
 .button:hover,
 .button:focus {
-  background-color: var(--aiven-grey-80);
-  color: white;
+  background-color: var(--aiven-grey-0);
+  border-color: var(--aiven-grey-30);
+  color: var(--aiven-grey-90);
   text-decoration: none;
 }
 
 .button svg {
   display: block;
   flex: none;
+}
+
+html[data-theme='dark'] .button {
+  background-color: var(--aiven-grey-80);
+  color: var(--aiven-brand-white);
+  border-color: var(--aiven-grey-60);
+}
+
+html[data-theme='dark'] .button:hover,
+html[data-theme='dark'] .button:focus {
+  background-color: var(--aiven-grey-80);
+  border-color: var(--aiven-grey-50);
+  color: var(--aiven-brand-white);
 }
 
 .manualSetup {


### PR DESCRIPTION
Watched the last 50 MCP docs session recordings, applying some optimizations based on them:

- Moved Aiven MCP higher in the sidebar menu, so users looking at Aiven CLI will find the MCP
- Promoted MCP in the CLI and API docs page as a Tip
- Restyled the "Add to Cursor" one-click installation button to look better
- Fixed inconsistent default tab - Claude Code now always default
- Shortened install steps
- Added "What can I do with MCP?" section, for users that want to read more
- Added the MCP page to the "Related Pages" section of pages like Aiven API and Aiven CLI docs pages

[https://aiven.atlassian.net/browse/EVERSQL-1904](https://aiven.atlassian.net/browse/EVERSQL-1904)