### PR TITLE
fix: add mcp ai clients icons and collapse advanced settings

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -9,6 +9,14 @@ import TabItem from '@theme/TabItem';
 import {mcpUrl} from '@site/src/components/mcpAivenLiveConstants';
 import MCPConfigSection from "@site/src/components/MCPConfigSection";
 import CursorConfigTab from "@site/src/components/CursorConfigTab";
+import McpClientTabLabel from "@site/src/components/McpClientTabLabel";
+import ClaudeCodeIcon from "@site/static/images/icons/claude-code.svg";
+import CursorIcon from "@site/static/images/icons/cursor.svg";
+import ClaudeDesktopIcon from "@site/static/images/icons/claude-desktop.svg";
+import VSCodeIcon from "@site/static/images/icons/vscode.svg";
+import GeminiCliIcon from "@site/static/images/icons/gemini-cli.svg";
+import OtherClientIcon from "@site/static/images/icons/mcp-client-other.svg";
+import LocalInstallIcon from "@site/static/images/icons/local-install.svg";
 
 Create and manage Aiven services from AI assistants such as Cursor and Claude Code,
 including PostgreSQL®, Apache Kafka®, plans, metrics, logs, and service configuration.
@@ -30,7 +38,7 @@ can sign in and authorize MCP access.
 ## Install the Aiven MCP {#configure-aiven-mcp}
 
 <Tabs>
-<TabItem value="claude-code" label="Claude Code" default>
+<TabItem value="claude-code" label={<McpClientTabLabel icon={ClaudeCodeIcon} label="Claude Code" />} default>
 
 1. Open a terminal.
 1. Choose your options below, then run the generated command:
@@ -48,7 +56,7 @@ can sign in and authorize MCP access.
 For more information, see the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp).
 
 </TabItem>
-<TabItem value="cursor" label="Cursor">
+<TabItem value="cursor" label={<McpClientTabLabel icon={CursorIcon} label="Cursor" />}>
 
 <CursorConfigTab baseUrl={mcpUrl} />
 
