### PR TITLE
feat: Kafka audit logging docs

### DIFF
--- a/docs/products/kafka/concepts/audit-logging.md
+++ b/docs/products/kafka/concepts/audit-logging.md
@@ -4,77 +4,73 @@ sidebar_label: Audit logging
 early: true
 ---
 
-Audit logging for Aiven for Apache Kafka® records Kafka client activity on your
-service, including which authenticated Kafka users connected and which Kafka operations
-were allowed or denied during a configured time period.
+Audit logging for Aiven for Apache Kafka® records authenticated Kafka client activity on your service.
+Audit logs show which Kafka users were active and can show which Kafka operations
+were allowed or denied, depending on your audit logging settings.
 
 Use audit logs to support security reviews and compliance workflows.
 
 ## How audit logging works
 
-When a Kafka client connects to your Aiven for Apache Kafka service, Aiven checks each
-requested operation and records whether it is allowed or denied. Audit logging writes
-the results to the service logs with the `AUDIT:` prefix.
+After a Kafka client authenticates with your Aiven for Apache Kafka service, Aiven
+checks requested operations and records whether they are allowed or denied. Audit
+logging writes entries to the service logs with the `AUDIT:` prefix.
 
-Each audit entry identifies the Kafka user, also called a principal, that connected.
-In audit logs, the principal is the Kafka user account that a client authenticates
-with, for example `User:avnadmin`.
+Each audit entry identifies the Kafka user, also called a principal. In audit logs,
+the principal is the Kafka user account that a client authenticates with, for example
+`User:avnadmin`.
+
+Audit logging writes entries to the service logs at regular intervals, based on the
+configured aggregation period. Each entry shows the first time activity was detected
+for a Kafka user during that period.
 
 Audit logging supports any authentication method and does not require additional
-access control list (ACL) setup. To enable it, see
+access control list (ACL) setup.
+
+You can configure audit logging to:
+
+- Record Kafka operations, such as read or write requests, or record only that a Kafka
+  user was active.
+- Include or exclude denied authorization attempts.
+- Group entries by Kafka user or by Kafka user and source IP address.
+- Change how often audit entries are written to the service logs.
+
+To enable and configure audit logging, see
 [Configure audit logging for Aiven for Apache Kafka®](/docs/products/kafka/howto/configure-audit-logging).
 
-## What audit logging records
+## Audit log examples
 
-Audit logging supports two record types. Use the `record_type` setting to choose how
-much detail to include. Aiven writes audit entries to the service logs at the end of
-each aggregation period.
-
-- **`user_operations`** (default): Records each Kafka user's activity and the distinct
-  Kafka operations performed during the aggregation period, such as produce, fetch,
-  and configuration changes. If the same operation on the same resource occurs
-  multiple times during the period, it appears once in the audit entry.
-- **`user_activity`**: Records only that a Kafka user was active during the aggregation
-  period. It does not list the operations performed. Use it when you need less
-  detailed logs that show which users were active, but not what they did.
-
-A `user_operations` entry lists the Kafka user, the source IP address, when the user
-first became active in the aggregation period, and each operation performed with its
-result:
+A `user_operations` entry lists the Kafka user, source IP address, when the user first
+became active in the aggregation period, and each operation with its result:
 
 ```text
-AUDIT: User:alice (192.168.1.10) was active since 2024-01-15T10:00:00Z: Allow WRITE on TOPIC:orders, Allow READ on GROUP:my-consumer
+[2024-07-29 11:02:27,861] AUDIT: User:alice (/192.0.2.10) was active since 2024-07-29T10:57:28.048485122Z: Allow WRITE on TOPIC:orders, Allow READ on GROUP:order-consumers
 ```
 
-A `user_activity` entry includes only the Kafka user, source IP address, and the time
-the user first became active in the aggregation period:
+A `user_activity` entry includes only the Kafka user, source IP address, and when the
+user first became active:
 
 ```text
-AUDIT: User:alice (192.168.1.10) was active since 2024-01-15T10:00:00Z.
+[2024-07-29 11:02:27,861] AUDIT: User:alice (/192.0.2.10) was active since 2024-07-29T10:57:28.048485122Z.
 ```
-
-Other audit log settings control whether denied authorization attempts are included,
-how entries are grouped, and how often entries are written to the service logs. To
-configure these settings, see
-[Configure audit logging for Aiven for Apache Kafka®](/docs/products/kafka/howto/configure-audit-logging).
 
 ## Limitations
 
