### PR TITLE
update: Database service management reuse - PART 2

### DIFF
--- a/docs/products/grafana/backups-migration.md
+++ b/docs/products/grafana/backups-migration.md
@@ -1,0 +1,14 @@
+---
+title: Backups and migration in Aiven for Grafana®
+sidebar_label: Backups and migration
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Protect and recover your Aiven for Grafana® service data with cross-region backups and
+restore tracking.
+
+<RelatedPages/>
+
+- [Backup to another region](/docs/products/grafana/howto/backup-to-another-region)
+- [Track restore progress](/docs/products/grafana/howto/track-restore-progress)

--- a/docs/products/grafana/concepts/service-memory.md
+++ b/docs/products/grafana/concepts/service-memory.md
@@ -1,0 +1,23 @@
+---
+title: Memory and out-of-memory conditions in Aiven for Grafana®
+sidebar_label: Memory and out-of-memory
+---
+
+import ServiceMemoryLimits from "@site/static/includes/service-memory-limits.md";
+import OutOfMemory from "@site/static/includes/out-of-memory-condition.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Understand the memory limits and out-of-memory conditions that apply to your Aiven for Grafana® service.
+
+## Service memory limits
+
+<ServiceMemoryLimits/>
+
+## Out of memory conditions
+
+<OutOfMemory/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/grafana/howto/change-service-plan)
+- [Prepare for high load](/docs/products/grafana/howto/prepare-for-high-load)

--- a/docs/products/grafana/howto/backup-to-another-region.md
+++ b/docs/products/grafana/howto/backup-to-another-region.md
@@ -1,0 +1,19 @@
+---
+title: Back up your Aiven for Grafana® service to another region
+sidebar_label: Backup to another region
+---
+
+import BtarConcepts from "@site/static/includes/btar-concepts.md";
+import BtarInstructions from "@site/static/includes/btar-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Copy your Aiven for Grafana® service backups to a secondary region for disaster recovery.
+
+<BtarConcepts/>
+
+<BtarInstructions/>
+
+<RelatedPages/>
+
+- [Track restore progress](/docs/products/grafana/howto/track-restore-progress)
+- [Fork your service](/docs/products/grafana/howto/fork-service)

--- a/docs/products/grafana/howto/change-cloud-region.md
+++ b/docs/products/grafana/howto/change-cloud-region.md
@@ -1,0 +1,19 @@
+---
+title: Change the cloud or region for your Aiven for Grafana® service
+sidebar_label: Change cloud or region
+---
+
+import ChangeCloud from "@site/static/includes/change-cloud-console.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Move your Aiven for Grafana® service to a different cloud provider or region.
+
+<ChangeCloud/>
+
+Your service starts a migration to the new location and remains available during the process.
+When the migration completes, the service continues running in the new cloud or region.
+
+<RelatedPages/>
+
+- [Fork your service](/docs/products/grafana/howto/fork-service)
+- [Migrate to another cloud or region](/docs/platform/howto/migrate-services-cloud-region)

--- a/docs/products/grafana/howto/change-service-plan.md
+++ b/docs/products/grafana/howto/change-service-plan.md
@@ -1,0 +1,16 @@
+---
+title: Change the plan for your Aiven for Grafana® service
+sidebar_label: Change service plan
+---
+
+import ChangePlan from "@site/static/includes/change-service-plan.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Change the service plan for your Aiven for Grafana® service to scale resources up or down and optimize costs.
+
+<ChangePlan/>
+
+<RelatedPages/>
+
+- [Prepare for high load](/docs/products/grafana/howto/prepare-for-high-load)
+- [Memory and out-of-memory conditions](/docs/products/grafana/concepts/service-memory)

--- a/docs/products/grafana/howto/connect-service.md
+++ b/docs/products/grafana/howto/connect-service.md
@@ -1,0 +1,16 @@
+---
+title: Connect to your Aiven for Grafana® service
+sidebar_label: Connect to a service
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+After your service is running, connect to it and start using it.
+
+For details on accessing and using your service, see
+[Get started with Aiven for Grafana®](/docs/products/grafana/get-started).
+
+<RelatedPages/>
+
+- [Get started with Aiven for Grafana®](/docs/products/grafana/get-started)
+- [Create a service](/docs/products/grafana/howto/create-service)

--- a/docs/products/grafana/howto/create-service.md
+++ b/docs/products/grafana/howto/create-service.md
@@ -1,0 +1,16 @@
+---
+title: Create an Aiven for Grafana® service
+sidebar_label: Create a service
+---
+
+import CreateService from "@site/static/includes/create-service-console.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Create an Aiven for Grafana® service in the [Aiven Console](https://console.aiven.io).
+
+<CreateService serviceType="Grafana®"/>
+
+<RelatedPages/>
+
+- [Connect to a service](/docs/products/grafana/howto/connect-service)
+- [Create a service with the CLI, API, or Terraform](/docs/platform/howto/create_new_service)

--- a/docs/products/grafana/howto/maintenance-updates.md
+++ b/docs/products/grafana/howto/maintenance-updates.md
@@ -1,0 +1,27 @@
+---
+title: Maintenance and updates for your Aiven for Grafana® service
+sidebar_label: Maintenance and updates
+---
+
+import MaintenanceUpdates from "@site/static/includes/maintenance-updates.md";
+import MaintenanceWindowConcepts from "@site/static/includes/maintenance-window-concepts.md";
+import MaintenanceWindowInstructions from "@site/static/includes/maintenance-window-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Manage maintenance updates and set the maintenance window for your Aiven for Grafana® service.
+
+## Maintenance updates
+
+<MaintenanceUpdates/>
+
+## Maintenance window
+
+<MaintenanceWindowConcepts/>
+
+## Set the maintenance window {#set-the-maintenance-window}
+
+<MaintenanceWindowInstructions/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/grafana/howto/change-service-plan)

--- a/docs/products/grafana/howto/prepare-for-high-load.md
+++ b/docs/products/grafana/howto/prepare-for-high-load.md
@@ -1,0 +1,16 @@
+---
+title: Prepare your Aiven for Grafana® service for high load
+sidebar_label: Prepare for high load
+---
+
+import PrepareHighLoad from "@site/static/includes/prepare-for-high-load.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Prepare your Aiven for Grafana® service for higher than usual traffic to avoid outages and keep performance stable.
+
+<PrepareHighLoad/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/grafana/howto/change-service-plan)
+- [Maintenance and updates](/docs/products/grafana/howto/maintenance-updates)

--- a/docs/products/grafana/howto/track-restore-progress.md
+++ b/docs/products/grafana/howto/track-restore-progress.md
@@ -1,0 +1,16 @@
+---
+title: Track restore progress for your Aiven for Grafana® service
+sidebar_label: Track restore progress
+---
+
+import RestoreProgress from "@site/static/includes/restore-progress-tracking.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Track the restore progress of individual nodes in your Aiven for Grafana® service during node replacement, forking, or maintenance, using the Aiven API.
+
+<RestoreProgress/>
+
+<RelatedPages/>
+
+- [Fork your service](/docs/products/grafana/howto/fork-service)
+- [Back up to another region](/docs/products/grafana/howto/backup-to-another-region)

--- a/docs/products/grafana/maintenance-lifecycle.md
+++ b/docs/products/grafana/maintenance-lifecycle.md
@@ -1,0 +1,13 @@
+---
+title: Maintenance and lifecycle in Aiven for Grafana®
+sidebar_label: Maintenance and lifecycle
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Manage maintenance updates and the maintenance window for your Aiven for Grafana® service.
+
+<RelatedPages/>
+
+- [Maintenance and updates](/docs/products/grafana/howto/maintenance-updates)
+- [Maintenance window](/docs/platform/concepts/maintenance-window)

