### PR TITLE
update: Kafka EOL

### DIFF
--- a/docs/platform/reference/eol-for-major-versions.md
+++ b/docs/platform/reference/eol-for-major-versions.md
@@ -140,6 +140,7 @@ available on the Aiven platform.
 | 3.9.x     | 2027-09-30 | 2027-06-30                       | 2025-03-20                      |
 | 4.0.x     | 2026-09-18 | 2026-06-18                       | 2025-09-18                      |
 | 4.1.x     | 2027-01-31 | 2026-09-10                       | 2025-12-10                      |
+| 4.2.x     | 2027-06-15 | 2027-03-15                       | 2026-06-15                      |
 
 :::note
 Apache Kafka 3.8 is the last version that supports ZooKeeper.


### PR DESCRIPTION
## Describe your changes

Kafka 4.2 EOL 

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
