### PR TITLE
update: OS dedicated node roles GA

### DIFF
--- a/docs/products/opensearch/concepts/dedicated-node-roles.md
+++ b/docs/products/opensearch/concepts/dedicated-node-roles.md
@@ -5,11 +5,13 @@ sidebar_label: Dedicated node roles
 
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Aiven for OpenSearch® supports clusters with dedicated node roles, allowing you to assign specialized functions to different node groups for improved performance and scalability.
+Aiven for OpenSearch® supports dedicated node roles, enabling workload isolation across
+specialized node groups for optimized performance and scaling.
 
-The dedicated node roles feature is supported for Aiven for OpenSearch® version 2.19 and
-later. It's available in specific service plans for production workloads that require
-enhanced performance and reliability.
+The dedicated node roles capability is generally available (GA) for Aiven for OpenSearch®
+version 2.19 and later. The cluster topology with node roles is available for 9-node and
+15-node service plans, for production workloads that require enhanced performance and
+reliability.
 
 ## Benefits and use cases
 
@@ -165,13 +167,13 @@ The dedicated node roles feature is plan-based.
 ### Start using dedicated node roles
 
 Create an Aiven for OpenSearch® service and choose a plan that includes
-dedicated node roles. For steps, see
+dedicated node roles, available under Cluster plans. For steps, see
 [Get started with Aiven for OpenSearch®](/docs/products/opensearch/get-started#create-an-aiven-for-opensearch-service).
 
-### Configure dedicated node roles
+### Scale a cluster plan
 
 To move to another dedicated-role layout, change the service plan to a
-different eligible plan. For steps, see
+different eligible plan, available under Cluster plans. For steps, see
 [Change a service plan](/docs/platform/howto/scale-services).
 
 ### Disable dedicated node roles

--- a/docs/products/opensearch/concepts/dedicated-node-roles.md
+++ b/docs/products/opensearch/concepts/dedicated-node-roles.md
@@ -5,8 +5,7 @@ sidebar_label: Dedicated node roles
 
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Aiven for OpenSearch® supports dedicated node roles, enabling workload isolation across
-specialized node groups for optimized performance and scaling.
+Aiven for OpenSearch® supports dedicated node roles, enabling workload isolation across specialized node groups for optimized performance and scaling.
 
 The dedicated node roles capability is generally available (GA) for Aiven for OpenSearch®
 version 2.19 and later. The cluster topology with node roles is available for 9-node and

--- a/docs/products/opensearch/concepts/dedicated-node-roles.md
+++ b/docs/products/opensearch/concepts/dedicated-node-roles.md
@@ -1,23 +1,15 @@
 ---
 title: Dedicated node roles in Aiven for OpenSearch®
 sidebar_label: Dedicated node roles
-limited: true
 ---
 
 import RelatedPages from "@site/src/components/RelatedPages";
-import LimitedBadge from "@site/src/components/Badges/LimitedBadge";
 
 Aiven for OpenSearch® supports clusters with dedicated node roles, allowing you to assign specialized functions to different node groups for improved performance and scalability.
 
-The dedicated node roles feature is in
-[limited availability](/docs/platform/concepts/service-and-feature-releases#limited-availability-)
-for Aiven for OpenSearch® version 2.19 and later. It's available in specific service plans
-for production workloads that require enhanced performance and reliability.
-
-:::tip
-[Contact Aiven](https://aiven.io/contact) to request access, learn which service plans include
-dedicated node roles, and get recommendations for your workload.
-:::
+The dedicated node roles feature is supported for Aiven for OpenSearch® version 2.19 and
+later. It's available in specific service plans for production workloads that require
+enhanced performance and reliability.
 
 ## Benefits and use cases
 
@@ -167,7 +159,6 @@ The dedicated node roles feature is plan-based.
 
 ### Prerequisites
 
-- This is a <LimitedBadge/> feature. [Contact Aiven](https://aiven.io/contact) to enable it.
 - [Upgrade Aiven for OpenSearch®](/docs/products/opensearch/howto/os-version-upgrade) to
   2.19 or later if your service runs an older version.
 


### PR DESCRIPTION
https://aiven.atlassian.net/browse/MA-3935

CHANGES

- Removed "LA" labels
- Intro sentence — reworded to "supports dedicated node roles, enabling workload isolation across specialized node groups for optimized performance and scaling."
- Availability paragraph — now states the capability is "generally available (GA)" and "available for 9-node and 15-node service plans."
- Start using dedicated node roles — added "available under Cluster plans" to the plan selection sentence.
- Heading rename — "Configure dedicated node roles" → "Scale a cluster plan".
- Scale a cluster plan paragraph — added "available under Cluster plans" to the plan-change sentence.