--- a/docs/products/grafana/scaling-performance.md
+++ b/docs/products/grafana/scaling-performance.md
@@ -1,0 +1,14 @@
+---
+title: Scaling and performance in Aiven for Grafana®
+sidebar_label: Scaling and performance
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Scale resources and prepare your Aiven for Grafana® service for changing load.
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/grafana/howto/change-service-plan)
+- [Prepare for high load](/docs/products/grafana/howto/prepare-for-high-load)
+- [Memory and out-of-memory conditions](/docs/products/grafana/concepts/service-memory)

--- a/docs/products/metrics/concepts/service-memory.md
+++ b/docs/products/metrics/concepts/service-memory.md
@@ -1,0 +1,23 @@
+---
+title: Memory and out-of-memory conditions in Aiven for Metrics
+sidebar_label: Memory and out-of-memory
+---
+
+import ServiceMemoryLimits from "@site/static/includes/service-memory-limits.md";
+import OutOfMemory from "@site/static/includes/out-of-memory-condition.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Understand the memory limits and out-of-memory conditions that apply to your Aiven for Metrics service.
+
+## Service memory limits
+
+<ServiceMemoryLimits/>
+
+## Out of memory conditions
+
+<OutOfMemory/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/metrics/howto/change-service-plan)
+- [Prepare for high load](/docs/products/metrics/howto/prepare-for-high-load)

--- a/docs/products/metrics/howto/change-cloud-region.md
+++ b/docs/products/metrics/howto/change-cloud-region.md
@@ -1,0 +1,19 @@
+---
+title: Change the cloud or region for your Aiven for Metrics service
+sidebar_label: Change cloud or region
+---
+
+import ChangeCloud from "@site/static/includes/change-cloud-console.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Move your Aiven for Metrics service to a different cloud provider or region.
+
+<ChangeCloud/>
+
+Your service starts a migration to the new location and remains available during the process.
+When the migration completes, the service continues running in the new cloud or region.
+
+<RelatedPages/>
+
+- [Migrate to another cloud or region](/docs/platform/howto/migrate-services-cloud-region)
+- [Change the service plan](/docs/products/metrics/howto/change-service-plan)

--- a/docs/products/metrics/howto/change-service-plan.md
+++ b/docs/products/metrics/howto/change-service-plan.md
@@ -1,0 +1,16 @@
+---
+title: Change the plan for your Aiven for Metrics service
+sidebar_label: Change service plan
+---
+
+import ChangePlan from "@site/static/includes/change-service-plan.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Change the service plan for your Aiven for Metrics service to scale resources up or down and optimize costs.
+
+<ChangePlan/>
+
+<RelatedPages/>
+
+- [Prepare for high load](/docs/products/metrics/howto/prepare-for-high-load)
+- [Memory and out-of-memory conditions](/docs/products/metrics/concepts/service-memory)

--- a/docs/products/metrics/howto/connect-service.md
+++ b/docs/products/metrics/howto/connect-service.md
@@ -1,0 +1,16 @@
+---
+title: Connect to your Aiven for Metrics service
+sidebar_label: Connect to a service
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+After your service is running, connect to it and start using it.
+
+For details on accessing and using your service, see
+[Get started with Aiven for Metrics](/docs/products/metrics/get-started).
+
+<RelatedPages/>
+
+- [Get started with Aiven for Metrics](/docs/products/metrics/get-started)
+- [Create a service](/docs/products/metrics/howto/create-service)

--- a/docs/products/metrics/howto/create-service.md
+++ b/docs/products/metrics/howto/create-service.md
@@ -1,0 +1,16 @@
+---
+title: Create an Aiven for Metrics service
+sidebar_label: Create a service
+---
+
+import CreateService from "@site/static/includes/create-service-console.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Create an Aiven for Metrics service in the [Aiven Console](https://console.aiven.io).
+
+<CreateService serviceType="Thanos Metrics"/>
+
+<RelatedPages/>
+
+- [Connect to a service](/docs/products/metrics/howto/connect-service)
+- [Create a service with the CLI, API, or Terraform](/docs/platform/howto/create_new_service)

--- a/docs/products/metrics/howto/maintenance-updates.md
+++ b/docs/products/metrics/howto/maintenance-updates.md
@@ -1,0 +1,27 @@
+---
+title: Maintenance and updates for your Aiven for Metrics service
+sidebar_label: Maintenance and updates
+---
+
+import MaintenanceUpdates from "@site/static/includes/maintenance-updates.md";
+import MaintenanceWindowConcepts from "@site/static/includes/maintenance-window-concepts.md";
+import MaintenanceWindowInstructions from "@site/static/includes/maintenance-window-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Manage maintenance updates and set the maintenance window for your Aiven for Metrics service.
+
+## Maintenance updates
+
+<MaintenanceUpdates/>
+
+## Maintenance window
+
+<MaintenanceWindowConcepts/>
+
+## Set the maintenance window {#set-the-maintenance-window}
+
+<MaintenanceWindowInstructions/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/metrics/howto/change-service-plan)

--- a/docs/products/metrics/howto/prepare-for-high-load.md
+++ b/docs/products/metrics/howto/prepare-for-high-load.md
@@ -1,0 +1,16 @@
+---
+title: Prepare your Aiven for Metrics service for high load
+sidebar_label: Prepare for high load
+---
+
+import PrepareHighLoad from "@site/static/includes/prepare-for-high-load.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Prepare your Aiven for Metrics service for higher than usual traffic to avoid outages and keep performance stable.
+
+<PrepareHighLoad/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/metrics/howto/change-service-plan)
+- [Maintenance and updates](/docs/products/metrics/howto/maintenance-updates)

--- a/docs/products/metrics/howto/track-restore-progress.md
+++ b/docs/products/metrics/howto/track-restore-progress.md
@@ -1,0 +1,15 @@
+---
+title: Track restore progress for your Aiven for Metrics service
+sidebar_label: Track restore progress
+---
+
+import RestoreProgress from "@site/static/includes/restore-progress-tracking.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Track the restore progress of individual nodes in your Aiven for Metrics service during node replacement, forking, or maintenance, using the Aiven API.
+
+<RestoreProgress/>
+
+<RelatedPages/>
+- [Maintenance and updates](/docs/products/metrics/howto/maintenance-updates)
+- [Change cloud or region](/docs/products/metrics/howto/change-cloud-region)

--- a/docs/products/metrics/maintenance-lifecycle.md
+++ b/docs/products/metrics/maintenance-lifecycle.md
@@ -1,0 +1,15 @@
+---
+title: Maintenance and lifecycle in Aiven for Metrics
+sidebar_label: Maintenance and lifecycle
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Manage maintenance updates, maintenance windows, and node restore progress for your
+Aiven for Metrics service.
+
+<RelatedPages/>
+
+- [Maintenance and updates](/docs/products/metrics/howto/maintenance-updates)
+- [Track restore progress](/docs/products/metrics/howto/track-restore-progress)
+- [Maintenance window](/docs/platform/concepts/maintenance-window)

--- a/docs/products/metrics/scaling-performance.md
+++ b/docs/products/metrics/scaling-performance.md
@@ -1,0 +1,14 @@
+---
+title: Scaling and performance in Aiven for Metrics
+sidebar_label: Scaling and performance
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Scale resources and prepare your Aiven for Metrics service for changing load.
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/metrics/howto/change-service-plan)
+- [Prepare for high load](/docs/products/metrics/howto/prepare-for-high-load)
+- [Memory and out-of-memory conditions](/docs/products/metrics/concepts/service-memory)

--- a/docs/products/mysql/concepts/mysql-memory-usage.md
+++ b/docs/products/mysql/concepts/mysql-memory-usage.md
@@ -3,6 +3,10 @@ title: Understand MySQL memory usage
 sidebar_label: Memory usage
 ---
 
+import RelatedPages from "@site/src/components/RelatedPages";
+import ServiceMemoryLimits from "@site/static/includes/service-memory-limits.md";
+import OutOfMemory from "@site/static/includes/out-of-memory-condition.md";
+
 MySQL memory utilization can appear high, even if the service is relatively idle.
 
 [All services are subject to operating overhead](/docs/platform/concepts/service-memory-limits), but some services, including MySQL, pre-allocate memory.
