### PR TITLE
feat: howto setup kafka oidc for aws iam principals

### DIFF
--- a/docs/products/kafka/howto/enable-oidc.md
+++ b/docs/products/kafka/howto/enable-oidc.md
@@ -11,8 +11,9 @@ import RelatedPages from "@site/src/components/RelatedPages";
 
 Aiven for Apache Kafka® supports OAuth 2.0/OIDC authentication for Kafka clients.
 Use OAuth 2.0/OIDC authentication to let clients authenticate with tokens issued by an
-identity provider, or by an identity broker supporting Outbound Identity Federation
-(see [how to set it up with AWS IAM](/docs/products/kafka/howto/kafka-oauth2-aws-iam)).
+identity provider or by an identity broker that supports Outbound Identity Federation.
+For AWS IAM, see
+[OAuth 2.0/OIDC with AWS IAM](/docs/products/kafka/howto/kafka-oauth2-aws-iam).
 
 ## Prerequisites
 
@@ -207,4 +208,4 @@ operational impact, apply these changes during a maintenance window.
 
 - [Enable OAuth 2.0/OIDC support for Apache Kafka REST proxy](/docs/products/kafka/karapace/howto/enable-oauth-oidc-kafka-rest-proxy)
 - [Enable and configure SASL authentication](/docs/products/kafka/howto/kafka-sasl-auth)
-- [OAuth 2.0/OIDC with AWS IAM using Outbound Identity Federation](/docs/products/kafka/howto/kafka-oauth2-aws-iam)
+- [OAuth 2.0/OIDC with AWS IAM](/docs/products/kafka/howto/kafka-oauth2-aws-iam)

--- a/docs/products/kafka/howto/enable-oidc.md
+++ b/docs/products/kafka/howto/enable-oidc.md
@@ -11,7 +11,8 @@ import RelatedPages from "@site/src/components/RelatedPages";
 
 Aiven for Apache Kafka® supports OAuth 2.0/OIDC authentication for Kafka clients.
 Use OAuth 2.0/OIDC authentication to let clients authenticate with tokens issued by an
-identity provider, or by an identity broker such as Outbound Identity Federation.
+identity provider, or by an identity broker supporting Outbound Identity Federation
+(see [how to set it up with AWS IAM](/docs/products/kafka/howto/kafka-oauth2-aws-iam)).
 
 ## Prerequisites
 
@@ -206,3 +207,4 @@ operational impact, apply these changes during a maintenance window.
 
 - [Enable OAuth 2.0/OIDC support for Apache Kafka REST proxy](/docs/products/kafka/karapace/howto/enable-oauth-oidc-kafka-rest-proxy)
 - [Enable and configure SASL authentication](/docs/products/kafka/howto/kafka-sasl-auth)
+- [OAuth 2.0/OIDC with AWS IAM using Outbound Identity Federation](/docs/products/kafka/howto/kafka-oauth2-aws-iam)

--- a/docs/products/kafka/howto/kafka-oauth2-aws-iam.md
+++ b/docs/products/kafka/howto/kafka-oauth2-aws-iam.md
@@ -5,9 +5,10 @@ sidebar_label: OAuth 2.0/OIDC with AWS IAM
 
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Use AWS IAM Outbound Identity Federation to authenticate Kafka clients with OAuth 2.0/OIDC.
-This lets AWS IAM principals connect to Aiven for Apache Kafka® without managing
-separate credentials by using short-lived JWTs issued by AWS STS.
+Use AWS IAM Outbound Identity Federation to authenticate Apache Kafka® clients with
+OAuth 2.0/OIDC. AWS IAM principals can connect to Aiven for Apache Kafka® without
+managing separate credentials by using short-lived JSON Web Tokens (JWTs) issued by
+AWS Security Token Service (AWS STS).
 
 ## Prerequisites
 
