### PR TITLE
feat: Switch classic Kafka topic to diskless

### DIFF
--- a/docs/products/kafka/diskless/concepts/diskless-topics-architecture.md
+++ b/docs/products/kafka/diskless/concepts/diskless-topics-architecture.md
@@ -55,9 +55,6 @@ To improve performance, brokers cache recently read data. When a broker fetches 
 object, it temporarily stores the data to speed up future reads—especially within the
 same availability zone.
 
-To improve read efficiency, Aiven consolidates diskless topic data into
-Kafka-compatible log segments in tiered storage.
-
 ## Batch Coordinator and metadata
 
 The Batch Coordinator manages metadata for diskless topics. It assigns offsets to message

--- a/docs/products/kafka/diskless/concepts/diskless-topics-architecture.md
+++ b/docs/products/kafka/diskless/concepts/diskless-topics-architecture.md
@@ -55,6 +55,9 @@ To improve performance, brokers cache recently read data. When a broker fetches 
 object, it temporarily stores the data to speed up future reads—especially within the
 same availability zone.
 
+To improve read efficiency, Aiven consolidates diskless topic data into
+Kafka-compatible log segments in tiered storage.
+
 ## Batch Coordinator and metadata
 
 The Batch Coordinator manages metadata for diskless topics. It assigns offsets to message

--- a/docs/products/kafka/diskless/concepts/limitations.md
+++ b/docs/products/kafka/diskless/concepts/limitations.md
@@ -8,8 +8,10 @@ Diskless topics are compatible with Kafka APIs and clients, with some limitation
 - Transactions are not supported for produce or consume operations.
 - Compacted topics are not supported.
 - Kafka Streams state stores are not supported. Stream processing can read from diskless
-  topics but must write to classic topics.
-- Classic and tiered Kafka topics cannot be converted to diskless topics.
+  topics but writes to classic topics.
+- You cannot switch a diskless topic back to a classic topic. To switch a
+  classic topic to diskless, see
+  [Switch a classic topic to a diskless topic](/docs/products/kafka/howto/switch-topic-to-diskless).
 
 ## Internal metadata service behavior {#internal-metadata-service}
 
@@ -37,13 +39,13 @@ Aiven for PostgreSQL® service in the project. This PostgreSQL service:
 - Stores metadata required for diskless topics.
 - Appears as a separate service in the project.
 - Is created and managed automatically by Aiven.
-- Should not be configured or managed independently.
+- Do not configure or manage independently.
 
 ### Maintenance behavior
 
 Maintenance for this internal service occurs in the same maintenance window as the Kafka
-service. In the Aiven Console, references to internal components may appear during
-maintenance or upgrade flows, but they cannot be managed independently.
+service. In the Aiven Console, references to internal components can appear during
+maintenance or upgrade flows, but you cannot manage them independently.
 
 For more information about how diskless topics work, see [Diskless topics
 architecture](/docs/products/kafka/diskless/concepts/diskless-topics-architecture).

--- a/docs/products/kafka/diskless/concepts/limitations.md
+++ b/docs/products/kafka/diskless/concepts/limitations.md
@@ -8,7 +8,7 @@ Diskless topics are compatible with Kafka APIs and clients, with some limitation
 - Transactions are not supported for produce or consume operations.
 - Compacted topics are not supported.
 - Kafka Streams state stores are not supported. Stream processing can read from diskless
-  topics but writes to classic topics.
+  topics, but use classic topics for writes at this time.
 - You cannot switch a diskless topic back to a classic topic. To switch a
   classic topic to diskless, see
   [Switch a classic topic to a diskless topic](/docs/products/kafka/howto/switch-topic-to-diskless).

--- a/docs/products/kafka/howto/switch-topic-to-diskless.md
+++ b/docs/products/kafka/howto/switch-topic-to-diskless.md
@@ -10,17 +10,11 @@ import RelatedPages from "@site/src/components/RelatedPages";
 
 Switch an existing
 [classic topic](/docs/products/kafka/diskless/concepts/topics-vs-classic)
-in Aiven for Apache Kafka® to a diskless topic.
-You do not need to copy data or rename the topic. The topic remains available during the
-switch.
+in Aiven for Apache Kafka® to a diskless topic without copying data or renaming
+the topic. The topic remains available during the switch.
 