@@ -113,3 +117,16 @@ determine if:
 -   The sum of the buffer pools are greater than the
     [available service memory](/docs/platform/concepts/service-memory-limits)
 -   Queries are generating excessive temporary (spill) files
+
+## Service memory limits
+
+<ServiceMemoryLimits/>
+
+## Out of memory conditions
+
+<OutOfMemory/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/mysql/howto/change-service-plan)
+- [Scale disk storage](/docs/products/mysql/howto/scale-disk-storage)

--- a/docs/products/mysql/howto/backup-to-another-region.md
+++ b/docs/products/mysql/howto/backup-to-another-region.md
@@ -1,0 +1,19 @@
+---
+title: Back up your Aiven for MySQL® service to another region
+sidebar_label: Backup to another region
+---
+
+import BtarConcepts from "@site/static/includes/btar-concepts.md";
+import BtarInstructions from "@site/static/includes/btar-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Copy your Aiven for MySQL® service backups to a secondary region for disaster recovery.
+
+<BtarConcepts/>
+
+<BtarInstructions/>
+
+<RelatedPages/>
+
+- [Backups](/docs/products/mysql/concepts/mysql-backups)
+- [Track restore progress](/docs/products/mysql/howto/track-restore-progress)

--- a/docs/products/mysql/howto/change-cloud-region.md
+++ b/docs/products/mysql/howto/change-cloud-region.md
@@ -1,0 +1,19 @@
+---
+title: Change the cloud or region for your Aiven for MySQL® service
+sidebar_label: Change cloud or region
+---
+
+import ChangeCloud from "@site/static/includes/change-cloud-console.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Move your Aiven for MySQL® service to a different cloud provider or region.
+
+<ChangeCloud/>
+
+Your service starts a migration to the new location and remains available during the process.
+When the migration completes, the service continues running in the new cloud or region.
+
+<RelatedPages/>
+
+- [Fork your service](/docs/products/mysql/howto/fork-service)
+- [Migrate to another cloud or region](/docs/platform/howto/migrate-services-cloud-region)

--- a/docs/products/mysql/howto/change-service-plan.md
+++ b/docs/products/mysql/howto/change-service-plan.md
@@ -1,0 +1,16 @@
+---
+title: Change the plan for your Aiven for MySQL® service
+sidebar_label: Change service plan
+---
+
+import ChangePlan from "@site/static/includes/change-service-plan.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Change the service plan for your Aiven for MySQL® service to scale resources up or down and optimize costs.
+
+<ChangePlan/>
+
+<RelatedPages/>
+
+- [Scale disk storage](/docs/products/mysql/howto/scale-disk-storage)
+- [Prepare for high load](/docs/products/mysql/howto/prepare-for-high-load)

--- a/docs/products/mysql/howto/connect-service.md
+++ b/docs/products/mysql/howto/connect-service.md
@@ -1,0 +1,15 @@
+---
+title: Connect to your Aiven for MySQL® service
+sidebar_label: Connect to a service
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+After your service is running, connect to it using your preferred tools and clients.
+
+Check more tools for connecting to Aiven for MySQL® in [Connect to Aiven for MySQL®](/docs/products/mysql/howto/list-code-samples).
+
+<RelatedPages/>
+
+- [Connect to Aiven for MySQL®](/docs/products/mysql/howto/list-code-samples)
+- [Create a service](/docs/products/mysql/howto/create-service)

--- a/docs/products/mysql/howto/connect-service.md
+++ b/docs/products/mysql/howto/connect-service.md
@@ -7,7 +7,7 @@ import RelatedPages from "@site/src/components/RelatedPages";
 
 After your service is running, connect to it using your preferred tools and clients.
 
-Check more tools for connecting to Aiven for MySQL® in [Connect to Aiven for MySQL®](/docs/products/mysql/howto/list-code-samples).
+Browse all supported tools for connecting to Aiven for MySQL® in [Connect to Aiven for MySQL®](/docs/products/mysql/howto/list-code-samples).
 
 <RelatedPages/>
 

--- a/docs/products/mysql/howto/create-service.md
+++ b/docs/products/mysql/howto/create-service.md
@@ -1,0 +1,16 @@
+---
+title: Create an Aiven for MySQL® service
+sidebar_label: Create a service
+---
+
+import CreateService from "@site/static/includes/create-service-console.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Create an Aiven for MySQL® service in the [Aiven Console](https://console.aiven.io).
+
+<CreateService serviceType="MySQL"/>
+
+<RelatedPages/>
+
+- [Connect to a service](/docs/products/mysql/howto/connect-service)
+- [Create a service with the CLI, API, or Terraform](/docs/platform/howto/create_new_service)

--- a/docs/products/mysql/howto/maintenance-updates.md
+++ b/docs/products/mysql/howto/maintenance-updates.md
@@ -1,0 +1,28 @@
+---
+title: Maintenance and updates for your Aiven for MySQL® service
+sidebar_label: Maintenance and updates
+---
+
+import MaintenanceUpdates from "@site/static/includes/maintenance-updates.md";
+import MaintenanceWindowConcepts from "@site/static/includes/maintenance-window-concepts.md";
+import MaintenanceWindowInstructions from "@site/static/includes/maintenance-window-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Manage maintenance updates and set the maintenance window for your Aiven for MySQL® service.
+
+## Maintenance updates
+
+<MaintenanceUpdates/>
+
+## Maintenance window
+
+<MaintenanceWindowConcepts/>
+
+## Set the maintenance window {#set-the-maintenance-window}
+
+<MaintenanceWindowInstructions/>
+
+<RelatedPages/>
+
+- [Version upgrades](/docs/products/mysql/howto/manage-mysql-version)
+- [Change the service plan](/docs/products/mysql/howto/change-service-plan)

--- a/docs/products/mysql/howto/prepare-for-high-load.md
+++ b/docs/products/mysql/howto/prepare-for-high-load.md
@@ -1,0 +1,16 @@
+---
+title: Prepare your Aiven for MySQL® service for high load
+sidebar_label: Prepare for high load
+---
+
+import PrepareHighLoad from "@site/static/includes/prepare-for-high-load.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Prepare your Aiven for MySQL® service for higher than usual traffic to avoid outages and keep performance stable.
+
+<PrepareHighLoad/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/mysql/howto/change-service-plan)
+- [Scale disk storage](/docs/products/mysql/howto/scale-disk-storage)

--- a/docs/products/mysql/howto/scale-disk-storage.md
+++ b/docs/products/mysql/howto/scale-disk-storage.md
@@ -1,0 +1,21 @@
+---
+title: Scale disk storage for your Aiven for MySQL® service
+sidebar_label: Scale disk storage
+---
+
+import DiskConcepts from "@site/static/includes/scale-disk-storage-concepts.md";
+import DiskInstructions from "@site/static/includes/scale-disk-storage-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Scale the disk storage of your Aiven for MySQL® service up or down without disrupting the running service.
+
+<DiskConcepts/>
+
+## Add or remove storage
+
+<DiskInstructions/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/mysql/howto/change-service-plan)
+- [Memory and out-of-memory conditions](/docs/products/mysql/concepts/mysql-memory-usage)

--- a/docs/products/mysql/howto/track-restore-progress.md
+++ b/docs/products/mysql/howto/track-restore-progress.md
@@ -1,0 +1,16 @@
+---
+title: Track restore progress for your Aiven for MySQL® service
+sidebar_label: Track restore progress
+---
+
+import RestoreProgress from "@site/static/includes/restore-progress-tracking.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Track the restore progress of individual nodes in your Aiven for MySQL® service during node replacement, forking, or maintenance, using the Aiven API.
+
+<RestoreProgress/>
+
+<RelatedPages/>
+
+- [Backups](/docs/products/mysql/concepts/mysql-backups)
+- [Fork your service](/docs/products/mysql/howto/fork-service)