@@ -58,7 +66,7 @@ as `List my Aiven projects.` and click **Allow** if prompted.
 For more information, see the [Cursor MCP documentation](https://cursor.com/docs/mcp).
 
 </TabItem>
-<TabItem value="claude-desktop" label="Claude Desktop">
+<TabItem value="claude-desktop" label={<McpClientTabLabel icon={ClaudeDesktopIcon} label="Claude Desktop" />}>
 
 1. Open the Claude Desktop configuration file. If it does not exist, create it:
 
@@ -83,7 +91,7 @@ For more information, see the [Cursor MCP documentation](https://cursor.com/docs
 For more information, see the [Claude Desktop MCP documentation](https://modelcontextprotocol.io/docs/develop/connect-local-servers).
 
 </TabItem>
-<TabItem value="vscode" label="VS Code">
+<TabItem value="vscode" label={<McpClientTabLabel icon={VSCodeIcon} label="VS Code" />}>
 
 :::note
 Requires VS Code 1.102 or later with the GitHub Copilot extension installed
@@ -110,7 +118,7 @@ and enabled.
 For more information, see the [VS Code MCP documentation](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
 
 </TabItem>
-<TabItem value="gemini-cli" label="Gemini CLI">
+<TabItem value="gemini-cli" label={<McpClientTabLabel icon={GeminiCliIcon} label="Gemini CLI" />}>
 
 1. Create or edit the `~/.gemini/settings.json` file.
 1. Add the following configuration:
@@ -127,7 +135,7 @@ For more information, see the [VS Code MCP documentation](https://code.visualstu
    approve the tool execution if prompted.
 
 </TabItem>
-<TabItem value="other" label="Other clients">
+<TabItem value="other" label={<McpClientTabLabel icon={OtherClientIcon} label="Other clients" />}>
 
 1. Open your MCP client configuration.
 1. Choose your options below, then add the generated configuration to your client:
@@ -148,7 +156,7 @@ Some clients require a transport type, such as `"type": "http"`. If the configur
 fails, see your client documentation.
 
 </TabItem>
-<TabItem value="local" label="Local installation">
+<TabItem value="local" label={<McpClientTabLabel icon={LocalInstallIcon} label="Local installation" />}>
 
 Run the Aiven MCP server locally with `npx` instead of using the hosted server.
 You need an [Aiven API token](/docs/platform/howto/create_authentication_token)
@@ -161,7 +169,7 @@ non-production services. For more information, see
 [Security and responsibility](#security-and-responsibility).
 
 <Tabs>
-<TabItem value="claude-code" label="Claude Code" default>
+<TabItem value="claude-code" label={<McpClientTabLabel icon={ClaudeCodeIcon} label="Claude Code" />} default>
 
 1. Open a terminal.
 1. Run the following command, replacing `your-token-here` with your Aiven API token:
@@ -173,7 +181,7 @@ non-production services. For more information, see
 1. Run `/mcp` in Claude Code to verify the server is registered.
 
 </TabItem>
-<TabItem value="cursor" label="Cursor">
+<TabItem value="cursor" label={<McpClientTabLabel icon={CursorIcon} label="Cursor" />}>
 
 1. In your project root, create or edit the `.cursor/mcp.json` file.
 1. Add the following configuration, replacing `your-token-here` with your Aiven API token:
@@ -197,7 +205,7 @@ non-production services. For more information, see
 1. Save the file and restart Cursor.
 
 </TabItem>
-<TabItem value="claude-desktop" label="Claude Desktop">
+<TabItem value="claude-desktop" label={<McpClientTabLabel icon={ClaudeDesktopIcon} label="Claude Desktop" />}>
 
 1. Open the Claude Desktop configuration file.
 1. Add the following configuration, replacing `your-token-here` with your Aiven API token:
@@ -221,7 +229,7 @@ non-production services. For more information, see
 1. Save the file and restart Claude Desktop.
 
 </TabItem>
-<TabItem value="vscode" label="VS Code">
+<TabItem value="vscode" label={<McpClientTabLabel icon={VSCodeIcon} label="VS Code" />}>
 
 1. In the `.vscode` directory, create or edit the `mcp.json` file.
 1. Add the following configuration, replacing `your-token-here` with your Aiven API token:
@@ -245,7 +253,7 @@ non-production services. For more information, see
 1. Save the file and reload VS Code.
 
 </TabItem>
-<TabItem value="other" label="Other clients">
+<TabItem value="other" label={<McpClientTabLabel icon={OtherClientIcon} label="Other clients" />}>
 
 1. Open your MCP client configuration.
 1. Add the following configuration, replacing `your-token-here` with your Aiven API token:

--- a/src/components/MCPConfigToggle/index.tsx
+++ b/src/components/MCPConfigToggle/index.tsx
@@ -77,7 +77,6 @@ export default function MCPConfigToggle({ onChange }: MCPConfigToggleProps): JSX
   return (
     <div className={styles.container}>
       <div className={styles.section}>
-        <span className={styles.sectionLabel}>Permissions</span>
         <label className={styles.option}>
           <input
             type="checkbox"
@@ -90,61 +89,61 @@ export default function MCPConfigToggle({ onChange }: MCPConfigToggleProps): JSX
       </div>
       {!readOnly && (
         <p className={styles.warning} role="alert">
-          ⚠ Write mode lets the assistant create, modify, and delete services and data.
+          ⚠ With read-only mode disabled, the assistant can create, modify, and delete services and data.
           {' '}
           <a href="#security-and-responsibility">Review security and responsibility</a>.
         </p>
       )}
 
-      <div className={styles.separator} aria-hidden="true" />
+      <details className={styles.disclosure}>
+        <summary className={styles.summary}>Advanced settings</summary>
+        <div className={styles.disclosureBody}>
+          <div className={styles.separator} aria-hidden="true" />
 
-      <div className={styles.section}>
-        <span className={styles.sectionLabel}>Available tools</span>
-        <div className={styles.scopeRow}>
-          {ALL_CHOICES.map((choice) => (
-            <label key={choice} className={styles.option}>
+          <div className={styles.section}>
+            <span className={styles.sectionLabel}>Available tools</span>
+            <div className={styles.scopeRow}>
+              {ALL_CHOICES.map((choice) => (
+                <label key={choice} className={styles.option}>
+                  <input
+                    type="checkbox"
+                    checked={isChecked(choice)}
+                    onChange={(e) => handleScope(choice, e.target.checked)}
+                    className={styles.checkbox}
+                  />
+                  <span>{SCOPE_LABELS[choice]}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.separator} aria-hidden="true" />
+
+          <div className={styles.section}>
+            <span className={styles.sectionLabel}>Development</span>
+            <label className={styles.option}>
               <input
                 type="checkbox"
-                checked={isChecked(choice)}
-                onChange={(e) => handleScope(choice, e.target.checked)}
+                checked={allowSecrets}
+                onChange={(e) => handleAllowSecrets(e.target.checked)}
                 className={styles.checkbox}
               />
-              <span>{SCOPE_LABELS[choice]}</span>
+              <span>Allow connection credentials (development only)</span>
             </label>
-          ))}
-        </div>
-      </div>
+          </div>
+          {allowSecrets && (
+            <p className={styles.warning} role="alert">
+              ⚠ This shares PostgreSQL and Kafka connection credentials with the AI agent,
+              including URIs, passwords, and certificates, so it can connect to your services.
+              Do not enable it in production.{' '}
+              <a href="#security-and-responsibility">Review the security implications</a>.
+            </p>
+          )}
 
-      <div className={styles.separator} aria-hidden="true" />
+          <div className={styles.separator} aria-hidden="true" />
 
-      <div className={styles.section}>
-        <span className={styles.sectionLabel}>Development</span>
-        <label className={styles.option}>
-          <input
-            type="checkbox"
-            checked={allowSecrets}
-            onChange={(e) => handleAllowSecrets(e.target.checked)}
-            className={styles.checkbox}
-          />
-          <span>Allow connection credentials (development only)</span>
-        </label>
-      </div>
-      {allowSecrets && (
-        <p className={styles.warning} role="alert">
-          ⚠ This shares PostgreSQL and Kafka connection credentials with the AI agent,
-          including URIs, passwords, and certificates, so it can connect to your services.
-          Do not enable it in production.{' '}
-          <a href="#security-and-responsibility">Review the security implications</a>.
-        </p>
-      )}
-
-      <div className={styles.separator} aria-hidden="true" />
-
-      <details className={styles.disclosure}>
-        <summary className={styles.summary}>Subscribed through a cloud marketplace?</summary>
-        <div className={styles.disclosureBody}>
-          <label className={styles.option}>
-            <span>Marketplace</span>
+          <div className={styles.section}>
+            <span className={styles.sectionLabel}>Marketplace</span>
             <select
               value={marketplace}
               onChange={(e) => handleMarketplace(e.target.value as '' | Marketplace)}
@@ -154,7 +153,7 @@ export default function MCPConfigToggle({ onChange }: MCPConfigToggleProps): JSX
                 <option key={value} value={value}>{MARKETPLACE_LABELS[value]}</option>
               ))}
             </select>
-          </label>
+          </div>
           <p className={styles.hint}>
             Select your marketplace only if you subscribed to Aiven through AWS, Azure, or Google
             Cloud Marketplace. This helps you sign in to the correct console.

--- a/src/components/McpClientTabLabel/index.tsx
+++ b/src/components/McpClientTabLabel/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+type McpClientTabLabelProps = {
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  label: string;
+};
+
+export default function McpClientTabLabel({ icon: Icon, label }: McpClientTabLabelProps): JSX.Element {
+  return (
+    <span className={styles.tabLabel}>
+      <Icon className={styles.icon} />
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/src/components/McpClientTabLabel/styles.module.css
+++ b/src/components/McpClientTabLabel/styles.module.css
@@ -1,0 +1,11 @@
+.tabLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.icon {
+  flex: none;
+  width: 16px;
+  height: 16px;
+}

--- a/static/images/icons/claude-code.svg
+++ b/static/images/icons/claude-code.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none">
+  <rect x="3" y="4" width="18" height="16" rx="2" stroke="currentColor" stroke-width="2"/>
+  <path d="M7 9L10 12L7 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12 15H15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/static/images/icons/claude-desktop.svg
+++ b/static/images/icons/claude-desktop.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none">
+  <rect x="3" y="4" width="18" height="13" rx="2" stroke="currentColor" stroke-width="2"/>
+  <path d="M8 21H16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M12 17V21" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="12" cy="10.5" r="2.5" stroke="currentColor" stroke-width="2"/>
+</svg>

--- a/static/images/icons/gemini-cli.svg
+++ b/static/images/icons/gemini-cli.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none">
+  <path d="M5 6L11 12L5 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M13 18H19" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/static/images/icons/local-install.svg
+++ b/static/images/icons/local-install.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none">
+  <path d="M12 3V15M12 15L8 11M12 15L16 11" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M4 17V19C4 20.1046 4.89543 21 6 21H18C19.1046 21 20 20.1046 20 19V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/static/images/icons/mcp-client-other.svg
+++ b/static/images/icons/mcp-client-other.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none">
+  <path d="M9 4V7M15 4V7M9 17V20M15 17V20M4 9H7M4 15H7M17 9H20M17 15H20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <rect x="7" y="7" width="10" height="10" rx="2" stroke="currentColor" stroke-width="2"/>
+</svg>

--- a/static/images/icons/vscode.svg
+++ b/static/images/icons/vscode.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none">
+  <path d="M9 8L4 12L9 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M15 8L20 12L15 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M13.5 5L10.5 19" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Experience improvements for the MCP docs page:

* Collapse the advanced settings so it will be easier for users to install the MCP with default settings
* Enable read only mode by default
* Add icons for the AI clients to make the tabs look more appealing