### PR TITLE
update: Add Ahrefs analytics script to docs site

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -129,6 +129,11 @@ const config: Config = {
     },
   ],
   scripts: [
+    {
+      src: 'https://analytics.ahrefs.com/analytics.js',
+      'data-key': 'aKHyPgCOLHo1m4IX2uzglw',
+      async: true,
+    },
     {src: '/docs/page_scripts/snowplow.js', async: true},
     {
       src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js',


### PR DESCRIPTION
## Describe your changes

Adds the Ahrefs Web Analytics tracking snippet to the docs site so we can track traffic and keyword rankings for aiven.io/docs pages 

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
