### PR TITLE
update: MCP allow_secrets param

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -307,3 +307,8 @@ Aiven secures the platform and API. You are responsible for the following:
   operations on production resources.
 - **Configure MCP servers securely**, including enabling read-only mode to
   restrict the server to non-destructive operations.
+- **Keep credential exposure off in production.** The
+  **Allow connection credentials** option (`allow_secrets=true`) returns
+  PostgreSQL and Kafka connection credentials, including URIs, passwords, and
+  certificates, to the AI agent so it can connect to your services. Use it only
+  for development with non-production services that do not hold sensitive data.

--- a/src/components/CursorConfigTab/index.tsx
+++ b/src/components/CursorConfigTab/index.tsx
@@ -9,7 +9,7 @@ type CursorConfigTabProps = {
 };
 
 export default function CursorConfigTab({ baseUrl }: CursorConfigTabProps): JSX.Element {
-  const [state, setState] = useState<MCPConfigState>({ readOnly: true, scopes: [], marketplace: '' });
+  const [state, setState] = useState<MCPConfigState>({ readOnly: true, scopes: [], marketplace: '', allowSecrets: false });
 
   const url = buildMcpUrl(baseUrl, state);
   const configJson = JSON.stringify({ mcpServers: { aiven: { type: 'http', url } } }, null, 2);
@@ -17,7 +17,7 @@ export default function CursorConfigTab({ baseUrl }: CursorConfigTabProps): JSX.
   const cursorConfig = { url, type: 'http' };
   const encodedConfig = typeof btoa !== 'undefined' ? btoa(JSON.stringify(cursorConfig)) : '';
   const deepLink = `cursor://anysphere.cursor-deeplink/mcp/install?name=aiven-mcp&config=${encodedConfig}`;
-  const cacheKey = `${state.readOnly}-${state.scopes.join(',')}-${state.marketplace}`;
+  const cacheKey = `${state.readOnly}-${state.scopes.join(',')}-${state.marketplace}-${state.allowSecrets}`;
 
   return (
     <div className={styles.container}>

--- a/src/components/MCPConfigSection/index.tsx
+++ b/src/components/MCPConfigSection/index.tsx
@@ -10,12 +10,12 @@ type MCPConfigSectionProps = {
 };
 
 export default function MCPConfigSection({ baseUrl, format, configTemplate }: MCPConfigSectionProps): JSX.Element {
-  const [state, setState] = useState<MCPConfigState>({ readOnly: true, scopes: [], marketplace: '' });
+  const [state, setState] = useState<MCPConfigState>({ readOnly: true, scopes: [], marketplace: '', allowSecrets: false });
 
   const url = buildMcpUrl(baseUrl, state);
   const config = configTemplate(url);
   const content = format === 'json' ? JSON.stringify(config, null, 2) : config;
-  const cacheKey = `${format}-${state.readOnly}-${state.scopes.join(',')}-${state.marketplace}`;
+  const cacheKey = `${format}-${state.readOnly}-${state.scopes.join(',')}-${state.marketplace}-${state.allowSecrets}`;
 
   return (
     <div className={styles.container}>

--- a/src/components/MCPConfigToggle/index.tsx
+++ b/src/components/MCPConfigToggle/index.tsx
@@ -28,6 +28,7 @@ export type MCPConfigState = {
   readOnly: boolean;
   scopes: Scope[];
   marketplace: '' | Marketplace;
+  allowSecrets: boolean;
 };
 
 type MCPConfigToggleProps = {
@@ -38,12 +39,13 @@ export default function MCPConfigToggle({ onChange }: MCPConfigToggleProps): JSX
   const [readOnly, setReadOnly] = useState(true);
   const [scopes, setScopes] = useState<Scope[]>([]);
   const [marketplace, setMarketplace] = useState<'' | Marketplace>('');
+  const [allowSecrets, setAllowSecrets] = useState(false);
 
   const emit = (next: MCPConfigState) => onChange?.(next);
 
   const handleReadOnly = (checked: boolean) => {
     setReadOnly(checked);
-    emit({ readOnly: checked, scopes, marketplace });
+    emit({ readOnly: checked, scopes, marketplace, allowSecrets });
   };
 
   const handleScope = (choice: ScopeChoice, checked: boolean) => {
@@ -56,12 +58,17 @@ export default function MCPConfigToggle({ onChange }: MCPConfigToggleProps): JSX
       next = scopes.filter((s) => s !== choice);
     }
     setScopes(next);
-    emit({ readOnly, scopes: next, marketplace });
+    emit({ readOnly, scopes: next, marketplace, allowSecrets });
   };
 
   const handleMarketplace = (value: '' | Marketplace) => {
     setMarketplace(value);
-    emit({ readOnly, scopes, marketplace: value });
+    emit({ readOnly, scopes, marketplace: value, allowSecrets });
+  };
+
+  const handleAllowSecrets = (checked: boolean) => {
+    setAllowSecrets(checked);
+    emit({ readOnly, scopes, marketplace, allowSecrets: checked });
   };
 
   const isChecked = (choice: ScopeChoice): boolean =>
@@ -110,6 +117,29 @@ export default function MCPConfigToggle({ onChange }: MCPConfigToggleProps): JSX
 
       <div className={styles.separator} aria-hidden="true" />
 
+      <div className={styles.section}>
+        <span className={styles.sectionLabel}>Development</span>
+        <label className={styles.option}>
+          <input
+            type="checkbox"
+            checked={allowSecrets}
+            onChange={(e) => handleAllowSecrets(e.target.checked)}
+            className={styles.checkbox}
+          />
+          <span>Allow connection credentials (development only)</span>
+        </label>
+      </div>
+      {allowSecrets && (
+        <p className={styles.warning} role="alert">
+          ⚠ This shares PostgreSQL and Kafka connection credentials with the AI agent,
+          including URIs, passwords, and certificates, so it can connect to your services.
+          Do not enable it in production.{' '}
+          <a href="#security-and-responsibility">Review the security implications</a>.
+        </p>
+      )}
+
+      <div className={styles.separator} aria-hidden="true" />
+
       <details className={styles.disclosure}>
         <summary className={styles.summary}>Subscribed through a cloud marketplace?</summary>
         <div className={styles.disclosureBody}>
@@ -142,6 +172,7 @@ export function buildMcpUrl(baseUrl: string, state: MCPConfigState): string {
   const params = new URLSearchParams();
   if (state.scopes.length > 0) params.set('services_scope', state.scopes.join(','));
   if (state.readOnly) params.set('read_only', 'true');
+  if (state.allowSecrets) params.set('allow_secrets', 'true');
   const qs = params.toString();
   return qs ? `${url}?${qs}` : url;
 }


### PR DESCRIPTION
Add an "Expose connection credentials" toggle to the MCP config and Cursor
  components that appends allow_secrets=true to the URL (and the Cursor deep-link).
  When enabled, show a "Not for production" badge beside the toggle linking to the
  security section, plus a full warning below. Document the option under Security
  and responsibility.
  
  
<img width="1081" height="289" alt="Screenshot 2026-06-22 at 14 36 32" src="https://github.com/user-attachments/assets/42a010e7-3ae4-4f18-9721-df53b920ccbe" />
