### PR TITLE
fix: add vpc-hosted pg access note to mcp docs

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -329,3 +329,5 @@ Aiven secures the platform and API. You are responsible for the following:
   PostgreSQL and Kafka connection credentials, including URIs, passwords, and
   certificates, to the AI agent so it can connect to your services. Use it only
   for development with non-production services that do not hold sensitive data.
+- **VPC-hosted PG services are supported.** You can connect directly to a
+  VPC-hosted PostgreSQL service.

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -329,5 +329,5 @@ Aiven secures the platform and API. You are responsible for the following:
   PostgreSQL and Kafka connection credentials, including URIs, passwords, and
   certificates, to the AI agent so it can connect to your services. Use it only
   for development with non-production services that do not hold sensitive data.
-- **VPC-hosted PG services are supported.** You can connect directly to a
-  VPC-hosted PostgreSQL service.
+- **Connect to VPC-hosted PostgreSQL services**: The Aiven MCP server supports
+  direct connections to PostgreSQL services running in a private VPC.


### PR DESCRIPTION
## Describe your changes
new bullet in docs/tools/mcp-server.md, to note that vpc-hosted pg services are now supprted.