### PR TITLE
update: add mm user-config consumer_fetch_max_wait_ms

### DIFF
--- a/docs/products/kafka/kafka-mirrormaker/concepts/configuration-layers.md
+++ b/docs/products/kafka/kafka-mirrormaker/concepts/configuration-layers.md
@@ -116,6 +116,7 @@ clusters. Set them on the service integration resource. To update these settings
 |-----------|-------------|---------------|---------------|
 | `consumer_fetch_min_bytes` | Minimum amount of data the server returns for a fetch request. Higher values reduce fetch frequency. | 1 | — |
 | `consumer_fetch_max_bytes` | Maximum amount of data the server returns for a fetch request. | 52428800 | 100 MiB |
+| `consumer_fetch_max_wait_ms` | Maximum amount of time the server waits for a fetch request. | 500 | 600,000 ms (10 minutes) |
 | `consumer_max_partition_fetch_bytes` | Maximum amount of data per partition the server returns in a single fetch response. | 1048576 | 100 MiB |
 | `consumer_max_poll_records` | Maximum number of records returned in a single poll request. | 500 | — |
 | `consumer_receive_buffer_bytes` | Size of the TCP receive buffer for the consumer. A value of `-1` uses the OS default. | 65536 | 100 MiB |


### PR DESCRIPTION
## Describe your changes

Add consumer_fetch_max_wait_ms to kafka_mirrormaker integration settings.

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
