### PR TITLE
update: support gcp/aws/azure marketplace users subscriptions to MCP

### DIFF
--- a/src/components/CursorConfigTab/index.tsx
+++ b/src/components/CursorConfigTab/index.tsx
@@ -9,7 +9,7 @@ type CursorConfigTabProps = {
 };
 
 export default function CursorConfigTab({ baseUrl }: CursorConfigTabProps): JSX.Element {
-  const [state, setState] = useState<MCPConfigState>({ readOnly: true, scopes: [] });
+  const [state, setState] = useState<MCPConfigState>({ readOnly: true, scopes: [], marketplace: '' });
 
   const url = buildMcpUrl(baseUrl, state);
   const configJson = JSON.stringify({ mcpServers: { aiven: { type: 'http', url } } }, null, 2);
@@ -17,7 +17,7 @@ export default function CursorConfigTab({ baseUrl }: CursorConfigTabProps): JSX.
   const cursorConfig = { url, type: 'http' };
   const encodedConfig = typeof btoa !== 'undefined' ? btoa(JSON.stringify(cursorConfig)) : '';
   const deepLink = `cursor://anysphere.cursor-deeplink/mcp/install?name=aiven-mcp&config=${encodedConfig}`;
-  const cacheKey = `${state.readOnly}-${state.scopes.join(',')}`;
+  const cacheKey = `${state.readOnly}-${state.scopes.join(',')}-${state.marketplace}`;
 
   return (
     <div className={styles.container}>

--- a/src/components/MCPConfigSection/index.tsx
+++ b/src/components/MCPConfigSection/index.tsx
@@ -10,12 +10,12 @@ type MCPConfigSectionProps = {
 };
 
 export default function MCPConfigSection({ baseUrl, format, configTemplate }: MCPConfigSectionProps): JSX.Element {
-  const [state, setState] = useState<MCPConfigState>({ readOnly: true, scopes: [] });
+  const [state, setState] = useState<MCPConfigState>({ readOnly: true, scopes: [], marketplace: '' });
 
   const url = buildMcpUrl(baseUrl, state);
   const config = configTemplate(url);
   const content = format === 'json' ? JSON.stringify(config, null, 2) : config;
-  const cacheKey = `${format}-${state.readOnly}-${state.scopes.join(',')}`;
+  const cacheKey = `${format}-${state.readOnly}-${state.scopes.join(',')}-${state.marketplace}`;
 
   return (
     <div className={styles.container}>

--- a/src/components/MCPConfigToggle/index.tsx
+++ b/src/components/MCPConfigToggle/index.tsx
@@ -14,9 +14,20 @@ const SCOPE_LABELS: Record<ScopeChoice, string> = {
 
 const ALL_CHOICES: ScopeChoice[] = ['all', ...SCOPE_OPTIONS];
 
+export const MARKETPLACE_OPTIONS = ['aws', 'azure', 'gcp'] as const;
+export type Marketplace = typeof MARKETPLACE_OPTIONS[number];
+
+const MARKETPLACE_LABELS: Record<'' | Marketplace, string> = {
+  '': 'None (Aiven)',
+  aws: 'AWS Marketplace',
+  azure: 'Azure Marketplace',
+  gcp: 'Google Cloud Marketplace',
+};
+
 export type MCPConfigState = {
   readOnly: boolean;
   scopes: Scope[];
+  marketplace: '' | Marketplace;
 };
 
 type MCPConfigToggleProps = {
@@ -26,12 +37,13 @@ type MCPConfigToggleProps = {
 export default function MCPConfigToggle({ onChange }: MCPConfigToggleProps): JSX.Element {
   const [readOnly, setReadOnly] = useState(true);
   const [scopes, setScopes] = useState<Scope[]>([]);
+  const [marketplace, setMarketplace] = useState<'' | Marketplace>('');
 
   const emit = (next: MCPConfigState) => onChange?.(next);
 
   const handleReadOnly = (checked: boolean) => {
     setReadOnly(checked);
-    emit({ readOnly: checked, scopes });
+    emit({ readOnly: checked, scopes, marketplace });
   };
 
   const handleScope = (choice: ScopeChoice, checked: boolean) => {
@@ -44,7 +56,12 @@ export default function MCPConfigToggle({ onChange }: MCPConfigToggleProps): JSX
       next = scopes.filter((s) => s !== choice);
     }
     setScopes(next);
-    emit({ readOnly, scopes: next });
+    emit({ readOnly, scopes: next, marketplace });
+  };
+
+  const handleMarketplace = (value: '' | Marketplace) => {
+    setMarketplace(value);
+    emit({ readOnly, scopes, marketplace: value });
   };
 
   const isChecked = (choice: ScopeChoice): boolean =>
@@ -90,14 +107,41 @@ export default function MCPConfigToggle({ onChange }: MCPConfigToggleProps): JSX
           ))}
         </div>
       </div>
+
+      <div className={styles.separator} aria-hidden="true" />
+
+      <details className={styles.disclosure}>
+        <summary className={styles.summary}>Subscribed through a cloud marketplace?</summary>
+        <div className={styles.disclosureBody}>
+          <label className={styles.option}>
+            <span>Marketplace</span>
+            <select
+              value={marketplace}
+              onChange={(e) => handleMarketplace(e.target.value as '' | Marketplace)}
+              className={styles.select}
+            >
+              {(['', ...MARKETPLACE_OPTIONS] as const).map((value) => (
+                <option key={value} value={value}>{MARKETPLACE_LABELS[value]}</option>
+              ))}
+            </select>
+          </label>
+          <p className={styles.hint}>
+            Select your marketplace only if you subscribed to Aiven through AWS, Azure, or Google
+            Cloud Marketplace. This helps you sign in to the correct console.
+          </p>
+        </div>
+      </details>
     </div>
   );
 }
 
 export function buildMcpUrl(baseUrl: string, state: MCPConfigState): string {
+  // The marketplace tenant is a path segment (e.g. `/mcp/gcp`); scopes and read-only are
+  // query parameters.
+  const url = state.marketplace ? `${baseUrl}/${state.marketplace}` : baseUrl;
   const params = new URLSearchParams();
   if (state.scopes.length > 0) params.set('services_scope', state.scopes.join(','));
   if (state.readOnly) params.set('read_only', 'true');
   const qs = params.toString();
-  return qs ? `${baseUrl}?${qs}` : baseUrl;
+  return qs ? `${url}?${qs}` : url;
 }

--- a/src/components/MCPConfigToggle/styles.module.css
+++ b/src/components/MCPConfigToggle/styles.module.css
@@ -68,3 +68,49 @@
   color: inherit;
   text-decoration: underline;
 }
+
+.select {
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: 13px;
+  border-radius: 4px;
+  border: 1px solid var(--aiven-card-border);
+  background-color: var(--ifm-background-color);
+  color: var(--ifm-color-content);
+  font-family: var(--aiven-card-font-family);
+}
+
+/* Reset Docusaurus' default <details> theming (background, border, padding). */
+.disclosure {
+  font-size: 13px;
+  margin: 0;
+  padding: 0;
+  background: none !important;
+  background-color: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+.summary {
+  cursor: pointer;
+  list-style: revert;
+  padding: 0;
+  background: none;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ifm-color-content);
+}
+
+.disclosureBody {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.hint {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--ifm-color-content-secondary, var(--ifm-color-content));
+}


### PR DESCRIPTION
Add an AWS/Azure/Google Cloud Marketplace dropdown to the MCP install options. Selecting one appends the tenant path segment (e.g. /mcp/gcp) to the generated URL across all client tabs and the Cursor deeplink, so marketplace users authenticate against their branded console.


<img width="1035" height="430" alt="Screenshot 2026-06-17 at 14 44 09" src="https://github.com/user-attachments/assets/c7ab3d9b-ba15-4d25-901b-b537f8129f9b" />
<img width="1057" height="517" alt="Screenshot 2026-06-17 at 14 44 14" src="https://github.com/user-attachments/assets/7227d60f-650e-4d4d-862f-a680935adeed" />