@@ -20,14 +21,19 @@ Before you begin, make sure you have:
 - The [Aiven CLI](/docs/tools/cli) installed.
 - The [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
   installed.
+- [`jq`](https://jqlang.github.io/jq/) installed.
 
-Define the audience value, typically as your Kafka service hostname. Replace `SERVICE_NAME` with your value:
+Define the audience value, typically as your Kafka service hostname. Replace
+`SERVICE_NAME` with your value:
 
 ```bash
 AUDIENCE=$(avn service get SERVICE_NAME --json | jq .user_config.kafka.sasl_oauthbearer_expected_audience)
 ```
 
-## Step 1: Enable Outbound Identity Federation in AWS
+Use the same audience value when you configure AWS, Aiven for Apache Kafka, and your
+Kafka client.
+
+## Enable Outbound Identity Federation in AWS
 
 Enable Outbound Identity Federation for your AWS account:
 
@@ -35,10 +41,10 @@ Enable Outbound Identity Federation for your AWS account:
 aws iam enable-outbound-web-identity-federation
 ```
 
-## Step 2: Verify IAM permissions
+## Verify IAM permissions
 
-Your AWS user must be attached an IAM policy that allows
-the `sts:GetWebIdentityToken` action with a condition matching the audience.
+Make sure the AWS principal that requests the token has permission to call
+`sts:GetWebIdentityToken` with the configured audience.
 
 The following example policy grants the minimum required permissions:
 
@@ -61,7 +67,7 @@ The following example policy grants the minimum required permissions:
 }
 ```
 
-## Step 3: Retrieve the issuer URL
+## Retrieve the issuer URL
 
 Get the issuer URL from your AWS account configuration:
 
@@ -69,11 +75,13 @@ Get the issuer URL from your AWS account configuration:
 ISSUER_URL=$(aws iam get-outbound-web-identity-federation-info | jq -r .IssuerIdentifier)
 ```
 
-The issuer URL is in the form `https://<uuid>.tokens.sts.global.api.aws`.
+The issuer URL has the form `https://<uuid>.tokens.sts.global.api.aws`.
 
-## Step 4: Update your Aiven for Apache Kafka service
+## Configure OIDC for Aiven for Apache Kafka
 
-Configure your Kafka service with the OIDC settings from the previous step.
+Configure your Kafka service with the OIDC issuer, JSON Web Key Set (JWKS) endpoint,
+audience, and subject claim.
+
 Replace `PROJECT_NAME` and `SERVICE_NAME` with your values:
 
 ```bash
@@ -85,66 +93,70 @@ avn service update --project PROJECT_NAME SERVICE_NAME \
 ```
 
 :::note
-This command triggers a rolling restart of your Apache Kafka brokers. Apply it
-during a maintenance window to minimize impact.
+This command triggers a rolling restart of your Apache Kafka brokers. To minimize
+impact, apply it during a maintenance window.
 :::
 
-For details on each parameter, see [OIDC parameters](/docs/products/kafka/howto/enable-oidc#oidc-parameters).
+For details about each parameter, see
+[OIDC parameters](/docs/products/kafka/howto/enable-oidc#oidc-parameters).
 
-## Step 5: Configure Kafka ACLs for your IAM principal
+## Configure Kafka ACLs for your IAM principal
 
-The JWT issued by AWS STS contains the IAM principal ARN as the `sub` claim.
-Aiven for Apache Kafka uses this value directly as the Kafka principal, so your
-ACLs must reference the full ARN prefixed with `User:`.
+The JWT issued by AWS STS contains the IAM principal Amazon Resource Name (ARN) as the
+`sub` claim. Aiven for Apache Kafka uses this value as the Kafka principal, so
+configure your access control lists (ACLs) to reference the full ARN prefixed with
+`User:`.
 
 Use the Aiven CLI to add the required ACLs. Replace `PROJECT_NAME`, `SERVICE_NAME`,
 and the ARN with your values:
 
 ```bash
-# Allow describe (required for both producers and consumers)
+PRINCIPAL="User:arn:aws:iam::123456789012:user/my-iam-user"
+
+# Allow topic describe operations.
 avn service kafka-acl-add --project PROJECT_NAME SERVICE_NAME \
   --permission allow \
-  --principal "User:arn:aws:iam::123456789012:user/my-iam-user" \
+  --principal "${PRINCIPAL}" \
   --operation Describe \
   --resource-type topic \
   --pattern-type literal \
   --resource-name my-topic
 
-# Allow produce
+# Allow produce operations.
 avn service kafka-acl-add --project PROJECT_NAME SERVICE_NAME \
   --permission allow \
-  --principal "User:arn:aws:iam::123456789012:user/my-iam-user" \
+  --principal "${PRINCIPAL}" \
   --operation Write \
   --resource-type topic \
   --pattern-type literal \
   --resource-name my-topic
 
-# Allow consume (topic)
+# Allow consume operations from the topic.
 avn service kafka-acl-add --project PROJECT_NAME SERVICE_NAME \
   --permission allow \
-  --principal "User:arn:aws:iam::123456789012:user/my-iam-user" \
+  --principal "${PRINCIPAL}" \
   --operation Read \
   --resource-type topic \
   --pattern-type literal \
   --resource-name my-topic
 
-# Allow consume (consumer group)
+# Allow consume operations with the consumer group.
 avn service kafka-acl-add --project PROJECT_NAME SERVICE_NAME \
   --permission allow \
-  --principal "User:arn:aws:iam::123456789012:user/my-iam-user" \
+  --principal "${PRINCIPAL}" \
   --operation Read \
   --resource-type group \
   --pattern-type literal \
   --resource-name my-consumer-group
 ```
 
-To verify the ACLs are in place:
+To verify that the ACLs are in place, run the following command:
 
 ```bash
 avn service kafka-acl-list --project PROJECT_NAME SERVICE_NAME
 ```
 
-Expected output:
+The output is similar to the following:
 
 ```text
 ID              PERMISSION_TYPE  PRINCIPAL                                              OPERATION  RESOURCE_TYPE  PATTERN_TYPE  RESOURCE_NAME      HOST
@@ -155,13 +167,12 @@ acl5baf3a60d8f  ALLOW            User:arn:aws:iam::123456789012:user/my-iam-user
 acl5baf3ab8316  ALLOW            User:arn:aws:iam::123456789012:user/my-iam-user        Read       Group          LITERAL       my-consumer-group  *
 ```
 
-## Step 6: Configure your Kafka client
+## Configure the Kafka client
 
 Your client must request a JWT from AWS STS at runtime and use it to authenticate
-with the Kafka service via `OAUTHBEARER`.
+with the Kafka service by using the `OAUTHBEARER` SASL mechanism.
 
-<details>
-<summary>Python example</summary>
+### Python example
 
 Install the required libraries:
 
@@ -169,7 +180,7 @@ Install the required libraries:
 pip install confluent-kafka boto3 PyJWT
 ```
 
-Download the CA certificate for your service from the Aiven Console, then use the
+Download the CA certificate for your service from the Aiven Console. Use the
 following code:
 
 ```python
@@ -185,7 +196,7 @@ AUDIENCE = "<your-kafka-service-hostname>"  # Must match the server-side audienc
 
 def fetch_token_from_aws_sts(config):
     """
-    Fetches a short-lived JWT from AWS STS.
+    Fetch a short-lived JWT from AWS STS.
 
     Equivalent to:
         aws sts get-web-identity-token \
@@ -204,7 +215,7 @@ def fetch_token_from_aws_sts(config):
     return token, expiry
 
 
-# Verify token fetch before connecting (fail fast)
+# Verify that token retrieval works before connecting.
 token, expiry = fetch_token_from_aws_sts(None)
 decoded = jwt.decode(token, options={"verify_signature": False})
 print(decoded)
@@ -233,9 +244,10 @@ def delivery_callback(err, msg):
 
 producer = Producer(kafka_config)
 producer.produce("my-topic", key="key", value="hello from OIDC", callback=delivery_callback)
+producer.flush()
+
 if delivery_errors:
     raise RuntimeError(f"Message delivery failed: {delivery_errors[0]}")
-producer.flush()
 
 # Consumer example
 consumer_config = {
@@ -259,13 +271,11 @@ finally:
     consumer.close()
 ```
 
-</details>
-
-<details>
-<summary>Java example</summary>
+### Java example
 
 Implement a custom `AuthenticateCallbackHandler` that calls
 `GetWebIdentityToken` and refreshes the token before it expires.
+
 Pass the handler class to your Kafka client configuration:
 
 ```properties
@@ -276,16 +286,14 @@ sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginMo
 sasl.login.callback.handler.class=<your-handler-that-calls-GetWebIdentityToken-and-refreshes-the-token-before-it-expires>
 ```
 
-Your handler should:
+Configure your handler to:
 
 1. Call the AWS SDK `StsClient.getWebIdentityToken()` with the configured audience and
    a signing algorithm.
-2. Return the token and its expiration time.
-3. Proactively refresh the token before it expires to avoid authentication failures.
+1. Return the token and its expiration time.
+1. Refresh the token before it expires to avoid authentication failures.
 
-</details>
-
-## Step 7 (optional): Disable other authentication mechanisms
+## Optional: Disable other authentication mechanisms
 
 To use only OAuth 2.0/OIDC authentication, you can now disable all other
 SASL authentication mechanisms. Replace `SERVICE_NAME` with your value:

--- a/docs/products/kafka/howto/kafka-oauth2-aws-iam.md
+++ b/docs/products/kafka/howto/kafka-oauth2-aws-iam.md
@@ -1,0 +1,303 @@
+---
+title: Set up Kafka OAuth 2.0/OIDC authentication with AWS IAM using Outbound Identity Federation
+sidebar_label: OAuth 2.0/OIDC with AWS IAM
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Use AWS IAM Outbound Identity Federation to authenticate Kafka clients with OAuth 2.0/OIDC.
+This lets AWS IAM principals connect to Aiven for Apache Kafka® without managing
+separate credentials by using short-lived JWTs issued by AWS STS.
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+- An [Aiven for Apache Kafka](/docs/products/kafka/get-started/create-kafka-service)
+  service with
+  [SASL authentication](/docs/products/kafka/howto/kafka-sasl-auth#enable-sasl-authentication)
+  enabled.
+- The [Aiven CLI](/docs/tools/cli) installed.
+- The [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+  installed.
+
+Define the audience value, typically as your Kafka service hostname. Replace `SERVICE_NAME` with your value:
+
+```bash
+AUDIENCE=$(avn service get SERVICE_NAME --json | jq .user_config.kafka.sasl_oauthbearer_expected_audience)
+```
+
+## Step 1: Enable Outbound Identity Federation in AWS
+
+Enable Outbound Identity Federation for your AWS account:
+
+```bash
+aws iam enable-outbound-web-identity-federation
+```
+
+## Step 2: Verify IAM permissions
+
+Your AWS user must be attached an IAM policy that allows
+the `sts:GetWebIdentityToken` action with a condition matching the audience.
+
+The following example policy grants the minimum required permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "sts:GetWebIdentityToken",
+    "Resource": "*",
+    "Condition": {
+      "ForAllValues:StringEquals": {
+        "sts:IdentityTokenAudience": "${AUDIENCE}"
+      },
+      "NumericLessThanEquals": {
+        "sts:DurationSeconds": 3600
+      }
+    }
+  }]
+}
+```
+
+## Step 3: Retrieve the issuer URL
+
+Get the issuer URL from your AWS account configuration:
+
+```bash
+ISSUER_URL=$(aws iam get-outbound-web-identity-federation-info | jq -r .IssuerIdentifier)
+```
+
+The issuer URL is in the form `https://<uuid>.tokens.sts.global.api.aws`.
+
+## Step 4: Update your Aiven for Apache Kafka service
+
+Configure your Kafka service with the OIDC settings from the previous step.
+Replace `PROJECT_NAME` and `SERVICE_NAME` with your values:
+
+```bash
+avn service update --project PROJECT_NAME SERVICE_NAME \
+  -c kafka.sasl_oauthbearer_jwks_endpoint_url="${ISSUER_URL}/.well-known/jwks.json" \
+  -c kafka.sasl_oauthbearer_expected_issuer="${ISSUER_URL}" \
+  -c kafka.sasl_oauthbearer_expected_audience="${AUDIENCE}" \
+  -c kafka.sasl_oauthbearer_sub_claim_name="sub"
+```
+
+:::note
+This command triggers a rolling restart of your Apache Kafka brokers. Apply it
+during a maintenance window to minimize impact.
+:::
+
+For details on each parameter, see [OIDC parameters](/docs/products/kafka/howto/enable-oidc#oidc-parameters).
+
+## Step 5: Configure Kafka ACLs for your IAM principal
+
+The JWT issued by AWS STS contains the IAM principal ARN as the `sub` claim.
+Aiven for Apache Kafka uses this value directly as the Kafka principal, so your
+ACLs must reference the full ARN prefixed with `User:`.
+
+Use the Aiven CLI to add the required ACLs. Replace `PROJECT_NAME`, `SERVICE_NAME`,
+and the ARN with your values:
+
+```bash
+# Allow describe (required for both producers and consumers)
+avn service kafka-acl-add --project PROJECT_NAME SERVICE_NAME \
+  --permission allow \
+  --principal "User:arn:aws:iam::123456789012:user/my-iam-user" \
+  --operation Describe \
+  --resource-type topic \
+  --pattern-type literal \
+  --resource-name my-topic
+
+# Allow produce
+avn service kafka-acl-add --project PROJECT_NAME SERVICE_NAME \
+  --permission allow \
+  --principal "User:arn:aws:iam::123456789012:user/my-iam-user" \
+  --operation Write \
+  --resource-type topic \
+  --pattern-type literal \
+  --resource-name my-topic
+
+# Allow consume (topic)
+avn service kafka-acl-add --project PROJECT_NAME SERVICE_NAME \
+  --permission allow \
+  --principal "User:arn:aws:iam::123456789012:user/my-iam-user" \
+  --operation Read \
+  --resource-type topic \
+  --pattern-type literal \
+  --resource-name my-topic
+
+# Allow consume (consumer group)
+avn service kafka-acl-add --project PROJECT_NAME SERVICE_NAME \
+  --permission allow \
+  --principal "User:arn:aws:iam::123456789012:user/my-iam-user" \
+  --operation Read \
+  --resource-type group \
+  --pattern-type literal \
+  --resource-name my-consumer-group
+```
+
+To verify the ACLs are in place:
+
+```bash
+avn service kafka-acl-list --project PROJECT_NAME SERVICE_NAME
+```
+
+Expected output:
+
+```text
+ID              PERMISSION_TYPE  PRINCIPAL                                              OPERATION  RESOURCE_TYPE  PATTERN_TYPE  RESOURCE_NAME      HOST
+==============  ===============  =====================================================  =========  =============  ============  =================  ====
+acl5baf3a5cada  ALLOW            User:arn:aws:iam::123456789012:user/my-iam-user        Describe   Topic          LITERAL       my-topic           *
+acl5baf3a77c15  ALLOW            User:arn:aws:iam::123456789012:user/my-iam-user        Write      Topic          LITERAL       my-topic           *
+acl5baf3a60d8f  ALLOW            User:arn:aws:iam::123456789012:user/my-iam-user        Read       Topic          LITERAL       my-topic           *
+acl5baf3ab8316  ALLOW            User:arn:aws:iam::123456789012:user/my-iam-user        Read       Group          LITERAL       my-consumer-group  *
+```
+
+## Step 6: Configure your Kafka client
+
+Your client must request a JWT from AWS STS at runtime and use it to authenticate
+with the Kafka service via `OAUTHBEARER`.
+
+<details>
+<summary>Python example</summary>
+
+Install the required libraries:
+
+```bash
+pip install confluent-kafka boto3 PyJWT
+```
+
+Download the CA certificate for your service from the Aiven Console, then use the
+following code:
+
+```python
+from confluent_kafka import Producer, Consumer
+import boto3
+import jwt
+
+# Aiven Kafka config
+KAFKA_BOOTSTRAP = "<your-service-hostname>:<port>"
+CA_CERT_PATH = "ca.pem"  # Download from the Aiven Console
+AUDIENCE = "<your-kafka-service-hostname>"  # Must match the server-side audience setting
+
+
+def fetch_token_from_aws_sts(config):
+    """
+    Fetches a short-lived JWT from AWS STS.
+
+    Equivalent to:
+        aws sts get-web-identity-token \
+            --audience "<AUDIENCE>" \
+            --signing-algorithm RS256 \
+            --duration-seconds 3600
+    """
+    sts_client = boto3.client("sts")
+    response = sts_client.get_web_identity_token(
+        Audience=[AUDIENCE],
+        DurationSeconds=3600,
+        SigningAlgorithm="RS256",
+    )
+    token = response["WebIdentityToken"]
+    expiry = response["Expiration"].timestamp()
+    return token, expiry
+
+
+# Verify token fetch before connecting (fail fast)
+token, expiry = fetch_token_from_aws_sts(None)
+decoded = jwt.decode(token, options={"verify_signature": False})
+print(decoded)
+
+# Client config
+kafka_config = {
+    "bootstrap.servers": KAFKA_BOOTSTRAP,
+    "security.protocol": "SASL_SSL",
+    "sasl.mechanism": "OAUTHBEARER",
+    "oauth_cb": fetch_token_from_aws_sts,
+    "ssl.ca.location": CA_CERT_PATH,
+}
+
+# Producer example
+delivery_errors = []
+
+
+def delivery_callback(err, msg):
+    if err:
+        delivery_errors.append(err)
+    else:
+        print(
+            f"Message produced to {msg.topic()} [{msg.partition()}] at offset {msg.offset()}"
+        )
+
+
+producer = Producer(kafka_config)
+producer.produce("my-topic", key="key", value="hello from OIDC", callback=delivery_callback)
+if delivery_errors:
+    raise RuntimeError(f"Message delivery failed: {delivery_errors[0]}")
+producer.flush()
+
+# Consumer example
+consumer_config = {
+    **kafka_config,
+    "group.id": "my-consumer-group",
+    "auto.offset.reset": "earliest",
+}
+consumer = Consumer(consumer_config)
+consumer.subscribe(["my-topic"])
+try:
+    while True:
+        msg = consumer.poll(timeout=5.0)
+        if msg is None:
+            print("No message received.")
+            break
+        if msg.error():
+            print(f"Consumer error: {msg.error()}")
+            continue
+        print(f"Received: {msg.value().decode('utf-8')}")
+finally:
+    consumer.close()
+```
+
+</details>
+
+<details>
+<summary>Java example</summary>
+
+Implement a custom `AuthenticateCallbackHandler` that calls
+`GetWebIdentityToken` and refreshes the token before it expires.
+Pass the handler class to your Kafka client configuration:
+
+```properties
+bootstrap.servers=<your-service-hostname>:<port>
+security.protocol=SASL_SSL
+sasl.mechanism=OAUTHBEARER
+sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
+sasl.login.callback.handler.class=<your-handler-that-calls-GetWebIdentityToken-and-refreshes-the-token-before-it-expires>
+```
+
+Your handler should:
+
+1. Call the AWS SDK `StsClient.getWebIdentityToken()` with the configured audience and
+   a signing algorithm.
+2. Return the token and its expiration time.
+3. Proactively refresh the token before it expires to avoid authentication failures.
+
+</details>
+
+## Step 7 (optional): Disable other authentication mechanisms
+
+To use only OAuth 2.0/OIDC authentication, you can now disable all other
+SASL authentication mechanisms. Replace `SERVICE_NAME` with your value:
+
+```bash
+avn service update SERVICE_NAME \
+  -c "kafka_sasl_mechanisms.plain=false" \
+  -c "kafka_sasl_mechanisms.scram_sha_256=false" \
+  -c "kafka_sasl_mechanisms.scram_sha_512=false"
+```
+
+<RelatedPages/>
+
+- [Enable OAuth 2.0/OIDC authentication for Apache Kafka®](/docs/products/kafka/howto/enable-oidc)
+- [Enable and configure SASL authentication](/docs/products/kafka/howto/kafka-sasl-auth)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -703,6 +703,7 @@ const sidebars: SidebarsConfig = {
                     'products/kafka/howto/kafka-sasl-auth',
                     'products/kafka/howto/renew-ssl-certs',
                     'products/kafka/howto/enable-oidc',
+                    'products/kafka/howto/kafka-oauth2-aws-iam',
                     'products/kafka/howto/kafka-custom-serde-encrypt',
                     'products/kafka/howto/ipv6-client-connectivity',
                   ],


### PR DESCRIPTION
## Describe your changes

Add how to setup Kafka OIDC for AWS IAM principals.

You can visualise the new page here: https://jclarysse-kafka-oidc-for-aws.aiven-docs.pages.dev/docs/products/kafka/howto/kafka-oauth2-aws-iam  

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