--- a/docs/products/opensearch/concepts/service-memory.md
+++ b/docs/products/opensearch/concepts/service-memory.md
@@ -1,0 +1,23 @@
+---
+title: Memory and out-of-memory conditions in Aiven for OpenSearch®
+sidebar_label: Memory and out-of-memory
+---
+
+import ServiceMemoryLimits from "@site/static/includes/service-memory-limits.md";
+import OutOfMemory from "@site/static/includes/out-of-memory-condition.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Understand the memory limits and out-of-memory conditions that apply to your Aiven for OpenSearch® service.
+
+## Service memory limits
+
+<ServiceMemoryLimits/>
+
+## Out of memory conditions
+
+<OutOfMemory/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/opensearch/howto/change-service-plan)
+- [Scale disk storage](/docs/products/opensearch/howto/scale-disk-storage)

--- a/docs/products/opensearch/howto/backup-to-another-region.md
+++ b/docs/products/opensearch/howto/backup-to-another-region.md
@@ -1,0 +1,19 @@
+---
+title: Back up your Aiven for OpenSearch® service to another region
+sidebar_label: Backup to another region
+---
+
+import BtarConcepts from "@site/static/includes/btar-concepts.md";
+import BtarInstructions from "@site/static/includes/btar-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Copy your Aiven for OpenSearch® service backups to a secondary region for disaster recovery.
+
+<BtarConcepts/>
+
+<BtarInstructions/>
+
+<RelatedPages/>
+
+- [Backups](/docs/products/opensearch/howto/restore_opensearch_backup)
+- [Track restore progress](/docs/products/opensearch/howto/track-restore-progress)

--- a/docs/products/opensearch/howto/change-cloud-region.md
+++ b/docs/products/opensearch/howto/change-cloud-region.md
@@ -1,0 +1,19 @@
+---
+title: Change the cloud or region for your Aiven for OpenSearch® service
+sidebar_label: Change cloud or region
+---
+
+import ChangeCloud from "@site/static/includes/change-cloud-console.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Move your Aiven for OpenSearch® service to a different cloud provider or region.
+
+<ChangeCloud/>
+
+Your service starts a migration to the new location and remains available during the process.
+When the migration completes, the service continues running in the new cloud or region.
+
+<RelatedPages/>
+
+- [Fork your service](/docs/products/opensearch/howto/fork-service)
+- [Migrate to another cloud or region](/docs/platform/howto/migrate-services-cloud-region)

--- a/docs/products/opensearch/howto/change-service-plan.md
+++ b/docs/products/opensearch/howto/change-service-plan.md
@@ -1,0 +1,16 @@
+---
+title: Change the plan for your Aiven for OpenSearch® service
+sidebar_label: Change service plan
+---
+
+import ChangePlan from "@site/static/includes/change-service-plan.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Change the service plan for your Aiven for OpenSearch® service to scale resources up or down and optimize costs.
+
+<ChangePlan/>
+
+<RelatedPages/>
+
+- [Scale disk storage](/docs/products/opensearch/howto/scale-disk-storage)
+- [Prepare for high load](/docs/products/opensearch/howto/prepare-for-high-load)

--- a/docs/products/opensearch/howto/connect-service.md
+++ b/docs/products/opensearch/howto/connect-service.md
@@ -7,7 +7,7 @@ import RelatedPages from "@site/src/components/RelatedPages";
 
 After your service is running, connect to it using your preferred tools and clients.
 
-Check more tools for connecting to Aiven for OpenSearch® in [Connect to Aiven for OpenSearch®](/docs/products/opensearch/howto/list-connect-to-service).
+Browse all supported tools for connecting to Aiven for OpenSearch® in [Connect to Aiven for OpenSearch®](/docs/products/opensearch/howto/list-connect-to-service).
 
 <RelatedPages/>
 

--- a/docs/products/opensearch/howto/connect-service.md
+++ b/docs/products/opensearch/howto/connect-service.md
@@ -1,0 +1,15 @@
+---
+title: Connect to your Aiven for OpenSearch® service
+sidebar_label: Connect to a service
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+After your service is running, connect to it using your preferred tools and clients.
+
+Check more tools for connecting to Aiven for OpenSearch® in [Connect to Aiven for OpenSearch®](/docs/products/opensearch/howto/list-connect-to-service).
+
+<RelatedPages/>
+
+- [Connect to Aiven for OpenSearch®](/docs/products/opensearch/howto/list-connect-to-service)
+- [Create a service](/docs/products/opensearch/howto/create-service)

--- a/docs/products/opensearch/howto/create-service.md
+++ b/docs/products/opensearch/howto/create-service.md
@@ -1,0 +1,16 @@
+---
+title: Create an Aiven for OpenSearch® service
+sidebar_label: Create a service
+---
+
+import CreateService from "@site/static/includes/create-service-console.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Create an Aiven for OpenSearch® service in the [Aiven Console](https://console.aiven.io).
+
+<CreateService serviceType="OpenSearch®"/>
+
+<RelatedPages/>
+
+- [Connect to a service](/docs/products/opensearch/howto/connect-service)
+- [Create a service with the CLI, API, or Terraform](/docs/platform/howto/create_new_service)

--- a/docs/products/opensearch/howto/maintenance-updates.md
+++ b/docs/products/opensearch/howto/maintenance-updates.md
@@ -1,0 +1,28 @@
+---
+title: Maintenance and updates for your Aiven for OpenSearch® service
+sidebar_label: Maintenance and updates
+---
+
+import MaintenanceUpdates from "@site/static/includes/maintenance-updates.md";
+import MaintenanceWindowConcepts from "@site/static/includes/maintenance-window-concepts.md";
+import MaintenanceWindowInstructions from "@site/static/includes/maintenance-window-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Manage maintenance updates and set the maintenance window for your Aiven for OpenSearch® service.
+
+## Maintenance updates
+
+<MaintenanceUpdates/>
+
+## Maintenance window
+
+<MaintenanceWindowConcepts/>
+
+## Set the maintenance window {#set-the-maintenance-window}
+
+<MaintenanceWindowInstructions/>
+
+<RelatedPages/>
+
+- [Version upgrades](/docs/products/opensearch/howto/os-version-upgrade)
+- [Change the service plan](/docs/products/opensearch/howto/change-service-plan)

--- a/docs/products/opensearch/howto/prepare-for-high-load.md
+++ b/docs/products/opensearch/howto/prepare-for-high-load.md
@@ -1,0 +1,16 @@
+---
+title: Prepare your Aiven for OpenSearch® service for high load
+sidebar_label: Prepare for high load
+---
+
+import PrepareHighLoad from "@site/static/includes/prepare-for-high-load.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Prepare your Aiven for OpenSearch® service for higher than usual traffic to avoid outages and keep performance stable.
+
+<PrepareHighLoad/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/opensearch/howto/change-service-plan)
+- [Scale disk storage](/docs/products/opensearch/howto/scale-disk-storage)

--- a/docs/products/opensearch/howto/scale-disk-storage.md
+++ b/docs/products/opensearch/howto/scale-disk-storage.md
@@ -1,0 +1,21 @@
+---
+title: Scale disk storage for your Aiven for OpenSearch® service
+sidebar_label: Scale disk storage
+---
+
+import DiskConcepts from "@site/static/includes/scale-disk-storage-concepts.md";
+import DiskInstructions from "@site/static/includes/scale-disk-storage-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Scale the disk storage of your Aiven for OpenSearch® service up or down without disrupting the running service.
+
+<DiskConcepts/>
+
+## Add or remove storage
+
+<DiskInstructions/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/opensearch/howto/change-service-plan)
+- [Memory and out-of-memory conditions](/docs/products/opensearch/concepts/service-memory)

--- a/docs/products/opensearch/howto/track-restore-progress.md
+++ b/docs/products/opensearch/howto/track-restore-progress.md
@@ -1,0 +1,16 @@
+---
+title: Track restore progress for your Aiven for OpenSearch® service
+sidebar_label: Track restore progress
+---
+
+import RestoreProgress from "@site/static/includes/restore-progress-tracking.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Track the restore progress of individual nodes in your Aiven for OpenSearch® service during node replacement, forking, or maintenance, using the Aiven API.
+
+<RestoreProgress/>
+
+<RelatedPages/>
+
+- [Backups](/docs/products/opensearch/howto/restore_opensearch_backup)
+- [Fork your service](/docs/products/opensearch/howto/fork-service)