-Review these limitations before you rely on audit logs:
+When using audit logs, note these limitations:
 
 - **Audit entries do not include exact operation times.** Audit logging groups
   activity over an aggregation period, so an entry's timestamp is not the exact time
   of an individual operation.
-- **Actions made with Aiven tools are not attributed to individual Aiven accounts.**
+- **Kafka audit logs do not show which Aiven account made changes using Aiven tools.**
   Kafka audit logs record only Kafka client activity. Operations performed in the
   Aiven Console, Aiven CLI, Aiven API, Aiven Provider for Terraform, or Kubernetes
   operator appear under an internal Aiven service account, not the individual Aiven
   account. This includes topic creation and deletion. To find who performed an
-  operation, use the [project event log](/docs/platform/howto/manage-project-audit-logs).
+  operation, use the [project event log](/docs/platform/howto/view-project-logs).
 
 ## Related pages
 
 - [Configure audit logging for Aiven for Apache Kafka®](/docs/products/kafka/howto/configure-audit-logging)
 - [Advanced parameters for Aiven for Apache Kafka®](/docs/products/kafka/reference/advanced-params)
 - [Integrate service logs into an Apache Kafka® topic](/docs/products/kafka/howto/integrate-service-logs-into-kafka-topic)
-- [Manage project audit logs](/docs/platform/howto/manage-project-audit-logs)
+- [View project logs](/docs/platform/howto/view-project-logs)

--- a/docs/products/kafka/concepts/audit-logging.md
+++ b/docs/products/kafka/concepts/audit-logging.md
@@ -1,7 +1,6 @@
 ---
 title: Audit logging for Aiven for Apache Kafka®
 sidebar_label: Audit logging
-early: true
 ---
 
 Audit logging for Aiven for Apache Kafka® records Kafka client activity on your service, including authenticated activity and unauthenticated access attempts.

--- a/docs/products/kafka/concepts/audit-logging.md
+++ b/docs/products/kafka/concepts/audit-logging.md
@@ -3,9 +3,9 @@ title: Audit logging for Aiven for Apache Kafka®
 sidebar_label: Audit logging
 ---
 
-Audit logging for Aiven for Apache Kafka® records Kafka client activity on your service, including authenticated activity and unauthenticated access attempts.
+Audit logging for Aiven for Apache Kafka® records Kafka client activity on your service.
 Audit logs show which Kafka users were active and can show which Kafka operations
-were allowed or denied, depending on your audit logging settings.
+were allowed or denied during a configured time period.
 
 Use audit logs to support security reviews and compliance workflows.
 