-Records written before the switch remain readable from the classic topic log,
-and new records are written to the diskless topic.
-
-Switching a topic to diskless applies only to Aiven for Apache Kafka services
-that have
-[diskless topics](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
-enabled.
+Records written before the switch remain readable from the classic topic log.
+Aiven writes new records to the diskless topic.
 
 :::note
 This feature is in
@@ -31,7 +25,8 @@ and is not enabled by default. To request access, contact your account team or
 
 ## Prerequisites
 
-- [Diskless topics](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
+- The classic-to-diskless topic switch feature and
+  [diskless topics](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
   are enabled for the service.
 - The service runs Apache Kafka® 4.1 or later.
 - [Tiered storage](/docs/products/kafka/howto/configure-topic-tiered-storage)
@@ -62,13 +57,6 @@ Before switching a topic, review the following:
 
 To switch a classic topic to a diskless topic, enable diskless for the topic using the
 Aiven CLI or Aiven API.
-
-:::note
-The topic keeps its existing tiered storage setting. Do not include
-`remote_storage_enable` in the diskless update request. If you set
-`remote_storage_enable` and `diskless_enable` in the same request, the request
-returns an error.
-:::
 
 <Tabs groupId="switch-method">
 <TabItem value="cli" label="Aiven CLI" default>
@@ -123,15 +111,15 @@ Replace the following values:
 After the update request succeeds, Aiven starts switching the topic to a
 diskless topic.
 
-## Verify the topic configuration
+## Verify the switch request
 
-Verify the topic configuration to confirm that the diskless switch request was
-accepted.
+Verify the topic configuration to confirm that Aiven accepted the diskless
+switch request.
 
 <Tabs groupId="confirm-method">
 <TabItem value="cli" label="Aiven CLI" default>
 
-This command uses `jq` to filter the output for the selected topic.
+The command uses `jq` to filter the output for the selected topic.
 
 Run the following command:
 
@@ -149,7 +137,7 @@ Replace the following values:
 
 In the output, verify that `diskless_enable` and `remote_storage_enable` are
 both set to `true`. This confirms that Aiven accepted the diskless switch
-request. Per-partition switch status or progress isn't exposed in the topic
+request. Per-partition switch status or progress is not exposed in the topic
 configuration.
 
 </TabItem>
@@ -175,7 +163,7 @@ Replace the following values:
 
 In the response, verify that `diskless_enable` and `remote_storage_enable` are
 both set to `true`. This confirms that Aiven accepted the diskless switch
-request. Per-partition switch status or progress isn't exposed in the topic
+request. Per-partition switch status or progress is not exposed in the topic
 configuration.
 
 </TabItem>
@@ -186,24 +174,38 @@ configuration.
 During the switch:
 
 - The topic remains available.
-- Producers might briefly receive retriable errors while the topic is switched.
-  Most Kafka clients retry these errors by default.
+- Producers might briefly receive errors that clients can retry.
+  Most Kafka clients retry these errors by default. If you have not changed the
+  default producer retry settings, no special tuning is usually required.
 - Consumer applications do not need changes to read records written before or
   after the switch.
 - The topic name and retention settings do not change.
-- Aiven manages the partition-level switch process. No action is required after
-  the update request succeeds.
+- Aiven manages the partition-level switch process. You do not need to take
+  action after the update request succeeds.
+
+### Producer settings
+
+If you changed any of these Kafka producer settings, verify that the values
+allow producers to retry records for at least as long as the defaults:
+
+| Producer setting | Default | Why it matters during the switch |
+| --- | --- | --- |
+| `delivery.timeout.ms` | `120000` | Allows up to 2 minutes for retrying a record. |
+| `retries` | `2147483647` | Effectively unlimited, but bounded by `delivery.timeout.ms`. |
+| `enable.idempotence` | `true` | Avoids duplicate or reordered records. |
+| `acks` | `all` | Supports `enable.idempotence` and durable failover. |
 
 ## How the switch works
 
 When you switch a topic to a diskless topic, Aiven does the following for each
 partition:
 
-1. Briefly pauses writes to the classic topic log.
-1. Waits until all records written to the classic topic log are safely
+1. Stops writing new records to the classic topic log.
+1. Waits until records written to the classic topic log are safely
    replicated.
-1. Records the offset where the diskless topic takes over.
-1. Initializes the diskless topic from that offset and routes new writes to it.
+1. Records the offset where the diskless topic starts.
+1. Initializes the diskless topic from that offset.
+1. Routes new writes to the diskless topic.
 
 Records written before the switch, including records already moved to tiered
 storage, remain readable until they expire based on the topic retention settings.

--- a/docs/products/kafka/howto/switch-topic-to-diskless.md
+++ b/docs/products/kafka/howto/switch-topic-to-diskless.md
@@ -8,8 +8,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Switch an existing [classic topic](/docs/products/kafka/diskless/concepts/topics-vs-classic) in Aiven for Apache Kafka® to a diskless topic without manually copying data or renaming the topic.
-The topic remains available during the switch.
+Switch an existing [classic topic](/docs/products/kafka/diskless/concepts/topics-vs-classic) in Aiven for Apache Kafka® to a diskless topic.
+You do not need to copy data or rename the topic. The topic remains available during the
+switch.
+
 
 Records written before the switch remain readable from the classic topic log,
 and new records are written to the diskless topic.

--- a/docs/products/kafka/howto/switch-topic-to-diskless.md
+++ b/docs/products/kafka/howto/switch-topic-to-diskless.md
@@ -1,6 +1,6 @@
 ---
 title: Switch a classic topic to a diskless topic
-sidebar_label: Switch a topic to diskless
+sidebar_label: Switch to a diskless topic
 early: true
 ---
 
@@ -8,30 +8,31 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Switch an existing classic topic in Aiven for Apache Kafka® to a diskless topic without manually copying data or renaming the topic.
+Switch an existing [classic topic](/docs/products/kafka/diskless/concepts/topics-vs-classic) in Aiven for Apache Kafka® to a diskless topic without manually copying data or renaming the topic.
 The topic remains available during the switch.
 
 Records written before the switch remain readable from the classic topic log,
-and new records are written to the diskless topic. This feature applies only to
-Aiven for Apache Kafka services that have
+and new records are written to the diskless topic.
+
+Switching a topic to diskless applies only to Aiven for Apache Kafka services
+that have
 [diskless topics](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
 enabled.
 
 :::note
-This feature is in early availability and is not enabled by default. To request
-access, contact your account team or Aiven support.
+This feature is in
+[early availability](/docs/platform/concepts/service-and-feature-releases#early-availability-)
+and is not enabled by default. To request access, contact your account team or
+[Aiven support](/docs/platform/howto/support#create-a-support-ticket).
 :::
 
 ## Prerequisites
 
-Before you switch a topic, make sure that:
-
-- Diskless topics are enabled for the service.
-- The classic-to-diskless topic switch is enabled for the service.
+- [Diskless topics](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
+  are enabled for the service.
 - The service runs Apache Kafka® 4.1 or later.
 - [Tiered storage](/docs/products/kafka/howto/configure-topic-tiered-storage) is
-  enabled for the topic. For Bring Your Own Cloud (BYOC) services with diskless
-  topics, make sure tiered storage is enabled before you switch the topic.
+  enabled for the topic before you switch it to diskless.
 - Unclean leader election is turned off for the topic. If unclean leader election
   is enabled, the switch does not start.
 - You have access to one of the following:
@@ -39,6 +40,12 @@ Before you switch a topic, make sure that:
   - [Aiven CLI](/docs/tools/cli) installed and authenticated.
   - [Aiven API token](/docs/platform/howto/create_authentication_token) for API
     requests.
+
+:::note
+Enable tiered storage before you switch the topic to diskless. Do not enable
+tiered storage and diskless in the same topic update request. This requirement
+also applies to Bring Your Own Cloud (BYOC) services with diskless topics.
+:::
 
 ## Considerations
 
@@ -49,15 +56,20 @@ Before switching a topic, review the following:
 - Diskless topic limitations apply after the switch. Review
   [Limitations of diskless topics](/docs/products/kafka/diskless/concepts/limitations)
   to confirm that diskless topics support your workload.
-- Switching a topic to diskless is currently available only with the Aiven CLI
-  or Aiven API.
 - The switch runs in the background. Internal partition-level switch state is not
   exposed in the Aiven CLI, Aiven API, or topic configuration.
 
-## Switch a topic to diskless
+## Switch a topic to a diskless topic
 
-To switch a topic, enable diskless for the topic using the Aiven CLI or Aiven
-API.
+To switch a classic topic to a diskless topic, enable diskless for the topic using the
+Aiven CLI or Aiven API.
+
+:::note
+The topic keeps its existing tiered storage setting. Do not include
+`remote_storage_enable` in the diskless update request. If you set
+`remote_storage_enable` and `diskless_enable` in the same request, the request
+returns an error.
+:::
 
 <Tabs groupId="switch-method">
 <TabItem value="cli" label="Aiven CLI" default>
@@ -76,7 +88,8 @@ Replace the following values:
 - `PROJECT_NAME`: Name of your Aiven project.
 - `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
 - `TOPIC_NAME`: Name of the topic to switch.
-- `PARTITION_COUNT`: Current number of partitions in the topic.
+- `PARTITION_COUNT`: Current number of partitions in the topic. Use the existing
+  partition count. Do not change the partition count as part of the switch.
 
 </TabItem>
 <TabItem value="api" label="Aiven API">
@@ -108,15 +121,13 @@ Replace the following values:
 </TabItem>
 </Tabs>
 
-The topic keeps its existing tiered storage setting. Do not set
-`remote_storage_enable` in the same request. If you set both properties, the
-request returns an error.
+After the update request succeeds, Aiven starts switching the topic to a
+diskless topic.
 
-After the update request succeeds, Aiven starts switching the topic to diskless.
+## Verify the topic configuration
 
-## Check the topic configuration
-
-Checking the topic configuration confirms that the switch request was accepted.
+Verify the topic configuration to confirm that the diskless switch request was
+accepted and that tiered storage remains enabled.
 
 <Tabs groupId="confirm-method">
 <TabItem value="cli" label="Aiven CLI" default>
@@ -137,7 +148,10 @@ Replace the following values:
 - `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
 - `TOPIC_NAME`: Name of the topic.
 
-In the output, verify that `diskless_enable` is set to `true`.
+In the output, verify that `diskless_enable` and `remote_storage_enable` are
+both set to `true`. This confirms that the diskless switch request was accepted.
+The partition-level switch can continue in the background and is not exposed in
+the topic configuration.
 
 </TabItem>
 <TabItem value="api" label="Aiven API">
@@ -160,7 +174,10 @@ Replace the following values:
 - `TOPIC_NAME`: Name of the topic.
 - `TOKEN`: Your Aiven API token.
 
-In the response, verify that `diskless_enable` is set to `true`.
+In the response, verify that `diskless_enable` and `remote_storage_enable` are
+both set to `true`. This confirms that the diskless switch request was accepted.
+The partition-level switch can continue in the background and is not exposed in
+the topic configuration.
 
 </TabItem>
 </Tabs>
@@ -180,10 +197,10 @@ During the switch:
 
 ## How the switch works
 
-When you switch a topic to diskless, Aiven does the following for each
+When you switch a topic to a diskless topic, Aiven does the following for each
 partition:
 
-1. Briefly stops writes to the classic topic log.
+1. Briefly pauses writes to the classic topic log.
 1. Waits until all records written to the classic topic log are safely
    replicated.
 1. Records the offset where the diskless topic takes over.
@@ -195,5 +212,6 @@ storage, remain readable until they expire based on the topic retention settings
 <RelatedPages/>
 
 - [Diskless topics](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
+- [Diskless vs. classic topics](/docs/products/kafka/diskless/concepts/topics-vs-classic)
 - [Enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage)
 - [Create Apache Kafka topics](/docs/products/kafka/howto/create-topic)

--- a/docs/products/kafka/howto/switch-topic-to-diskless.md
+++ b/docs/products/kafka/howto/switch-topic-to-diskless.md
@@ -29,8 +29,6 @@ and is not enabled by default. To request access, contact your account team or
   feature is enabled for the service. To request access, contact your account team or
   [Aiven support](/docs/platform/howto/support#create-a-support-ticket).
 - The service runs Apache Kafka® 4.1 or later.
-- Unclean leader election is turned off for the topic. If unclean leader election
-  is enabled, the switch does not start.
 - You have access to one of the following:
 
   - [Aiven CLI](/docs/tools/cli) installed and authenticated.
@@ -46,6 +44,8 @@ Before switching a topic, review the following:
 - Diskless topic limitations apply after the switch. Review
   [Limitations of diskless topics](/docs/products/kafka/diskless/concepts/limitations)
   to confirm that diskless topics support your workload.
+- Unclean leader election must be turned off for the topic. If unclean leader
+  election is enabled, the switch does not start.
 - If tiered storage is not enabled for the topic, Aiven enables it automatically
   as part of the switch. Topics that cannot have tiered storage enabled, such as
   topics with compaction configured, are not eligible for the diskless switch.
@@ -120,14 +120,11 @@ switch request.
 <Tabs groupId="confirm-method">
 <TabItem value="cli" label="Aiven CLI" default>
 
-The command uses `jq` to filter the output for the selected topic.
-
 Run the following command:
 
 ```bash
-avn service topic-list SERVICE_NAME \
-  --project PROJECT_NAME \
-  --json | jq '.[] | select(.topic_name=="TOPIC_NAME")'
+avn service topic-get SERVICE_NAME TOPIC_NAME \
+  --project PROJECT_NAME
 ```
 
 Replace the following values:
@@ -136,10 +133,10 @@ Replace the following values:
 - `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
 - `TOPIC_NAME`: Name of the topic.
 
-In the output, verify that `diskless_enable` and `remote_storage_enable` are
-both set to `true`. This confirms that Aiven accepted the diskless switch
-request. It does not confirm that every partition has finished switching.
-Per-partition switch status or progress is not exposed in the topic
+In the command output, find `diskless_enable` and `remote_storage_enable` and
+verify that their `VALUE` is `true`. This confirms that Aiven accepted the
+diskless switch request. It does not confirm that every partition has finished
+switching. Per-partition switch status or progress is not exposed in the topic
 configuration.
 
 </TabItem>

--- a/docs/products/kafka/howto/switch-topic-to-diskless.md
+++ b/docs/products/kafka/howto/switch-topic-to-diskless.md
@@ -12,7 +12,6 @@ Switch an existing [classic topic](/docs/products/kafka/diskless/concepts/topics
 You do not need to copy data or rename the topic. The topic remains available during the
 switch.
 
-
 Records written before the switch remain readable from the classic topic log,
 and new records are written to the diskless topic.
 
@@ -33,8 +32,6 @@ and is not enabled by default. To request access, contact your account team or
 - [Diskless topics](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
   are enabled for the service.
 - The service runs Apache Kafka® 4.1 or later.
-- [Tiered storage](/docs/products/kafka/howto/configure-topic-tiered-storage) is
-  enabled for the topic before you switch it to diskless.
 - Unclean leader election is turned off for the topic. If unclean leader election
   is enabled, the switch does not start.
 - You have access to one of the following:
@@ -42,12 +39,6 @@ and is not enabled by default. To request access, contact your account team or
   - [Aiven CLI](/docs/tools/cli) installed and authenticated.
   - [Aiven API token](/docs/platform/howto/create_authentication_token) for API
     requests.
-
-:::note
-Enable tiered storage before you switch the topic to diskless. Do not enable
-tiered storage and diskless in the same topic update request. This requirement
-also applies to Bring Your Own Cloud (BYOC) services with diskless topics.
-:::
 
 ## Considerations
 
@@ -129,7 +120,7 @@ diskless topic.
 ## Verify the topic configuration
 
 Verify the topic configuration to confirm that the diskless switch request was
-accepted and that tiered storage remains enabled.
+accepted.
 
 <Tabs groupId="confirm-method">
 <TabItem value="cli" label="Aiven CLI" default>

--- a/docs/products/kafka/howto/switch-topic-to-diskless.md
+++ b/docs/products/kafka/howto/switch-topic-to-diskless.md
@@ -25,12 +25,10 @@ and is not enabled by default. To request access, contact your account team or
 
 ## Prerequisites
 
-- The classic-to-diskless topic switch feature and
-  [diskless topics](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
-  are enabled for the service.
+- The [diskless topics](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
+  feature is enabled for the service. To request access, contact your account team or
+  [Aiven support](/docs/platform/howto/support#create-a-support-ticket).
 - The service runs Apache Kafka® 4.1 or later.
-- [Tiered storage](/docs/products/kafka/howto/configure-topic-tiered-storage)
-  is enabled for the topic before you switch it to diskless.
 - Unclean leader election is turned off for the topic. If unclean leader election
   is enabled, the switch does not start.
 - You have access to one of the following:
@@ -48,6 +46,9 @@ Before switching a topic, review the following:
 - Diskless topic limitations apply after the switch. Review
   [Limitations of diskless topics](/docs/products/kafka/diskless/concepts/limitations)
   to confirm that diskless topics support your workload.
+- If tiered storage is not enabled for the topic, Aiven enables it automatically
+  as part of the switch. Topics that cannot have tiered storage enabled, such as
+  topics with compaction configured, are not eligible for the diskless switch.
 - The switch runs in the background. A successful update request doesn't mean
   that every partition has finished switching. You can't view per-partition
   switch status or progress in the Aiven CLI, Aiven API, topic configuration,
@@ -191,7 +192,7 @@ allow producers to retry records for at least as long as the defaults:
 | Producer setting | Default | Why it matters during the switch |
 | --- | --- | --- |
 | `delivery.timeout.ms` | `120000` | Allows up to 2 minutes for retrying a record. |
-| `retries` | `2147483647` | Effectively unlimited, but bounded by `delivery.timeout.ms`. |
+| `retries` | `2147483647` | Effectively unlimited and bounded by `delivery.timeout.ms`. |
 | `enable.idempotence` | `true` | Avoids duplicate or reordered records. |
 | `acks` | `all` | Supports `enable.idempotence` and durable failover. |
 
@@ -201,11 +202,12 @@ When you switch a topic to a diskless topic, Aiven does the following for each
 partition:
 
 1. Stops writing new records to the classic topic log.
-1. Waits until records written to the classic topic log are safely
+1. Waits until records written to the classic topic partitions are safely
    replicated.
-1. Records the offset where the diskless topic starts.
-1. Initializes the diskless topic from that offset.
-1. Routes new writes to the diskless topic.
+1. Records the offsets where the diskless topic partitions start.
+1. Initializes the diskless topic partitions from those offsets.
+1. Routes reads and writes for those partitions through the diskless storage
+   system.
 
 Records written before the switch, including records already moved to tiered
 storage, remain readable until they expire based on the topic retention settings.

--- a/docs/products/kafka/howto/switch-topic-to-diskless.md
+++ b/docs/products/kafka/howto/switch-topic-to-diskless.md
@@ -8,7 +8,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Switch an existing [classic topic](/docs/products/kafka/diskless/concepts/topics-vs-classic) in Aiven for Apache Kafka® to a diskless topic.
+Switch an existing
+[classic topic](/docs/products/kafka/diskless/concepts/topics-vs-classic)
+in Aiven for Apache Kafka® to a diskless topic.
 You do not need to copy data or rename the topic. The topic remains available during the
 switch.
 
@@ -44,13 +46,15 @@ and is not enabled by default. To request access, contact your account team or
 
 Before switching a topic, review the following:
 
-- The switch is one-way. You cannot switch a diskless topic back to a classic
-  topic.
+- The switch is one-way. You can't switch a diskless topic back to a classic
+  topic. This might change in a future release.
 - Diskless topic limitations apply after the switch. Review
   [Limitations of diskless topics](/docs/products/kafka/diskless/concepts/limitations)
   to confirm that diskless topics support your workload.
-- The switch runs in the background. Internal partition-level switch state is not
-  exposed in the Aiven CLI, Aiven API, or topic configuration.
+- The switch runs in the background. A successful update request doesn't mean
+  that every partition has finished switching. You can't view per-partition
+  switch status or progress in the Aiven CLI, Aiven API, topic configuration,
+  or customer-facing metrics integrations.
 
 ## Switch a topic to a diskless topic
 
@@ -142,9 +146,9 @@ Replace the following values:
 - `TOPIC_NAME`: Name of the topic.
 
 In the output, verify that `diskless_enable` and `remote_storage_enable` are
-both set to `true`. This confirms that the diskless switch request was accepted.
-The partition-level switch can continue in the background and is not exposed in
-the topic configuration.
+both set to `true`. This confirms that Aiven accepted the diskless switch
+request. Per-partition switch status or progress isn't exposed in the topic
+configuration.
 
 </TabItem>
 <TabItem value="api" label="Aiven API">
@@ -168,9 +172,9 @@ Replace the following values:
 - `TOKEN`: Your Aiven API token.
 
 In the response, verify that `diskless_enable` and `remote_storage_enable` are
-both set to `true`. This confirms that the diskless switch request was accepted.
-The partition-level switch can continue in the background and is not exposed in
-the topic configuration.
+both set to `true`. This confirms that Aiven accepted the diskless switch
+request. Per-partition switch status or progress isn't exposed in the topic
+configuration.
 
 </TabItem>
 </Tabs>

--- a/docs/products/kafka/howto/switch-topic-to-diskless.md
+++ b/docs/products/kafka/howto/switch-topic-to-diskless.md
@@ -75,8 +75,6 @@ Replace the following values:
 - `PROJECT_NAME`: Name of your Aiven project.
 - `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
 - `TOPIC_NAME`: Name of the topic to switch.
-- `PARTITION_COUNT`: Current number of partitions in the topic. Use the existing
-  partition count. Do not change the partition count as part of the switch.
 
 </TabItem>
 <TabItem value="api" label="Aiven API">

--- a/docs/products/kafka/howto/switch-topic-to-diskless.md
+++ b/docs/products/kafka/howto/switch-topic-to-diskless.md
@@ -1,0 +1,170 @@
+---
+title: Switch a classic topic to a diskless topic
+sidebar_label: Switch a topic to diskless
+early: true
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Switch an existing classic topic in Aiven for Apache Kafka® to a diskless topic without manually copying data or renaming the topic.
+The topic remains available during the switch.
+
+Records written before the switch remain readable from the classic topic log,
+and new records are written to the diskless topic.
+This feature applies only to Aiven for Apache Kafka services that have
+[diskless topics](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
+enabled.
+
+## Prerequisites
+
+Before you switch a topic, make sure that:
+
+- Diskless topics are enabled for the service.
+- [Tiered storage](/docs/products/kafka/howto/configure-topic-tiered-storage) is
+  enabled for the topic.
+- Unclean leader election is turned off for the topic.
+- You have access to one of the following:
+  - [Aiven CLI](/docs/tools/cli) installed and authenticated.
+  - [Aiven API token](/docs/platform/howto/create_authentication_token) for API
+    requests.
+
+## Considerations
+
+Before switching a topic, review the following:
+
+- The switch is one-way. You cannot switch a diskless topic back to a classic
+  topic.
+- Diskless topic limitations apply after the switch. Review
+  [Limitations of diskless topics](/docs/products/kafka/diskless/concepts/limitations)
+  to confirm that diskless topics support your workload.
+
+## Switch a topic to diskless
+
+To switch a topic, enable diskless for the topic by setting `diskless_enable=true`.
+Use the Aiven CLI or Aiven API to switch a topic. This action is not available
+in the Aiven Console.
+
+<Tabs groupId="switch-method">
+<TabItem value="cli" label="Aiven CLI" default>
+
+Run the following command:
+
+```bash
+avn service topic-update SERVICE_NAME TOPIC_NAME \
+  --project PROJECT_NAME \
+  --config diskless_enable=true
+```
+
+Replace the following values:
+
+- `PROJECT_NAME`: Name of your Aiven project.
+- `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
+- `TOPIC_NAME`: Name of the topic to switch.
+
+</TabItem>
+<TabItem value="api" label="Aiven API">
+
+Send a request to update the topic configuration:
+
+```bash
+API_URL="https://api.aiven.io/v1/project/PROJECT_NAME/service"
+API_URL="${API_URL}/SERVICE_NAME/topic/TOPIC_NAME"
+
+curl --request PUT \
+  --url "${API_URL}" \
+  --header "Authorization: Bearer TOKEN" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "config": {
+      "diskless_enable": true
+    }
+  }'
+```
+
+Replace the following values:
+
+- `PROJECT_NAME`: Name of your Aiven project.
+- `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
+- `TOPIC_NAME`: Name of the topic to switch.
+- `TOKEN`: Your Aiven API token.
+
+</TabItem>
+</Tabs>
+
+The topic keeps its existing tiered storage setting. Do not set
+`remote_storage_enable` in the same request. If you set both properties, the
+request returns an error.
+
+After the update request succeeds, Aiven starts switching each partition in the
+topic.
+
+## Check the topic configuration
+
+The switch runs asynchronously and completes independently for each partition.
+Checking the topic configuration confirms that the switch request was accepted.
+
+<Tabs groupId="confirm-method">
+<TabItem value="cli" label="Aiven CLI" default>
+
+Run the following command:
+
+```bash
+avn service topic-get SERVICE_NAME TOPIC_NAME \
+  --project PROJECT_NAME
+```
+
+In the output, verify that `diskless_enable` is set to `true`.
+
+</TabItem>
+<TabItem value="api" label="Aiven API">
+
+Send a request to get the topic configuration:
+
+```bash
+API_URL="https://api.aiven.io/v1/project/PROJECT_NAME/service"
+API_URL="${API_URL}/SERVICE_NAME/topic/TOPIC_NAME"
+
+curl --request GET \
+  --url "${API_URL}" \
+  --header "Authorization: Bearer TOKEN"
+```
+
+In the response, verify that `diskless_enable` is set to `true`.
+
+</TabItem>
+</Tabs>
+
+## What to expect during the switch
+
+During the switch:
+
+- The topic remains available.
+- Producers might briefly receive retriable errors while each partition is
+  switched, such as `NOT_LEADER_FOR_PARTITION` or request timeouts. Most Kafka
+  clients retry these errors by default.
+- Consumer applications do not need changes to read records written before or
+  after the switch.
+- The topic name and retention settings do not change.
+- Partitions switch independently, so some partitions might finish before others.
+
+## How the switch works
+
+When you switch a topic to diskless, Aiven does the following for each
+partition:
+
+1. Briefly stops writes to the classic topic log.
+1. Waits until all records written to the classic topic log are safely
+   replicated.
+1. Records the offset where the diskless topic takes over.
+1. Initializes the diskless topic from that offset and routes new writes to it.
+
+Records written before the switch, including records already moved to tiered
+storage, remain readable until they expire based on the topic retention settings.
+
+<RelatedPages/>
+
+- [Diskless topics](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
+- [Enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage)
+- [Create Apache Kafka topics](/docs/products/kafka/howto/create-topic)

--- a/docs/products/kafka/howto/switch-topic-to-diskless.md
+++ b/docs/products/kafka/howto/switch-topic-to-diskless.md
@@ -67,7 +67,6 @@ Run the following command:
 ```bash
 avn service topic-update SERVICE_NAME TOPIC_NAME \
   --project PROJECT_NAME \
-  --partitions PARTITION_COUNT \
   --diskless-enable
 ```
 

--- a/docs/products/kafka/howto/switch-topic-to-diskless.md
+++ b/docs/products/kafka/howto/switch-topic-to-diskless.md
@@ -138,7 +138,8 @@ Replace the following values:
 
 In the output, verify that `diskless_enable` and `remote_storage_enable` are
 both set to `true`. This confirms that Aiven accepted the diskless switch
-request. Per-partition switch status or progress is not exposed in the topic
+request. It does not confirm that every partition has finished switching.
+Per-partition switch status or progress is not exposed in the topic
 configuration.
 
 </TabItem>

--- a/docs/products/kafka/howto/switch-topic-to-diskless.md
+++ b/docs/products/kafka/howto/switch-topic-to-diskless.md
@@ -12,20 +12,30 @@ Switch an existing classic topic in Aiven for Apache Kafka® to a diskless topic
 The topic remains available during the switch.
 
 Records written before the switch remain readable from the classic topic log,
-and new records are written to the diskless topic.
-This feature applies only to Aiven for Apache Kafka services that have
+and new records are written to the diskless topic. This feature applies only to
+Aiven for Apache Kafka services that have
 [diskless topics](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
 enabled.
+
+:::note
+This feature is in early availability and is not enabled by default. To request
+access, contact your account team or Aiven support.
+:::
 
 ## Prerequisites
 
 Before you switch a topic, make sure that:
 
 - Diskless topics are enabled for the service.
+- The classic-to-diskless topic switch is enabled for the service.
+- The service runs Apache Kafka® 4.1 or later.
 - [Tiered storage](/docs/products/kafka/howto/configure-topic-tiered-storage) is
-  enabled for the topic.
-- Unclean leader election is turned off for the topic.
+  enabled for the topic. For Bring Your Own Cloud (BYOC) services with diskless
+  topics, make sure tiered storage is enabled before you switch the topic.
+- Unclean leader election is turned off for the topic. If unclean leader election
+  is enabled, the switch does not start.
 - You have access to one of the following:
+
   - [Aiven CLI](/docs/tools/cli) installed and authenticated.
   - [Aiven API token](/docs/platform/howto/create_authentication_token) for API
     requests.
@@ -39,12 +49,15 @@ Before switching a topic, review the following:
 - Diskless topic limitations apply after the switch. Review
   [Limitations of diskless topics](/docs/products/kafka/diskless/concepts/limitations)
   to confirm that diskless topics support your workload.
+- Switching a topic to diskless is currently available only with the Aiven CLI
+  or Aiven API.
+- The switch runs in the background. Internal partition-level switch state is not
+  exposed in the Aiven CLI, Aiven API, or topic configuration.
 
 ## Switch a topic to diskless
 
-To switch a topic, enable diskless for the topic by setting `diskless_enable=true`.
-Use the Aiven CLI or Aiven API to switch a topic. This action is not available
-in the Aiven Console.
+To switch a topic, enable diskless for the topic using the Aiven CLI or Aiven
+API.
 
 <Tabs groupId="switch-method">
 <TabItem value="cli" label="Aiven CLI" default>
@@ -54,7 +67,8 @@ Run the following command:
 ```bash
 avn service topic-update SERVICE_NAME TOPIC_NAME \
   --project PROJECT_NAME \
-  --config diskless_enable=true
+  --partitions PARTITION_COUNT \
+  --diskless-enable
 ```
 
 Replace the following values:
@@ -62,6 +76,7 @@ Replace the following values:
 - `PROJECT_NAME`: Name of your Aiven project.
 - `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
 - `TOPIC_NAME`: Name of the topic to switch.
+- `PARTITION_COUNT`: Current number of partitions in the topic.
 
 </TabItem>
 <TabItem value="api" label="Aiven API">
@@ -97,23 +112,30 @@ The topic keeps its existing tiered storage setting. Do not set
 `remote_storage_enable` in the same request. If you set both properties, the
 request returns an error.
 
-After the update request succeeds, Aiven starts switching each partition in the
-topic.
+After the update request succeeds, Aiven starts switching the topic to diskless.
 
 ## Check the topic configuration
 
-The switch runs asynchronously and completes independently for each partition.
 Checking the topic configuration confirms that the switch request was accepted.
 
 <Tabs groupId="confirm-method">
 <TabItem value="cli" label="Aiven CLI" default>
 
+This command uses `jq` to filter the output for the selected topic.
+
 Run the following command:
 
 ```bash
-avn service topic-get SERVICE_NAME TOPIC_NAME \
-  --project PROJECT_NAME
+avn service topic-list SERVICE_NAME \
+  --project PROJECT_NAME \
+  --json | jq '.[] | select(.topic_name=="TOPIC_NAME")'
 ```
+
+Replace the following values:
+
+- `PROJECT_NAME`: Name of your Aiven project.
+- `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
+- `TOPIC_NAME`: Name of the topic.
 
 In the output, verify that `diskless_enable` is set to `true`.
 
@@ -131,6 +153,13 @@ curl --request GET \
   --header "Authorization: Bearer TOKEN"
 ```
 
+Replace the following values:
+
+- `PROJECT_NAME`: Name of your Aiven project.
+- `SERVICE_NAME`: Name of your Aiven for Apache Kafka service.
+- `TOPIC_NAME`: Name of the topic.
+- `TOKEN`: Your Aiven API token.
+
 In the response, verify that `diskless_enable` is set to `true`.
 
 </TabItem>
@@ -141,13 +170,13 @@ In the response, verify that `diskless_enable` is set to `true`.
 During the switch:
 
 - The topic remains available.
-- Producers might briefly receive retriable errors while each partition is
-  switched, such as `NOT_LEADER_FOR_PARTITION` or request timeouts. Most Kafka
-  clients retry these errors by default.
+- Producers might briefly receive retriable errors while the topic is switched.
+  Most Kafka clients retry these errors by default.
 - Consumer applications do not need changes to read records written before or
   after the switch.
 - The topic name and retention settings do not change.
-- Partitions switch independently, so some partitions might finish before others.
+- Aiven manages the partition-level switch process. No action is required after
+  the update request succeeds.
 
 ## How the switch works
 

--- a/docs/products/kafka/howto/switch-topic-to-diskless.md
+++ b/docs/products/kafka/howto/switch-topic-to-diskless.md
@@ -34,6 +34,8 @@ and is not enabled by default. To request access, contact your account team or
 - [Diskless topics](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
   are enabled for the service.
 - The service runs Apache Kafka® 4.1 or later.
+- [Tiered storage](/docs/products/kafka/howto/configure-topic-tiered-storage)
+  is enabled for the topic before you switch it to diskless.
 - Unclean leader election is turned off for the topic. If unclean leader election
   is enabled, the switch does not start.
 - You have access to one of the following:

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -748,6 +748,7 @@ const sidebars: SidebarsConfig = {
                     'products/kafka/howto/create-topic',
                     'products/kafka/howto/create-topics-automatically',
                     'products/kafka/howto/get-topic-partition-details',
+                    'products/kafka/howto/switch-topic-to-diskless',
                     'products/kafka/howto/schema-registry',
                     {
                       type: 'category',


### PR DESCRIPTION
## Describe your changes

Add docs for switching an existing Aiven for Apache Kafka classic topic to a diskless topic, including prerequisites, CLI/API steps, and expected behavior

https://aiven.atlassian.net/browse/KC-79

Preview:  https://kc-79-docs-for-topic-type-sw.aiven-docs.pages.dev/docs/products/kafka/howto/switch-topic-to-diskless

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
