### PR TITLE
update: PG CRDR LA

### DIFF
--- a/docs/products/postgresql/crdr/crdr-overview.md
+++ b/docs/products/postgresql/crdr/crdr-overview.md
@@ -71,10 +71,10 @@ Throughout the CRDR cycle, CRDR peer services or service nodes go into the follo
 ## Limitations
 
 - **Service plan requirements**: To set up CRDR, your primary service must use at least a
-  Startup plan. Hobbyist and Free plans are not supported.
+  Startup plan. Hobbyist, Free, and Developer plans are not supported.
 
   :::tip[Upgrading your plan]
-  If your Aiven for PostgreSQL service uses a Hobbyist plan or a Free plan,
+  If your Aiven for PostgreSQL service uses a Hobbyist, Free, or Developer plan,
   [upgrade](/docs/platform/howto/scale-services) to at least a Startup plan.
   :::
 

--- a/docs/products/postgresql/crdr/failover/crdr-failover-to-recovery.md
+++ b/docs/products/postgresql/crdr/failover/crdr-failover-to-recovery.md
@@ -58,7 +58,7 @@ Replace `PRIMARY_SERVICE_NAME` with the name of the primary service, for example
 </TabItem>
 <TabItem value="api" label="API">
 
-Call the [ServiceUpdte endpoint](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
+Call the [ServiceUpdate endpoint](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
 to change the `disaster_recovery_role` of the primary service to `failed`:
 
 ```bash {5}

--- a/docs/products/postgresql/crdr/failover/crdr-revert-to-primary.md
+++ b/docs/products/postgresql/crdr/failover/crdr-revert-to-primary.md
@@ -63,7 +63,7 @@ using a tool of your choice:
    Replace `PRIMARY_SERVICE_NAME` with the name of the primary service, for example, `pg-demo`.
 
 1. Promote the primary service to active by running
-   [avn byoc update](/docs/tools/cli/service-cli#avn-cli-service-update):
+   [avn service update](/docs/tools/cli/service-cli#avn-cli-service-update):
 
    ```bash
    avn service update PRIMARY_SERVICE_NAME \
@@ -130,7 +130,7 @@ using a tool of your choice:
       ```
 
 1. Promote the primary service as active by calling the
-   [ServiceUpdte endpoint](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
+   [ServiceUpdate endpoint](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
    to change `disaster_recovery_role` of the primary service to `active`:
 
    ```bash {5}
@@ -239,12 +239,6 @@ To get back to the original primary-recovery setup:
 
    ```bash
    terraform apply
-   ```
-
-1. Verify the failback:
-
-   ```bash
-   terraform output disaster_recovery_status
    ```
 
 </TabItem>

--- a/docs/products/postgresql/crdr/switchover/crdr-switchback.md
+++ b/docs/products/postgresql/crdr/switchover/crdr-switchback.md
@@ -24,117 +24,143 @@ Shift your workloads back to the primary region, where your service was hosted o
 <Tabs>
 <TabItem value="cli" label="CLI">
 
-Use the [Aiven CLI](/docs/tools/cli) to perform a switchback:
+Run [avn service update](/docs/tools/cli/service-cli#avn-cli-service-update) to promote
+the primary service back to active:
 
 ```bash
-avn service disaster-recovery promote-to-master \
-  --project PROJECT_NAME \
-  SERVICE_NAME
+avn service update PRIMARY_SERVICE_NAME \
+   --disaster-recovery-role active
 ```
 
-Replace the placeholders with your actual values:
+Replace `PRIMARY_SERVICE_NAME` with the name of the primary service, for example,
+`pg-demo`.
 
-- `PROJECT_NAME`: Your Aiven project name
-- `SERVICE_NAME`: Name of your primary PostgreSQL service
+Verify the switchback by checking both services:
 
-Monitor the switchback status:
+- Primary service status:
 
-```bash
-avn service disaster-recovery get \
-  --project PROJECT_NAME \
-  SERVICE_NAME
-```
+  ```bash
+  avn service get PRIMARY_SERVICE_NAME \
+    --json | jq '{state: .state, disaster_recovery_role: .disaster_recovery_role}'
+  ```
+
+  Expect the following output:
+
+  ```json
+  {
+    "state": "RUNNING",
+    "disaster_recovery_role": "active"
+  }
+  ```
+
+- Recovery service status:
+
+  ```bash
+  avn service get RECOVERY_SERVICE_NAME \
+    --json | jq '{state: .state, disaster_recovery_role: .disaster_recovery_role}'
+  ```
+
+  Expect the following output:
+
+  ```json
+  {
+    "state": "RUNNING",
+    "disaster_recovery_role": "passive"
+  }
+  ```
 
 </TabItem>
 <TabItem value="api" label="API">
 
-Use the [ServiceUpdate](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate) API
-endpoint to perform a switchback:
+Call the [ServiceUpdate endpoint](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
+to change the `disaster_recovery_role` of the primary service to `active`:
 
 ```bash
-curl -X PUT \
-  "https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME" \
-  -H "Authorization: Bearer API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "disaster_recovery_promote_to_master": true
-  }'
+curl --request PUT \
+  --url https://api.aiven.io/v1/project/PROJECT_NAME/service/PRIMARY_SERVICE_NAME \
+  -H 'Authorization: Bearer BEARER_TOKEN' \
+  -H 'content-type: application/json' \
+  --data '{"disaster_recovery_role": "active"}'
 ```
 
-Replace the placeholders:
+Replace the following:
 
-- `PROJECT_NAME`: Your Aiven project name
-- `SERVICE_NAME`: Name of your primary PostgreSQL service
-- `API_TOKEN`: Your Aiven API authentication token
+- `PROJECT_NAME`, for example `crdr-test`
+- `PRIMARY_SERVICE_NAME`, for example `pg-demo`
+- `BEARER_TOKEN`
 
-Check the disaster recovery status:
+After sending the request, verify the status of each service:
 
-```bash
-curl -X GET \
-  "https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME/disaster-recovery" \
-  -H "Authorization: Bearer API_TOKEN"
-```
+- Primary service status:
+
+  ```bash
+  avn service get PRIMARY_SERVICE_NAME \
+    --json | jq '{state: .state, disaster_recovery_role: .disaster_recovery_role}'
+  ```
+
+  Expect the following output:
+
+  ```json
+  {
+    "state": "RUNNING",
+    "disaster_recovery_role": "active"
+  }
+  ```
+
+- Recovery service status:
+
+  ```bash
+  avn service get RECOVERY_SERVICE_NAME \
+    --json | jq '{state: .state, disaster_recovery_role: .disaster_recovery_role}'
+  ```
+
+  Expect the following output:
+
+  ```json
+  {
+    "state": "RUNNING",
+    "disaster_recovery_role": "passive"
+  }
+  ```
 
 </TabItem>
 <TabItem value="tf" label="Terraform">
 
-The
-[`aiven_service_integration`](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/service_integration)
-resource with the `disaster_recovery` type manages the active-passive relationship between
-services. CRDR operations are performed by manipulating this integration.
+The Terraform provider manages the `disaster_recovery` integration as a static topology
+declaration. All integration fields are immutable, so a switchback requires destroying the
+switched integration and restoring the original one. This approach has a window during
+which the DR integration is offline. For a lower-risk switchback, use the Aiven CLI or
+API instead.
 
-To return to the original primary-recovery configuration after a planned switchover:
+To use Terraform:
 
-1. Comment out or remove the current switched disaster recovery integration.
-
-   ```hcl
-   # resource "aiven_service_integration" "disaster_recovery_switched" {
-   #   project                  = var.project_name
-   #   integration_type         = "disaster_recovery"
-   #   source_service_name      = aiven_postgresql.recovery.service_name
-   #   destination_service_name = aiven_postgresql.primary.service_name
-   # }
-   ```
-
-   or
+1. Remove the switched disaster recovery integration from Terraform state.
 
    ```bash
    terraform destroy -target=aiven_service_integration.disaster_recovery_switched
    ```
 
-1. Restore the original CRDR configuration.
+1. Restore the original integration with the primary service as the source.
 
    ```hcl
    resource "aiven_service_integration" "disaster_recovery" {
      project                  = var.project_name
      integration_type         = "disaster_recovery"
-     source_service_name      = aiven_postgresql.primary.service_name    # Back to original active
-     destination_service_name = aiven_postgresql.recovery.service_name   # Back to original passive
-
-     depends_on = [
-       aiven_postgresql.primary,
-       aiven_postgresql.recovery
-     ]
+     source_service_name      = aiven_postgresql.primary.service_name
+     destination_service_name = aiven_postgresql.recovery.service_name
    }
    ```
 
-1. Wait for the switchback to complete before restoring the original setup.
+1. Apply the restored configuration:
 
    ```bash
    terraform apply
    ```
 
-1. Verify the switchback has been completed successfully.
-
-   ```bash
-   terraform refresh
-   terraform show aiven_service_integration.disaster_recovery
-   ```
-
 </TabItem>
 </Tabs>
 
-When the switchback process is completed, your primary service is **Active**, and the
+After the switchback completes, your primary service is **Active**, and the
 recovery service is **Passive**, which means the primary service is in control over your
 workloads.
 

--- a/docs/products/postgresql/crdr/switchover/crdr-switchover.md
+++ b/docs/products/postgresql/crdr/switchover/crdr-switchover.md
@@ -28,112 +28,134 @@ disaster, or testing the resilience of your infrastructure.
 <Tabs>
 <TabItem value="cli" label="CLI">
 
-Use the [Aiven CLI](/docs/tools/cli) to perform a switchover:
+Run [avn service update](/docs/tools/cli/service-cli#avn-cli-service-update) to promote
+the recovery service to active:
 
 ```bash
-avn service disaster-recovery promote-to-master \
-  --project PROJECT_NAME \
-  SERVICE_NAME
+avn service update RECOVERY_SERVICE_NAME \
+   --disaster-recovery-role active
 ```
 
-Replace the placeholders with your actual values:
+Replace `RECOVERY_SERVICE_NAME` with the name of the recovery service, for example,
+`pg-demo-recovery`.
 
-- `PROJECT_NAME`: Your Aiven project name
-- `SERVICE_NAME`: Name of your recovery PostgreSQL service
+Verify the switchover by checking both services:
 
-Monitor the switchover status:
+- Recovery service status:
 
-```bash
-avn service disaster-recovery get \
-  --project PROJECT_NAME \
-  SERVICE_NAME
-```
+  ```bash
+  avn service get RECOVERY_SERVICE_NAME \
+    --json | jq '{state: .state, disaster_recovery_role: .disaster_recovery_role}'
+  ```
 
-Verify the service state after switchover:
+  Expect the following output:
 
-```bash
-avn service get \
-  --project PROJECT_NAME \
-  SERVICE_NAME
-```
+  ```json
+  {
+    "state": "RUNNING",
+    "disaster_recovery_role": "active"
+  }
+  ```
+
+- Primary service status:
+
+  ```bash
+  avn service get PRIMARY_SERVICE_NAME \
+    --json | jq '{state: .state, disaster_recovery_role: .disaster_recovery_role}'
+  ```
+
+  Expect the following output:
+
+  ```json
+  {
+    "state": "RUNNING",
+    "disaster_recovery_role": "passive"
+  }
+  ```
 
 </TabItem>
 <TabItem value="api" label="API">
 
-Use the [ServiceUpdate](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate) API
-endpoint to perform a switchover:
+Call the [ServiceUpdate endpoint](https://api.aiven.io/doc/#tag/Service/operation/ServiceUpdate)
+to change the `disaster_recovery_role` of the recovery service to `active`:
 
 ```bash
-curl -X PUT \
-  "https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME" \
-  -H "Authorization: Bearer API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "disaster_recovery_promote_to_master": true
-  }'
+curl --request PUT \
+  --url https://api.aiven.io/v1/project/PROJECT_NAME/service/RECOVERY_SERVICE_NAME \
+  -H 'Authorization: Bearer BEARER_TOKEN' \
+  -H 'content-type: application/json' \
+  --data '{"disaster_recovery_role": "active"}'
 ```
 
-Replace the placeholders:
+Replace the following:
 
-- `PROJECT_NAME`: Your Aiven project name
-- `SERVICE_NAME`: Name of your recovery PostgreSQL service
-- `API_TOKEN`: Your Aiven API authentication token
+- `PROJECT_NAME`, for example `crdr-test`
+- `RECOVERY_SERVICE_NAME`, for example `pg-demo-recovery`
+- `BEARER_TOKEN`
 
-Check the disaster recovery status:
+After sending the request, verify the status of each service:
 
-```bash
-curl -X GET \
-  "https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME/disaster-recovery" \
-  -H "Authorization: Bearer API_TOKEN"
-```
+- Recovery service status:
 
-Verify the service state after switchover:
+  ```bash
+  avn service get RECOVERY_SERVICE_NAME \
+    --json | jq '{state: .state, disaster_recovery_role: .disaster_recovery_role}'
+  ```
 
-```bash
-curl -X GET \
-  "https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME" \
-  -H "Authorization: Bearer API_TOKEN"
-```
+  Expect the following output:
+
+  ```json
+  {
+    "state": "RUNNING",
+    "disaster_recovery_role": "active"
+  }
+  ```
+
+- Primary service status:
+
+  ```bash
+  avn service get PRIMARY_SERVICE_NAME \
+    --json | jq '{state: .state, disaster_recovery_role: .disaster_recovery_role}'
+  ```
+
+  Expect the following output:
+
+  ```json
+  {
+    "state": "RUNNING",
+    "disaster_recovery_role": "passive"
+  }
+  ```
 
 </TabItem>
 <TabItem value="tf" label="Terraform">
 
-The
-[`aiven_service_integration`](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/service_integration)
-resource with the `disaster_recovery` type manages the active-passive relationship between
-services. CRDR operations are performed by manipulating this integration.
+The Terraform provider manages the `disaster_recovery` integration as a static topology
+declaration. All integration fields are immutable, so a switchover requires destroying the
+existing integration and creating a new one with the source and destination reversed.
+This approach has a window during which the DR integration is offline. For a
+lower-risk switchover, use the Aiven CLI or API instead.
 
-To trigger switchover and promote the recovery service to active:
+To use Terraform:
 
-1. Comment out or remove the existing disaster recovery integration.
-
-   ```hcl
-   # resource "aiven_service_integration" "disaster_recovery" {
-   #   project                  = var.project_name
-   #   integration_type         = "disaster_recovery"
-   #   source_service_name      = aiven_postgresql.primary.service_name
-   #   destination_service_name = aiven_postgresql.recovery.service_name
-   # }
-   ```
-
-   or
+1. Remove the existing disaster recovery integration from Terraform state.
 
    ```bash
    terraform destroy -target=aiven_service_integration.disaster_recovery
    ```
 
-1. Create an integration with the roles reversed.
+1. Create an integration with the recovery service as the source.
 
    ```hcl
    resource "aiven_service_integration" "disaster_recovery_switched" {
      project                  = var.project_name
      integration_type         = "disaster_recovery"
-     source_service_name      = aiven_postgresql.recovery.service_name   # Now active
-     destination_service_name = aiven_postgresql.primary.service_name    # Now passive
+     source_service_name      = aiven_postgresql.recovery.service_name
+     destination_service_name = aiven_postgresql.primary.service_name
    }
    ```
 
-1. Wait for the switchover to complete before applying the new configuration.
+1. Apply the new configuration:
 
    ```bash
    terraform apply
@@ -142,7 +164,7 @@ To trigger switchover and promote the recovery service to active:
 </TabItem>
 </Tabs>
 
-When the switchover process is completed, your primary service is **Passive**, and the
+After the switchover completes, your primary service is **Passive**, and the
 recovery service is **Active**, which means the recovery service is in control over your
 workloads.
 


### PR DESCRIPTION
https://aiven.atlassian.net/browse/PGSQL-781

Major changes:

- crdr-overview.md
  - Added Developer plan to the unsupported plans list (confirmed blocked in aiven-core: free, developer, hobbyist tiers are excluded)
- crdr-switchover.md (major corrections)
  - Replaced `avn service disaster-recovery promote-to-master` (command doesn't exist) with `avn service update RECOVERY_SERVICE_NAME --disaster-recovery-role active`
  - Replaced `avn service disaster-recovery get` (command doesn't exist) with `avn service get ... --json | jq`
  - Replaced `"disaster_recovery_promote_to_master": true` API field (field doesn't exist) with `"disaster_recovery_role": "active"` on the recovery service
  - Removed the fake `/disaster-recovery GET` API endpoint
  - Rewrote the Terraform tab to be honest: notes the immutable fields limitation, the DR gap window, and recommends CLI/API for lower risk
- crdr-switchback.md (same corrections as switchover, mirrored for primary service)
  - All wrong CLI/API commands replaced with correct `disaster_recovery_role: active` pattern on the primary service
  - Terraform tab rewritten with honest caveats