--- a/docs/products/opensearch/scaling-performance.md
+++ b/docs/products/opensearch/scaling-performance.md
@@ -1,0 +1,15 @@
+---
+title: Scaling and performance in Aiven for OpenSearch®
+sidebar_label: Scaling and performance
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Scale resources and tune performance to keep your Aiven for OpenSearch® service running
+efficiently as it grows.
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/opensearch/howto/change-service-plan)
+- [Scale disk storage](/docs/products/opensearch/howto/scale-disk-storage)
+- [Prepare for high load](/docs/products/opensearch/howto/prepare-for-high-load)

--- a/docs/products/postgresql/concepts/pg-shared-buffers.md
+++ b/docs/products/postgresql/concepts/pg-shared-buffers.md
@@ -4,6 +4,8 @@ sidebar_label: Shared buffers
 ---
 
 import RelatedPages from "@site/src/components/RelatedPages";
+import ServiceMemoryLimits from "@site/static/includes/service-memory-limits.md";
+import OutOfMemory from "@site/static/includes/out-of-memory-condition.md";
 
 Use shared buffers to share memory over multiple sessions. Discover how to inspect the database cache performance and the query cache performance and learn how to put data into cache manually.
 
@@ -206,6 +208,14 @@ pg_prewarm
 If the `shared buffers` size is less than pre-loaded data, only the
 tailing end of the data is cached as the earlier data encounters a
 forced ejection.
+
+## Service memory limits
+
+<ServiceMemoryLimits/>
+
+## Out of memory conditions
+
+<OutOfMemory/>
 
 <RelatedPages/>
 

--- a/docs/products/postgresql/howto/backup-to-another-region.md
+++ b/docs/products/postgresql/howto/backup-to-another-region.md
@@ -1,0 +1,19 @@
+---
+title: Back up your Aiven for PostgreSQL® service to another region
+sidebar_label: Backup to another region
+---
+
+import BtarConcepts from "@site/static/includes/btar-concepts.md";
+import BtarInstructions from "@site/static/includes/btar-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Copy your Aiven for PostgreSQL® service backups to a secondary region for disaster recovery.
+
+<BtarConcepts/>
+
+<BtarInstructions/>
+
+<RelatedPages/>
+
+- [Backups](/docs/products/postgresql/concepts/pg-backups)
+- [Track restore progress](/docs/products/postgresql/howto/track-restore-progress)

--- a/docs/products/postgresql/howto/change-service-plan.md
+++ b/docs/products/postgresql/howto/change-service-plan.md
@@ -1,0 +1,16 @@
+---
+title: Change the plan for your Aiven for PostgreSQL® service
+sidebar_label: Change service plan
+---
+
+import ChangePlan from "@site/static/includes/change-service-plan.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Change the service plan for your Aiven for PostgreSQL® service to scale resources up or down and optimize costs.
+
+<ChangePlan/>
+
+<RelatedPages/>
+
+- [Scale disk storage](/docs/products/postgresql/howto/scale-disk-storage)
+- [Prepare for high load](/docs/products/postgresql/howto/prepare-for-high-load)

--- a/docs/products/postgresql/howto/connect-service.md
+++ b/docs/products/postgresql/howto/connect-service.md
@@ -1,0 +1,15 @@
+---
+title: Connect to your Aiven for PostgreSQL® service
+sidebar_label: Connect to a service
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+After your service is running, connect to it using your preferred tools and clients.
+
+Check more tools for connecting to Aiven for PostgreSQL® in [Connect to Aiven for PostgreSQL®](/docs/products/postgresql/howto/list-code-samples).
+
+<RelatedPages/>
+
+- [Connect to Aiven for PostgreSQL®](/docs/products/postgresql/howto/list-code-samples)
+- [Create a service](/docs/products/postgresql/howto/create-service)

--- a/docs/products/postgresql/howto/connect-service.md
+++ b/docs/products/postgresql/howto/connect-service.md
@@ -7,7 +7,7 @@ import RelatedPages from "@site/src/components/RelatedPages";
 
 After your service is running, connect to it using your preferred tools and clients.
 
-Check more tools for connecting to Aiven for PostgreSQL® in [Connect to Aiven for PostgreSQL®](/docs/products/postgresql/howto/list-code-samples).
+Browse all supported tools for connecting to Aiven for PostgreSQL® in [Connect to Aiven for PostgreSQL®](/docs/products/postgresql/howto/list-code-samples).
 
 <RelatedPages/>
 

--- a/docs/products/postgresql/howto/create-service.md
+++ b/docs/products/postgresql/howto/create-service.md
@@ -1,0 +1,16 @@
+---
+title: Create an Aiven for PostgreSQL® service
+sidebar_label: Create a service
+---
+
+import CreateService from "@site/static/includes/create-service-console.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Create an Aiven for PostgreSQL® service in the [Aiven Console](https://console.aiven.io).
+
+<CreateService serviceType="PostgreSQL®"/>
+
+<RelatedPages/>
+
+- [Connect to a service](/docs/products/postgresql/howto/connect-service)
+- [Create a service with the CLI, API, or Terraform](/docs/platform/howto/create_new_service)

--- a/docs/products/postgresql/howto/maintenance-updates.md
+++ b/docs/products/postgresql/howto/maintenance-updates.md
@@ -1,0 +1,28 @@
+---
+title: Maintenance and updates for your Aiven for PostgreSQL® service
+sidebar_label: Maintenance and updates
+---
+
+import MaintenanceUpdates from "@site/static/includes/maintenance-updates.md";
+import MaintenanceWindowConcepts from "@site/static/includes/maintenance-window-concepts.md";
+import MaintenanceWindowInstructions from "@site/static/includes/maintenance-window-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Manage maintenance updates and set the maintenance window for your Aiven for PostgreSQL® service.
+
+## Maintenance updates
+
+<MaintenanceUpdates/>
+
+## Maintenance window
+
+<MaintenanceWindowConcepts/>
+
+## Set the maintenance window {#set-the-maintenance-window}
+
+<MaintenanceWindowInstructions/>
+
+<RelatedPages/>
+
+- [Version upgrades](/docs/products/postgresql/howto/upgrade)
+- [Change the service plan](/docs/products/postgresql/howto/change-service-plan)

--- a/docs/products/postgresql/howto/prepare-for-high-load.md
+++ b/docs/products/postgresql/howto/prepare-for-high-load.md
@@ -1,0 +1,16 @@
+---
+title: Prepare your Aiven for PostgreSQL® service for high load
+sidebar_label: Prepare for high load
+---
+
+import PrepareHighLoad from "@site/static/includes/prepare-for-high-load.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Prepare your Aiven for PostgreSQL® service for higher than usual traffic to avoid outages and keep performance stable.
+
+<PrepareHighLoad/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/postgresql/howto/change-service-plan)
+- [Scale disk storage](/docs/products/postgresql/howto/scale-disk-storage)

--- a/docs/products/postgresql/howto/scale-disk-storage.md
+++ b/docs/products/postgresql/howto/scale-disk-storage.md
@@ -1,0 +1,21 @@
+---
+title: Scale disk storage for your Aiven for PostgreSQL® service
+sidebar_label: Scale disk storage
+---
+
+import DiskConcepts from "@site/static/includes/scale-disk-storage-concepts.md";
+import DiskInstructions from "@site/static/includes/scale-disk-storage-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Scale the disk storage of your Aiven for PostgreSQL® service up or down without disrupting the running service.
+
+<DiskConcepts/>
+
+## Add or remove storage
+
+<DiskInstructions/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/postgresql/howto/change-service-plan)
+- [Memory and out-of-memory conditions](/docs/products/postgresql/concepts/pg-shared-buffers)