--- a/docs/products/kafka/concepts/audit-logging.md
+++ b/docs/products/kafka/concepts/audit-logging.md
@@ -1,0 +1,80 @@
+---
+title: Audit logging for Aiven for Apache Kafka®
+sidebar_label: Audit logging
+early: true
+---
+
+Audit logging for Aiven for Apache Kafka® records Kafka client activity on your
+service, including which authenticated Kafka users connected and which Kafka operations
+were allowed or denied during a configured time period.
+
+Use audit logs to support security reviews and compliance workflows.
+
+## How audit logging works
+
+When a Kafka client connects to your Aiven for Apache Kafka service, Aiven checks each
+requested operation and records whether it is allowed or denied. Audit logging writes
+the results to the service logs with the `AUDIT:` prefix.
+
+Each audit entry identifies the Kafka user, also called a principal, that connected.
+In audit logs, the principal is the Kafka user account that a client authenticates
+with, for example `User:avnadmin`.
+
+Audit logging supports any authentication method and does not require additional
+access control list (ACL) setup. To enable it, see
+[Configure audit logging for Aiven for Apache Kafka®](/docs/products/kafka/howto/configure-audit-logging).
+
+## What audit logging records
+
+Audit logging supports two record types. Use the `record_type` setting to choose how
+much detail to include. Aiven writes audit entries to the service logs at the end of
+each aggregation period.
+
+- **`user_operations`** (default): Records each Kafka user's activity and the distinct
+  Kafka operations performed during the aggregation period, such as produce, fetch,
+  and configuration changes. If the same operation on the same resource occurs
+  multiple times during the period, it appears once in the audit entry.
+- **`user_activity`**: Records only that a Kafka user was active during the aggregation
+  period. It does not list the operations performed. Use it when you need less
+  detailed logs that show which users were active, but not what they did.
+
+A `user_operations` entry lists the Kafka user, the source IP address, when the user
+first became active in the aggregation period, and each operation performed with its
+result:
+
+```text
+AUDIT: User:alice (192.168.1.10) was active since 2024-01-15T10:00:00Z: Allow WRITE on TOPIC:orders, Allow READ on GROUP:my-consumer
+```
+
+A `user_activity` entry includes only the Kafka user, source IP address, and the time
+the user first became active in the aggregation period:
+
+```text
+AUDIT: User:alice (192.168.1.10) was active since 2024-01-15T10:00:00Z.
+```
+
+Other audit log settings control whether denied authorization attempts are included,
+how entries are grouped, and how often entries are written to the service logs. To
+configure these settings, see
+[Configure audit logging for Aiven for Apache Kafka®](/docs/products/kafka/howto/configure-audit-logging).
+
+## Limitations
+
+Review these limitations before you rely on audit logs:
+
+- **Audit entries do not include exact operation times.** Audit logging groups
+  activity over an aggregation period, so an entry's timestamp is not the exact time
+  of an individual operation.
+- **Actions made with Aiven tools are not attributed to individual Aiven accounts.**
+  Kafka audit logs record only Kafka client activity. Operations performed in the
+  Aiven Console, Aiven CLI, Aiven API, Aiven Provider for Terraform, or Kubernetes
+  operator appear under an internal Aiven service account, not the individual Aiven
+  account. This includes topic creation and deletion. To find who performed an
+  operation, use the [project event log](/docs/platform/howto/manage-project-audit-logs).
+
+## Related pages
+
+- [Configure audit logging for Aiven for Apache Kafka®](/docs/products/kafka/howto/configure-audit-logging)
+- [Advanced parameters for Aiven for Apache Kafka®](/docs/products/kafka/reference/advanced-params)
+- [Integrate service logs into an Apache Kafka® topic](/docs/products/kafka/howto/integrate-service-logs-into-kafka-topic)
+- [Manage project audit logs](/docs/platform/howto/manage-project-audit-logs)

--- a/docs/products/kafka/concepts/audit-logging.md
+++ b/docs/products/kafka/concepts/audit-logging.md
@@ -4,7 +4,7 @@ sidebar_label: Audit logging
 early: true
 ---
 
-Audit logging for Aiven for Apache Kafka® records authenticated Kafka client activity on your service.
+Audit logging for Aiven for Apache Kafka® records Kafka client activity on your service, including authenticated activity and unauthenticated access attempts.
 Audit logs show which Kafka users were active and can show which Kafka operations
 were allowed or denied, depending on your audit logging settings.
 
@@ -18,7 +18,12 @@ logging writes entries to the service logs with the `AUDIT:` prefix.
 
 Each audit entry identifies the Kafka user, also called a principal. In audit logs,
 the principal is the Kafka user account that a client authenticates with, for example
-`User:avnadmin`.
+`User:avnadmin`, the default principal in Aiven.
+
+Audit logs also include internal client activity on your service. Some internal
+activity is authenticated, for example `User:karapace_sr`, the principal used by
+Karapace Schema Registry for accessing the `_schemas` topic. Other activity can be
+unauthenticated and appear as `User:ANONYMOUS`.
 
 Audit logging writes entries to the service logs at regular intervals, based on the
 configured aggregation period. Each entry shows the first time activity was detected
@@ -64,7 +69,7 @@ When using audit logs, note these limitations:
 - **Kafka audit logs do not show which Aiven account made changes using Aiven tools.**
   Kafka audit logs record only Kafka client activity. Operations performed in the
   Aiven Console, Aiven CLI, Aiven API, Aiven Provider for Terraform, or Kubernetes
-  operator appear under an internal Aiven service account, not the individual Aiven
+  operator can appear under an internal Aiven service account, not the individual Aiven
   account. This includes topic creation and deletion. To find who performed an
   operation, use the [project event log](/docs/platform/howto/view-project-logs).
 

--- a/docs/products/kafka/howto/configure-audit-logging.md
+++ b/docs/products/kafka/howto/configure-audit-logging.md
@@ -10,7 +10,7 @@ import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import ConsoleIcon from "@site/src/components/ConsoleIcons";
 
 Turn audit logging on for your Aiven for Apache Kafka® service, change what it records,
