### PR TITLE
update: Clarify Flink service creation availability

### DIFF
--- a/static/includes/flink-service-creation-limitation.md
+++ b/static/includes/flink-service-creation-limitation.md
@@ -1,10 +1,13 @@
 :::note
 
-**Aiven for Apache Flink® service creation is limited**
+**Aiven for Apache Flink® is not available for new service creation**
 
-Creating a new Aiven for Apache Flink® service is currently limited.
-If your organization does not have access to create an Aiven for Apache Flink service,
+Aiven no longer offers Aiven for Apache Flink® for new service creation.
+Existing Aiven for Apache Flink services remain fully supported, and current customers
+can continue to use and manage them as usual.
+If you have an existing Aiven for Apache Flink service and need assistance,
 open a [support ticket](/docs/platform/howto/support#create-a-support-ticket) or
-contact [Aiven Support](mailto:support@aiven.io) for assistance.
+contact [Aiven Support](mailto:support@aiven.io). For new stream-processing needs,
+contact your Aiven account manager to discuss the options available to you.
 
 :::


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
