### PR TITLE
update: remove some links to generic service creation article

### DIFF
--- a/docs/platform/concepts/service-forking.md
+++ b/docs/platform/concepts/service-forking.md
@@ -209,6 +209,3 @@ are available in the
 During the forking process, the fork might initially have only one node while backups
 are being taken. The other nodes appear after the backup process is complete.
 
-<RelatedPages/>
-
-- [Create a service](/docs/platform/howto/create_new_service)

--- a/docs/platform/howto/byoc/store-data.md
+++ b/docs/platform/howto/byoc/store-data.md
@@ -49,7 +49,7 @@ storage in your AWS custom cloud.
 ### Prerequisites
 
 - At least one AWS [custom cloud](/docs/platform/howto/byoc/create-cloud/create-custom-cloud)
-- At least one [Aiven-managed service](/docs/platform/howto/create_new_service), either
+- At least one Aiven-managed service, either
   Aiven for Apache Kafka® or Aiven for ClickHouse®, hosted in a custom cloud
 
   :::note

--- a/docs/platform/howto/tag-resources.md
+++ b/docs/platform/howto/tag-resources.md
@@ -71,6 +71,3 @@ Use the `tag` attribute in
 </TabItem>
 </Tabs>
 
-<RelatedPages/>
-
-- [Create a service](/docs/platform/howto/create_new_service)

--- a/docs/platform/howto/vpc-service-management.md
+++ b/docs/platform/howto/vpc-service-management.md
@@ -62,7 +62,7 @@ Create a service in a project VPC using a tool of your choice:
 <Tabs groupId="group1">
 <TabItem value="console" label="Aiven Console" default>
 
-When you [create a service](/docs/platform/howto/create_new_service) in the Aiven Console,
+When you create a service in the Aiven Console,
 select your project VPC as the cloud region.
 
 </TabItem>
@@ -149,7 +149,7 @@ Create a service in an organization VPC using a tool of your choice:
 <Tabs groupId="group1">
 <TabItem value="console" label="Console" default>
 
-When you [create a service](/docs/platform/howto/create_new_service) in the Aiven Console,
+When you create a service in the Aiven Console,
 select your organization VPC as the cloud region.
 
 </TabItem>


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