-and control how many log entries it produces.
+and manage audit log volume.
 
 For what audit logging captures and its limitations, see
 [Audit logging for Aiven for Apache Kafka®](/docs/products/kafka/concepts/audit-logging).
@@ -34,23 +34,20 @@ To configure audit logging, you need one of the following
 
 The `developer` and `read_only` roles cannot configure audit logging.
 
-## Configuration options
+## Audit logging settings
 
-You configure audit logging with the `kafka.audit_log` settings. How you refer to each
-setting depends on the method:
+Use these advanced configuration settings to customize audit logging. To record
+detailed operation entries, add `kafka.audit_log.record_type` and set it to
+`user_operations`.
 
-- In the **Aiven Console** and **Aiven CLI**, use the full name, such as
-  `kafka.audit_log.record_type`.
-- In the **Aiven API** and **Terraform**, set each option as a field inside the
-  `audit_log` object.
-
-The following options are available. When audit logging is enabled, unset options use
-their default values.
+In the service configuration, add these settings under `kafka.audit_log`, for example
+`kafka.audit_log.record_type`. For the exact syntax for each method, see
+[Enable audit logging](#enable-audit-logging).
 
 <table>
   <thead>
     <tr>
-      <th>Option</th>
+      <th>Setting</th>
       <th>Type</th>
       <th>Default</th>
       <th>Description</th>
@@ -63,8 +60,8 @@ their default values.
       <td><code>user_operations</code></td>
       <td>
         The type of activity to record. Use <code>user_operations</code> for detailed
-        operation logs, or <code>user_activity</code> to record only that a Kafka user
-        was active.
+        operation entries, or <code>user_activity</code> to record only that a Kafka
+        user was active.
       </td>
     </tr>
     <tr>
@@ -72,7 +69,7 @@ their default values.
       <td>integer</td>
       <td><code>300</code></td>
       <td>
-        How long, in seconds, to group entries before writing them to the log. A
+        How long, in seconds, to group entries before writing them to the service logs. A
         higher value produces fewer, larger entries. Accepts a value from 1 to 1800.
       </td>
     </tr>
@@ -81,7 +78,8 @@ their default values.
       <td>boolean</td>
       <td><code>false</code></td>
       <td>
-        Whether to include denied authorization attempts in audit log entries.
+        Whether to include denied authorization attempts in audit log entries. When
+        false, audit log entries include only allowed operations.
       </td>
     </tr>
     <tr>
@@ -99,9 +97,8 @@ their default values.
 
 ## Enable audit logging
 
-Audit logging turns on when the `kafka.audit_log` settings are present. To enable it
-with default settings, add at least one option, such as `record_type`. The other
-options then use their defaults.
+To enable audit logging, add at least one `kafka.audit_log` setting to your service
+configuration. Any setting you add must have a valid value.
 
 <Tabs groupId="enable-methods">
 <TabItem value="console" label="Aiven Console" default>
@@ -111,15 +108,15 @@ options then use their defaults.
 1. Click <ConsoleLabel name="service settings"/>.
 1. In the **Advanced configuration** section, click **Configure**.
 1. Click <ConsoleIcon name="Add config options"/> and enter `audit` to find the audit
-   logging options.
-1. Add each option you want, then set its value. For example, add
-   `kafka.audit_log.record_type` and select `user_operations`.
+   logging settings.
+1. Add `kafka.audit_log.record_type` and select `user_operations`.
+1. Optional: Add other audit logging settings and set their values.
 1. Click **Save configuration**.
 
 </TabItem>
 <TabItem value="cli" label="Aiven CLI">
 
-Set the options with the [`avn service update`](/docs/tools/cli/service-cli) command
+Set these settings with the [`avn service update`](/docs/tools/cli/service-cli) command
 and the `-c` flag:
 
 ```bash
@@ -159,6 +156,9 @@ curl -s -X PUT \
   }'
 ```
 
+Replace `PROJECT_NAME`, `SERVICE_NAME`, and `TOKEN` with your project name, service
+name, and authentication token.
+
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 
@@ -190,9 +190,14 @@ resource "aiven_kafka" "example_kafka" {
 
 ## Change audit logging settings
 
-To change what audit logging records, set new values for the `kafka.audit_log` options
+To change what audit logging records, set new values for the `kafka.audit_log` settings
 with any of the preceding methods. Services that already use audit logging keep their
 current settings until you change them.
+
+:::important
+You cannot remove audit logging settings or turn off audit logging yourself. To turn
+off audit logging, [contact Aiven support](/docs/platform/howto/support).
+:::
 
 ## View audit logs
 

--- a/docs/products/kafka/howto/configure-audit-logging.md
+++ b/docs/products/kafka/howto/configure-audit-logging.md
@@ -1,13 +1,11 @@
 ---
 title: Configure audit logging for Aiven for Apache Kafka®
 sidebar_label: Configure audit logging
-early: true
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
-import ConsoleIcon from "@site/src/components/ConsoleIcons";
 
 Turn audit logging on for your Aiven for Apache Kafka® service, change what it records, and manage audit log volume.
 
@@ -51,7 +49,7 @@ configuration. Any setting you add must have a valid value.
    service.
 1. Click <ConsoleLabel name="service settings"/>.
 1. In the **Advanced configuration** section, click **Configure**.
-1. Click <ConsoleIcon name="Add config options"/> and enter `audit` to find the audit
+1. Click <ConsoleLabel name="Add config options"/> and enter `audit` to find the audit
    logging settings.
 1. Add `kafka.audit_log.record_type` and select `user_operations`.
 1. Optional: Add other audit logging settings and set their values.

--- a/docs/products/kafka/howto/configure-audit-logging.md
+++ b/docs/products/kafka/howto/configure-audit-logging.md
@@ -1,0 +1,231 @@
+---
+title: Configure audit logging for Aiven for Apache Kafka®
+sidebar_label: Configure audit logging
+early: true
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import ConsoleIcon from "@site/src/components/ConsoleIcons";
+
+Turn audit logging on for your Aiven for Apache Kafka® service, change what it records,
+and control how many log entries it produces.
+
+For what audit logging captures and its limitations, see
+[Audit logging for Aiven for Apache Kafka®](/docs/products/kafka/concepts/audit-logging).
+
+:::important
+Turning audit logging on or changing its settings restarts the Kafka brokers in your
+service one at a time. Make these changes during a maintenance window or a period of
+low traffic.
+:::
+
+## Prerequisites
+
+To configure audit logging, you need one of the following
+[project roles or permissions](/docs/platform/concepts/permissions#project-roles-and-permissions):
+
+- `admin`: Full access to services in the project.
+- `operator`: Full service management access.
+- `project:services:write`: Broad services write access.
+- `service:configuration:write`: Least-privilege access for changing service
+  configuration.
+
+The `developer` and `read_only` roles cannot configure audit logging.
+
+## Configuration options
+
+You configure audit logging with the `kafka.audit_log` settings. How you refer to each
+setting depends on the method:
+
+- In the **Aiven Console** and **Aiven CLI**, use the full name, such as
+  `kafka.audit_log.record_type`.
+- In the **Aiven API** and **Terraform**, set each option as a field inside the
+  `audit_log` object.
+
+The following options are available. When audit logging is enabled, unset options use
+their default values.
+
+<table>
+  <thead>
+    <tr>
+      <th>Option</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>record_type</code></td>
+      <td>string</td>
+      <td><code>user_operations</code></td>
+      <td>
+        The type of activity to record. Use <code>user_operations</code> for detailed
+        operation logs, or <code>user_activity</code> to record only that a Kafka user
+        was active.
+      </td>
+    </tr>
+    <tr>
+      <td><code>aggregation_period_sec</code></td>
+      <td>integer</td>
+      <td><code>300</code></td>
+      <td>
+        How long, in seconds, to group entries before writing them to the log. A
+        higher value produces fewer, larger entries. Accepts a value from 1 to 1800.
+      </td>
+    </tr>
+    <tr>
+      <td><code>include_denials</code></td>
+      <td>boolean</td>
+      <td><code>false</code></td>
+      <td>
+        Whether to include denied authorization attempts in audit log entries.
+      </td>
+    </tr>
+    <tr>
+      <td><code>group_by</code></td>
+      <td>string</td>
+      <td><code>user_and_ip</code></td>
+      <td>
+        How to group entries: by Kafka user only (<code>user</code>), or by Kafka user
+        and IP address (<code>user_and_ip</code>). Applies only when
+        <code>record_type</code> is <code>user_operations</code>.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Enable audit logging
+
+Audit logging turns on when the `kafka.audit_log` settings are present. To enable it
+with default settings, add at least one option, such as `record_type`. The other
+options then use their defaults.
+
+<Tabs groupId="enable-methods">
+<TabItem value="console" label="Aiven Console" default>
+
+1. In the [Aiven Console](https://console.aiven.io/), open your Aiven for Apache Kafka
+   service.
+1. Click <ConsoleLabel name="service settings"/>.
+1. In the **Advanced configuration** section, click **Configure**.
+1. Click <ConsoleIcon name="Add config options"/> and enter `audit` to find the audit
+   logging options.
+1. Add each option you want, then set its value. For example, add
+   `kafka.audit_log.record_type` and select `user_operations`.
+1. Click **Save configuration**.
+
+</TabItem>
+<TabItem value="cli" label="Aiven CLI">
+
+Set the options with the [`avn service update`](/docs/tools/cli/service-cli) command
+and the `-c` flag:
+
+```bash
+avn service update SERVICE_NAME \
+  --project PROJECT_NAME \
+  -c kafka.audit_log.record_type=user_operations \
+  -c kafka.audit_log.aggregation_period_sec=300 \
+  -c kafka.audit_log.include_denials=false \
+  -c kafka.audit_log.group_by=user_and_ip
+```
+
+Replace `SERVICE_NAME` and `PROJECT_NAME` with your service and project names.
+
+</TabItem>
+<TabItem value="api" label="Aiven API">
+
+Send a `PUT` request to the
+[service update](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
+endpoint:
+
+```bash
+curl -s -X PUT \
+  --url "https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME" \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_config": {
+      "kafka": {
+        "audit_log": {
+          "record_type": "user_operations",
+          "aggregation_period_sec": 300,
+          "include_denials": false,
+          "group_by": "user_and_ip"
+        }
+      }
+    }
+  }'
+```
+
+</TabItem>
+<TabItem value="terraform" label="Terraform">
+
+Add an `audit_log` block to the `kafka_user_config` block of your `aiven_kafka`
+resource:
+
+```hcl
+resource "aiven_kafka" "example_kafka" {
+  project      = var.project_name
+  cloud_name   = "google-europe-west1"
+  plan         = "business-4"
+  service_name = "example-kafka"
+
+  kafka_user_config {
+    kafka {
+      audit_log {
+        record_type            = "user_operations"
+        aggregation_period_sec = 300
+        include_denials        = false
+        group_by               = "user_and_ip"
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Change audit logging settings
+
+To change what audit logging records, set new values for the `kafka.audit_log` options
+with any of the preceding methods. Services that already use audit logging keep their
+current settings until you change them.
+
+## View audit logs
+
+Audit entries appear in the service logs with the `AUDIT:` prefix. To view them, use
+one of the following methods:
+
+- In the [Aiven Console](https://console.aiven.io/), open your service and click
+  <ConsoleLabel name="logs"/>.
+- With the Aiven CLI, run:
+
+  ```bash
+  avn service logs SERVICE_NAME \
+    --project PROJECT_NAME
+  ```
+
+- Send the service logs to another system through a
+  [log integration](/docs/products/kafka/howto/integrate-service-logs-into-kafka-topic).
+
+## Manage audit log volume
+
+Audit logging can produce many log entries. To manage the volume:
+
+- Set `group_by` to `user` instead of `user_and_ip` to combine a Kafka user's activity
+  across IP addresses.
+- Increase `aggregation_period_sec` to group entries over a longer time window.
+- Keep `include_denials` set to `false` unless you need denied attempts in audit log
+  entries.
+- Use `user_activity` instead of `user_operations` when you only need to know which
+  Kafka users were active.
+
+## Related pages
+
+- [Audit logging for Aiven for Apache Kafka®](/docs/products/kafka/concepts/audit-logging)
+- [Advanced parameters for Aiven for Apache Kafka®](/docs/products/kafka/reference/advanced-params)
+- [Integrate service logs into an Apache Kafka® topic](/docs/products/kafka/howto/integrate-service-logs-into-kafka-topic)
+- [Monitor and alert logs for denied ACL](/docs/products/kafka/howto/monitor-logs-acl-failure)

--- a/docs/products/kafka/howto/configure-audit-logging.md
+++ b/docs/products/kafka/howto/configure-audit-logging.md
@@ -9,16 +9,21 @@ import TabItem from '@theme/TabItem';
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import ConsoleIcon from "@site/src/components/ConsoleIcons";
 
-Turn audit logging on for your Aiven for Apache Kafka® service, change what it records,
-and manage audit log volume.
+Turn audit logging on for your Aiven for Apache Kafka® service, change what it records, and manage audit log volume.
 
 For what audit logging captures and its limitations, see
 [Audit logging for Aiven for Apache Kafka®](/docs/products/kafka/concepts/audit-logging).
 
 :::important
-Turning audit logging on or changing its settings restarts the Kafka brokers in your
-service one at a time. Make these changes during a maintenance window or a period of
-low traffic.
+Before you turn on audit logging, note the following:
+
+- Turning audit logging on or changing its settings restarts the Kafka brokers in your
+  service one at a time. Make these changes during a maintenance window or a period of
+  low traffic.
+- After you turn on audit logging, you cannot remove audit logging settings or turn off
+  audit logging yourself. To turn off audit logging,
+  [contact Aiven support](/docs/platform/howto/support).
+
 :::
 
 ## Prerequisites
@@ -34,15 +39,95 @@ To configure audit logging, you need one of the following
 
 The `developer` and `read_only` roles cannot configure audit logging.
 
+## Enable audit logging
+
+To enable audit logging, add at least one `kafka.audit_log` setting to your service
+configuration. Any setting you add must have a valid value.
+
+<Tabs groupId="enable-methods">
+<TabItem value="console" label="Aiven Console" default>
+
+1. In the [Aiven Console](https://console.aiven.io/), open your Aiven for Apache Kafka
+   service.
+1. Click <ConsoleLabel name="service settings"/>.
+1. In the **Advanced configuration** section, click **Configure**.
+1. Click <ConsoleIcon name="Add config options"/> and enter `audit` to find the audit
+   logging settings.
+1. Add `kafka.audit_log.record_type` and select `user_operations`.
+1. Optional: Add other audit logging settings and set their values.
+1. Click **Save configuration**.
+
+</TabItem>
+<TabItem value="cli" label="Aiven CLI">
+
+Set `kafka.audit_log.record_type` with the
+[`avn service update`](/docs/tools/cli/service-cli) command and the `-c` flag:
+
+```bash
+avn service update SERVICE_NAME \
+  --project PROJECT_NAME \
+  -c kafka.audit_log.record_type=user_operations
+```
+
+Replace `SERVICE_NAME` and `PROJECT_NAME` with your service and project names.
+
+</TabItem>
+<TabItem value="api" label="Aiven API">
+
+Send a `PUT` request to the
+[service update](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
+endpoint:
+
+```bash
+curl -s -X PUT \
+  --url "https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME" \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_config": {
+      "kafka": {
+        "audit_log": {
+          "record_type": "user_operations"
+        }
+      }
+    }
+  }'
+```
+
+Replace `PROJECT_NAME`, `SERVICE_NAME`, and `TOKEN` with your project name, service
+name, and authentication token.
+
+</TabItem>
+<TabItem value="terraform" label="Terraform">
+
+Add an `audit_log` block to the `kafka_user_config` block of your `aiven_kafka`
+resource:
+
+```hcl
+resource "aiven_kafka" "example_kafka" {
+  project      = var.project_name
+  cloud_name   = "google-europe-west1"
+  plan         = "business-4"
+  service_name = "example-kafka"
+
+  kafka_user_config {
+    kafka {
+      audit_log {
+        record_type = "user_operations"
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
 ## Audit logging settings
 
-Use these advanced configuration settings to customize audit logging. To record
-detailed operation entries, add `kafka.audit_log.record_type` and set it to
-`user_operations`.
-
-In the service configuration, add these settings under `kafka.audit_log`, for example
-`kafka.audit_log.record_type`. For the exact syntax for each method, see
-[Enable audit logging](#enable-audit-logging).
+Use these advanced configuration settings to customize audit logging. In the service
+configuration, add these settings under `kafka.audit_log`, for example
+`kafka.audit_log.record_type`.
 
 <table>
   <thead>
@@ -95,109 +180,11 @@ In the service configuration, add these settings under `kafka.audit_log`, for ex
   </tbody>
 </table>
 
-## Enable audit logging
-
-To enable audit logging, add at least one `kafka.audit_log` setting to your service
-configuration. Any setting you add must have a valid value.
-
-<Tabs groupId="enable-methods">
-<TabItem value="console" label="Aiven Console" default>
-
-1. In the [Aiven Console](https://console.aiven.io/), open your Aiven for Apache Kafka
-   service.
-1. Click <ConsoleLabel name="service settings"/>.
-1. In the **Advanced configuration** section, click **Configure**.
-1. Click <ConsoleIcon name="Add config options"/> and enter `audit` to find the audit
-   logging settings.
-1. Add `kafka.audit_log.record_type` and select `user_operations`.
-1. Optional: Add other audit logging settings and set their values.
-1. Click **Save configuration**.
-
-</TabItem>
-<TabItem value="cli" label="Aiven CLI">
-
-Set these settings with the [`avn service update`](/docs/tools/cli/service-cli) command
-and the `-c` flag:
-
-```bash
-avn service update SERVICE_NAME \
-  --project PROJECT_NAME \
-  -c kafka.audit_log.record_type=user_operations \
-  -c kafka.audit_log.aggregation_period_sec=300 \
-  -c kafka.audit_log.include_denials=false \
-  -c kafka.audit_log.group_by=user_and_ip
-```
-
-Replace `SERVICE_NAME` and `PROJECT_NAME` with your service and project names.
-
-</TabItem>
-<TabItem value="api" label="Aiven API">
-
-Send a `PUT` request to the
-[service update](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
-endpoint:
-
-```bash
-curl -s -X PUT \
-  --url "https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME" \
-  -H "Authorization: Bearer TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "user_config": {
-      "kafka": {
-        "audit_log": {
-          "record_type": "user_operations",
-          "aggregation_period_sec": 300,
-          "include_denials": false,
-          "group_by": "user_and_ip"
-        }
-      }
-    }
-  }'
-```
-
-Replace `PROJECT_NAME`, `SERVICE_NAME`, and `TOKEN` with your project name, service
-name, and authentication token.
-
-</TabItem>
-<TabItem value="terraform" label="Terraform">
-
-Add an `audit_log` block to the `kafka_user_config` block of your `aiven_kafka`
-resource:
-
-```hcl
-resource "aiven_kafka" "example_kafka" {
-  project      = var.project_name
-  cloud_name   = "google-europe-west1"
-  plan         = "business-4"
-  service_name = "example-kafka"
-
-  kafka_user_config {
-    kafka {
-      audit_log {
-        record_type            = "user_operations"
-        aggregation_period_sec = 300
-        include_denials        = false
-        group_by               = "user_and_ip"
-      }
-    }
-  }
-}
-```
-
-</TabItem>
-</Tabs>
-
 ## Change audit logging settings
 
 To change what audit logging records, set new values for the `kafka.audit_log` settings
 with any of the preceding methods. Services that already use audit logging keep their
 current settings until you change them.
-
-:::important
-You cannot remove audit logging settings or turn off audit logging yourself. To turn
-off audit logging, [contact Aiven support](/docs/platform/howto/support).
-:::
 
 ## View audit logs
 
@@ -210,7 +197,8 @@ one of the following methods:
 
   ```bash
   avn service logs SERVICE_NAME \
-    --project PROJECT_NAME
+    --project PROJECT_NAME \
+    | grep AUDIT:
   ```
 
 - Send the service logs to another system through a

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -601,6 +601,7 @@ const sidebars: SidebarsConfig = {
                     'products/kafka/concepts/log-compaction',
                     'products/kafka/concepts/auth-types',
                     'products/kafka/concepts/acl',
+                    'products/kafka/concepts/audit-logging',
                     'products/kafka/concepts/schema-registry-authorization',
                     'products/kafka/concepts/kafka-rest-api',
                     'products/kafka/concepts/kraft-mode',
@@ -699,6 +700,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'products/kafka/howto/keystore-truststore',
                     'products/kafka/howto/manage-acls',
+                    'products/kafka/howto/configure-audit-logging',
                     'products/kafka/howto/monitor-logs-acl-failure',
                     'products/kafka/howto/kafka-sasl-auth',
                     'products/kafka/howto/renew-ssl-certs',


### PR DESCRIPTION
## Describe your changes

Adds documentation for Aiven for Apache Kafka® audit logging, including what it records, how log entries work, supported record types, limitations, and related configuration links.

https://aiven.atlassian.net/browse/KCON-465

Page preview 

- https://kcon-465-document-the-config.aiven-docs.pages.dev/docs/products/kafka/concepts/audit-logging
- https://kcon-465-document-the-config.aiven-docs.pages.dev/docs/products/kafka/howto/configure-audit-logging


## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