--- a/docs/products/postgresql/howto/track-restore-progress.md
+++ b/docs/products/postgresql/howto/track-restore-progress.md
@@ -1,0 +1,16 @@
+---
+title: Track restore progress for your Aiven for PostgreSQL® service
+sidebar_label: Track restore progress
+---
+
+import RestoreProgress from "@site/static/includes/restore-progress-tracking.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Track the restore progress of individual nodes in your Aiven for PostgreSQL® service during node replacement, forking, or maintenance, using the Aiven API.
+
+<RestoreProgress/>
+
+<RelatedPages/>
+
+- [Backups](/docs/products/postgresql/concepts/pg-backups)
+- [Fork your service](/docs/products/postgresql/howto/fork-service)

--- a/docs/products/valkey/concepts/memory-usage.md
+++ b/docs/products/valkey/concepts/memory-usage.md
@@ -3,6 +3,10 @@ title: Memory management and persistence in Aiven for Valkey™
 sidebar_label: Memory management
 ---
 
+import RelatedPages from "@site/src/components/RelatedPages";
+import ServiceMemoryLimits from "@site/static/includes/service-memory-limits.md";
+import OutOfMemory from "@site/static/includes/out-of-memory-condition.md";
+
 Learn how Aiven for Valkey™ addresses the challenges of high memory usage and high change rate. Discover how it implements robust memory management and persistence strategies.
 
 Aiven for Valkey™ functions primarily as a database cache. Data fetched from a database
@@ -132,3 +136,16 @@ excessive memory usage or challenges in initializing new nodes.
 If you frequently need to write large volumes of data, contact Aiven support to
 discuss service configuration options that can accommodate your needs.
 :::
+
+## Service memory limits
+
+<ServiceMemoryLimits/>
+
+## Out of memory conditions
+
+<OutOfMemory/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/valkey/howto/change-service-plan)
+- [Scale disk storage](/docs/products/valkey/howto/scale-disk-storage)

--- a/docs/products/valkey/howto/backup-to-another-region.md
+++ b/docs/products/valkey/howto/backup-to-another-region.md
@@ -1,0 +1,19 @@
+---
+title: Back up your Aiven for Valkey™ service to another region
+sidebar_label: Backup to another region
+---
+
+import BtarConcepts from "@site/static/includes/btar-concepts.md";
+import BtarInstructions from "@site/static/includes/btar-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Copy your Aiven for Valkey™ service backups to a secondary region for disaster recovery.
+
+<BtarConcepts/>
+
+<BtarInstructions/>
+
+<RelatedPages/>
+
+- [Backups](/docs/products/valkey/howto/configure-backups)
+- [Track restore progress](/docs/products/valkey/howto/track-restore-progress)

--- a/docs/products/valkey/howto/change-cloud-region.md
+++ b/docs/products/valkey/howto/change-cloud-region.md
@@ -1,0 +1,19 @@
+---
+title: Change the cloud or region for your Aiven for Valkey™ service
+sidebar_label: Change cloud or region
+---
+
+import ChangeCloud from "@site/static/includes/change-cloud-console.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Move your Aiven for Valkey™ service to a different cloud provider or region.
+
+<ChangeCloud/>
+
+Your service starts a migration to the new location and remains available during the process.
+When the migration completes, the service continues running in the new cloud or region.
+
+<RelatedPages/>
+
+- [Fork your service](/docs/products/valkey/howto/fork-service)
+- [Migrate to another cloud or region](/docs/platform/howto/migrate-services-cloud-region)

--- a/docs/products/valkey/howto/change-service-plan.md
+++ b/docs/products/valkey/howto/change-service-plan.md
@@ -1,0 +1,16 @@
+---
+title: Change the plan for your Aiven for Valkey™ service
+sidebar_label: Change service plan
+---
+
+import ChangePlan from "@site/static/includes/change-service-plan.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Change the service plan for your Aiven for Valkey™ service to scale resources up or down and optimize costs.
+
+<ChangePlan/>
+
+<RelatedPages/>
+
+- [Scale disk storage](/docs/products/valkey/howto/scale-disk-storage)
+- [Prepare for high load](/docs/products/valkey/howto/prepare-for-high-load)

--- a/docs/products/valkey/howto/connect-service.md
+++ b/docs/products/valkey/howto/connect-service.md
@@ -1,0 +1,15 @@
+---
+title: Connect to your Aiven for Valkey™ service
+sidebar_label: Connect to a service
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+After your service is running, connect to it using your preferred tools and clients.
+
+Check more tools for connecting to Aiven for Valkey™ in [Connect to Aiven for Valkey™](/docs/products/valkey/howto/connect-services).
+
+<RelatedPages/>
+
+- [Connect to Aiven for Valkey™](/docs/products/valkey/howto/connect-services)
+- [Create a service](/docs/products/valkey/howto/create-service)

--- a/docs/products/valkey/howto/connect-service.md
+++ b/docs/products/valkey/howto/connect-service.md
@@ -7,7 +7,7 @@ import RelatedPages from "@site/src/components/RelatedPages";
 
 After your service is running, connect to it using your preferred tools and clients.
 
-Check more tools for connecting to Aiven for Valkey™ in [Connect to Aiven for Valkey™](/docs/products/valkey/howto/connect-services).
+Browse all supported tools for connecting to Aiven for Valkey™ in [Connect to Aiven for Valkey™](/docs/products/valkey/howto/connect-services).
 
 <RelatedPages/>
 

--- a/docs/products/valkey/howto/create-service.md
+++ b/docs/products/valkey/howto/create-service.md
@@ -1,0 +1,16 @@
+---
+title: Create an Aiven for Valkey™ service
+sidebar_label: Create a service
+---
+
+import CreateService from "@site/static/includes/create-service-console.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Create an Aiven for Valkey™ service in the [Aiven Console](https://console.aiven.io).
+
+<CreateService serviceType="Valkey"/>
+
+<RelatedPages/>
+
+- [Connect to a service](/docs/products/valkey/howto/connect-service)
+- [Create a service with the CLI, API, or Terraform](/docs/platform/howto/create_new_service)

--- a/docs/products/valkey/howto/maintenance-updates.md
+++ b/docs/products/valkey/howto/maintenance-updates.md
@@ -1,0 +1,28 @@
+---
+title: Maintenance and updates for your Aiven for Valkey™ service
+sidebar_label: Maintenance and updates
+---
+
+import MaintenanceUpdates from "@site/static/includes/maintenance-updates.md";
+import MaintenanceWindowConcepts from "@site/static/includes/maintenance-window-concepts.md";
+import MaintenanceWindowInstructions from "@site/static/includes/maintenance-window-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Manage maintenance updates and set the maintenance window for your Aiven for Valkey™ service.
+
+## Maintenance updates
+
+<MaintenanceUpdates/>
+
+## Maintenance window
+
+<MaintenanceWindowConcepts/>
+
+## Set the maintenance window {#set-the-maintenance-window}
+
+<MaintenanceWindowInstructions/>
+
+<RelatedPages/>
+
+- [Version upgrades](/docs/products/valkey/howto/valkey-version-upgrade)
+- [Change the service plan](/docs/products/valkey/howto/change-service-plan)

--- a/docs/products/valkey/howto/prepare-for-high-load.md
+++ b/docs/products/valkey/howto/prepare-for-high-load.md
@@ -1,0 +1,16 @@
+---
+title: Prepare your Aiven for Valkey™ service for high load
+sidebar_label: Prepare for high load
+---
+
+import PrepareHighLoad from "@site/static/includes/prepare-for-high-load.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Prepare your Aiven for Valkey™ service for higher than usual traffic to avoid outages and keep performance stable.
+
+<PrepareHighLoad/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/valkey/howto/change-service-plan)
+- [Scale disk storage](/docs/products/valkey/howto/scale-disk-storage)

--- a/docs/products/valkey/howto/scale-disk-storage.md
+++ b/docs/products/valkey/howto/scale-disk-storage.md
@@ -1,0 +1,21 @@
+---
+title: Scale disk storage for your Aiven for Valkey™ service
+sidebar_label: Scale disk storage
+---
+
+import DiskConcepts from "@site/static/includes/scale-disk-storage-concepts.md";
+import DiskInstructions from "@site/static/includes/scale-disk-storage-instructions.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Scale the disk storage of your Aiven for Valkey™ service up or down without disrupting the running service.
+
+<DiskConcepts/>
+
+## Add or remove storage
+
+<DiskInstructions/>
+
+<RelatedPages/>
+
+- [Change the service plan](/docs/products/valkey/howto/change-service-plan)
+- [Memory and out-of-memory conditions](/docs/products/valkey/concepts/memory-usage)

--- a/docs/products/valkey/howto/track-restore-progress.md
+++ b/docs/products/valkey/howto/track-restore-progress.md
@@ -1,0 +1,16 @@
+---
+title: Track restore progress for your Aiven for Valkey™ service
+sidebar_label: Track restore progress
+---
+
+import RestoreProgress from "@site/static/includes/restore-progress-tracking.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Track the restore progress of individual nodes in your Aiven for Valkey™ service during node replacement, forking, or maintenance, using the Aiven API.
+
+<RestoreProgress/>
+
+<RelatedPages/>
+
+- [Backups](/docs/products/valkey/howto/configure-backups)
+- [Fork your service](/docs/products/valkey/howto/fork-service)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1456,6 +1456,8 @@ const sidebars: SidebarsConfig = {
               type: 'category',
               label: 'Service management',
               items: [
+                'products/grafana/howto/create-service',
+                'products/grafana/howto/connect-service',
                 'products/grafana/howto/power-cycle-service',
                 'products/grafana/howto/rename-service',
                 'products/grafana/howto/tag-service',
@@ -1534,6 +1536,8 @@ const sidebars: SidebarsConfig = {
               type: 'category',
               label: 'Service management',
               items: [
+                'products/metrics/howto/create-service',
+                'products/metrics/howto/connect-service',
                 'products/metrics/howto/power-cycle-service',
                 'products/metrics/howto/tag-service',
                 'products/metrics/howto/change-cloud-region',
@@ -1622,6 +1626,8 @@ const sidebars: SidebarsConfig = {
               type: 'category',
               label: 'Service management',
               items: [
+                'products/mysql/howto/create-service',
+                'products/mysql/howto/connect-service',
                 'products/mysql/howto/power-cycle-service',
                 'products/mysql/howto/rename-service',
                 'products/mysql/howto/tag-service',
@@ -1791,6 +1797,8 @@ const sidebars: SidebarsConfig = {
               type: 'category',
               label: 'Service management',
               items: [
+                'products/opensearch/howto/create-service',
+                'products/opensearch/howto/connect-service',
                 'products/opensearch/howto/power-cycle-service',
                 'products/opensearch/howto/rename-service',
                 'products/opensearch/howto/tag-service',
@@ -2010,6 +2018,8 @@ const sidebars: SidebarsConfig = {
               type: 'category',
               label: 'Service management',
               items: [
+                'products/postgresql/howto/create-service',
+                'products/postgresql/howto/connect-service',
                 'products/postgresql/howto/power-cycle-service',
                 'products/postgresql/howto/rename-service',
                 'products/postgresql/howto/tag-service',
@@ -2267,6 +2277,8 @@ const sidebars: SidebarsConfig = {
               type: 'category',
               label: 'Service management',
               items: [
+                'products/valkey/howto/create-service',
+                'products/valkey/howto/connect-service',
                 'products/valkey/howto/power-cycle-service',
                 'products/valkey/howto/rename-service',
                 'products/valkey/howto/tag-service',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1460,9 +1460,44 @@ const sidebars: SidebarsConfig = {
                 'products/grafana/howto/rename-service',
                 'products/grafana/howto/tag-service',
                 'products/grafana/howto/fork-service',
+                'products/grafana/howto/change-cloud-region',
                 'products/grafana/reference/advanced-params',
                 'products/grafana/howto/send-emails',
                 'products/grafana/reference/plugins',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Scaling and performance',
+              link: {
+                type: 'doc',
+                id: 'products/grafana/scaling-performance',
+              },
+              items: [
+                'products/grafana/howto/change-service-plan',
+                'products/grafana/howto/prepare-for-high-load',
+                'products/grafana/concepts/service-memory',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Maintenance and lifecycle',
+              link: {
+                type: 'doc',
+                id: 'products/grafana/maintenance-lifecycle',
+              },
+              items: ['products/grafana/howto/maintenance-updates'],
+            },
+            {
+              type: 'category',
+              label: 'Backups and migration',
+              link: {
+                type: 'doc',
+                id: 'products/grafana/backups-migration',
+              },
+              items: [
+                'products/grafana/howto/backup-to-another-region',
+                'products/grafana/howto/track-restore-progress',
               ],
             },
             {
@@ -1501,6 +1536,32 @@ const sidebars: SidebarsConfig = {
               items: [
                 'products/metrics/howto/power-cycle-service',
                 'products/metrics/howto/tag-service',
+                'products/metrics/howto/change-cloud-region',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Scaling and performance',
+              link: {
+                type: 'doc',
+                id: 'products/metrics/scaling-performance',
+              },
+              items: [
+                'products/metrics/howto/change-service-plan',
+                'products/metrics/howto/prepare-for-high-load',
+                'products/metrics/concepts/service-memory',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Maintenance and lifecycle',
+              link: {
+                type: 'doc',
+                id: 'products/metrics/maintenance-lifecycle',
+              },
+              items: [
+                'products/metrics/howto/maintenance-updates',
+                'products/metrics/howto/track-restore-progress',
               ],
             },
           ],
@@ -1565,6 +1626,7 @@ const sidebars: SidebarsConfig = {
                 'products/mysql/howto/rename-service',
                 'products/mysql/howto/tag-service',
                 'products/mysql/howto/fork-service',
+                'products/mysql/howto/change-cloud-region',
                 'products/mysql/howto/manage-service-users',
                 'products/mysql/reference/advanced-params',
               ],
@@ -1577,11 +1639,14 @@ const sidebars: SidebarsConfig = {
                 id: 'products/mysql/scaling-performance',
               },
               items: [
+                'products/mysql/howto/change-service-plan',
+                'products/mysql/howto/scale-disk-storage',
                 'products/mysql/concepts/mysql-memory-usage',
                 'products/mysql/concepts/mysql-tuning-and-concurrency',
                 'products/mysql/howto/identify-disk-usage-issues',
                 'products/mysql/howto/prevent-disk-full',
                 'products/mysql/howto/reclaim-disk-space',
+                'products/mysql/howto/prepare-for-high-load',
               ],
             },
             {
@@ -1591,7 +1656,10 @@ const sidebars: SidebarsConfig = {
                 type: 'doc',
                 id: 'products/mysql/maintenance-lifecycle',
               },
-              items: ['products/mysql/howto/manage-mysql-version'],
+              items: [
+                'products/mysql/howto/manage-mysql-version',
+                'products/mysql/howto/maintenance-updates',
+              ],
             },
             {
               type: 'category',
@@ -1617,6 +1685,8 @@ const sidebars: SidebarsConfig = {
                     'products/mysql/concepts/mysql-backups',
                     'products/mysql/howto/use-incremental-backups',
                     'products/mysql/howto/migrate-database-mysqldump',
+                    'products/mysql/howto/backup-to-another-region',
+                    'products/mysql/howto/track-restore-progress',
                   ],
                 },
                 {
@@ -1725,6 +1795,7 @@ const sidebars: SidebarsConfig = {
                 'products/opensearch/howto/rename-service',
                 'products/opensearch/howto/tag-service',
                 'products/opensearch/howto/fork-service',
+                'products/opensearch/howto/change-cloud-region',
                 'products/opensearch/reference/advanced-params',
                 'products/opensearch/concepts/dedicated-node-roles',
                 'products/opensearch/concepts/high-availability-for-opensearch',
@@ -1735,18 +1806,37 @@ const sidebars: SidebarsConfig = {
             },
             {
               type: 'category',
+              label: 'Scaling and performance',
+              link: {
+                type: 'doc',
+                id: 'products/opensearch/scaling-performance',
+              },
+              items: [
+                'products/opensearch/howto/change-service-plan',
+                'products/opensearch/howto/scale-disk-storage',
+                'products/opensearch/howto/prepare-for-high-load',
+                'products/opensearch/concepts/service-memory',
+              ],
+            },
+            {
+              type: 'category',
               label: 'Maintenance and lifecycle',
               link: {
                 type: 'doc',
                 id: 'products/opensearch/maintenance-lifecycle',
               },
-              items: ['products/opensearch/howto/os-version-upgrade'],
+              items: [
+                'products/opensearch/howto/os-version-upgrade',
+                'products/opensearch/howto/maintenance-updates',
+              ],
             },
             {
               type: 'category',
               label: 'Backups and migration',
               items: [
                 'products/opensearch/howto/restore_opensearch_backup',
+                'products/opensearch/howto/backup-to-another-region',
+                'products/opensearch/howto/track-restore-progress',
                 'products/opensearch/howto/import-opensearch-data-elasticsearch-dump-to-aiven',
                 'products/opensearch/howto/import-opensearch-data-elasticsearch-dump-to-aws',
                 {
@@ -1924,6 +2014,7 @@ const sidebars: SidebarsConfig = {
                 'products/postgresql/howto/rename-service',
                 'products/postgresql/howto/tag-service',
                 'products/postgresql/howto/fork-service',
+                'products/postgresql/howto/migrate-cloud-region',
                 'products/postgresql/howto/manage-service-users',
                 'products/postgresql/reference/advanced-params',
               ],
@@ -1951,10 +2042,13 @@ const sidebars: SidebarsConfig = {
                 id: 'products/postgresql/scaling-performance',
               },
               items: [
+                'products/postgresql/howto/change-service-plan',
+                'products/postgresql/howto/scale-disk-storage',
                 'products/postgresql/concepts/pg-shared-buffers',
                 'products/postgresql/concepts/pg-disk-usage',
                 'products/postgresql/howto/pg-object-size',
                 'products/postgresql/howto/prevent-full-disk',
+                'products/postgresql/howto/prepare-for-high-load',
               ],
             },
             {
@@ -1964,7 +2058,10 @@ const sidebars: SidebarsConfig = {
                 type: 'doc',
                 id: 'products/postgresql/maintenance-lifecycle',
               },
-              items: ['products/postgresql/howto/upgrade'],
+              items: [
+                'products/postgresql/howto/upgrade',
+                'products/postgresql/howto/maintenance-updates',
+              ],
             },
             {
               type: 'category',
@@ -2024,6 +2121,8 @@ const sidebars: SidebarsConfig = {
                 'products/postgresql/concepts/pg-backups',
                 'products/postgresql/howto/create-manual-backups',
                 'products/postgresql/howto/restore-backup',
+                'products/postgresql/howto/backup-to-another-region',
+                'products/postgresql/howto/track-restore-progress',
                 {
                   type: 'category',
                   label: 'Migrate',
@@ -2035,7 +2134,6 @@ const sidebars: SidebarsConfig = {
 
                     'products/postgresql/howto/migrate-pg-dump-restore',
                     'products/postgresql/howto/migrate-using-bucardo',
-                    'products/postgresql/howto/migrate-cloud-region',
                   ],
                 },
               ],
@@ -2173,6 +2271,7 @@ const sidebars: SidebarsConfig = {
                 'products/valkey/howto/rename-service',
                 'products/valkey/howto/tag-service',
                 'products/valkey/howto/fork-service',
+                'products/valkey/howto/change-cloud-region',
                 'products/valkey/howto/manage-service-users',
                 'products/valkey/reference/advanced-params',
                 'products/valkey/reference/restricted-commands',
@@ -2186,8 +2285,11 @@ const sidebars: SidebarsConfig = {
                 id: 'products/valkey/scaling-performance',
               },
               items: [
+                'products/valkey/howto/change-service-plan',
+                'products/valkey/howto/scale-disk-storage',
                 'products/valkey/concepts/memory-usage',
                 'products/valkey/troubleshooting/warning-overcommit_memory',
+                'products/valkey/howto/prepare-for-high-load',
               ],
             },
             {
@@ -2197,7 +2299,10 @@ const sidebars: SidebarsConfig = {
                 type: 'doc',
                 id: 'products/valkey/maintenance-lifecycle',
               },
-              items: ['products/valkey/howto/valkey-version-upgrade'],
+              items: [
+                'products/valkey/howto/valkey-version-upgrade',
+                'products/valkey/howto/maintenance-updates',
+              ],
             },
             {
               type: 'category',
@@ -2218,6 +2323,8 @@ const sidebars: SidebarsConfig = {
               },
               items: [
                 'products/valkey/howto/configure-backups',
+                'products/valkey/howto/backup-to-another-region',
+                'products/valkey/howto/track-restore-progress',
                 'products/valkey/howto/migrate-redis-aiven-cli',
                 'products/valkey/howto/migrate-redis-aiven-via-console',
                 'products/valkey/howto/migrate-caching-valkey-to-aiven-for-valkey',

--- a/static/includes/maintenance-updates.md
+++ b/static/includes/maintenance-updates.md
@@ -1,3 +1,5 @@
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+
 Aiven applies some maintenance updates automatically.
 Aiven provides two types of updates:
 

--- a/static/includes/maintenance-window-instructions.md
+++ b/static/includes/maintenance-window-instructions.md
@@ -1,3 +1,7 @@
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 To set the maintenance window for your service:
 
 <Tabs groupId="group1">

--- a/static/includes/service-memory-limits.md
+++ b/static/includes/service-memory-limits.md
@@ -11,11 +11,11 @@ memory limit.
 
 A server or node's **usable memory** can be calculated as:
 
-${ RAM - overhead }$
+`usable memory = RAM - overhead`
 
 Where:
 
-- $overhead$ is 350 MiB (≈ 0.34 GiB).
+- `overhead` is 350 MiB (≈ 0.34 GiB).
 
 Services may utilize optional components, service integrations,
 connection pooling, or plug-ins, which are not included in overhead


### PR DESCRIPTION
https://aiven.atlassian.net/browse/DOC-1948

Created per-service articles from the 7 component groups — only where the service supports the feature (verified against aiven-core), with service-specific info, placed in the correct IA sections.

Feature → article | Section | Services:
- Change service plan | Scaling and performance | all 6
- Prepare for high load | Scaling and performance | all 6
- Scale disk storage | Scaling and performance | PG, MySQL, OpenSearch, Valkey
- Maintenance and updates (updates + window) | Maintenance and lifecycle | all 6
- Change cloud or region | Service management | all 6 (PG reuses its existing page)
- Track restore progress | Backups and migration (Metrics: Maintenance) | all 6
- Backup to another region (BTAR) | Backups and migration | all except Metrics
- Memory + out-of-memory | Scaling and performance | new pages for OpenSearch/Grafana/Metrics; merged into existing memory pages for PG/MySQL/Valkey

Also:

- 6 new section overview pages (OpenSearch Scaling; Grafana Scaling/Maintenance/Backups; Metrics Scaling/Maintenance), wired as category landing pages — new sections were created for OpenSearch/Grafana/Metrics that didn't have them.
- Moved PG's existing migrate-cloud-region into Service management (its content already uses the change-cloud-console include).

Three includes needed fixes to build (they were provided incomplete/latent-buggy):
- maintenance-updates.md and maintenance-window-instructions.md — added the missing ConsoleLabel/Tabs/TabItem imports (they used the components without importing them).
- service-memory-limits.md — the ${ RAM - overhead }$ line was parsed by MDX as a JS expression (RAM is not defined, broke the build). Rewrote it as inline code (usable memory = RAM - overhead).

Finally, for Metrics (no backups/fork), I put Track restore progress under Maintenance and lifecycle rather than creating a "Backups and migration" section that would be misleading.