### PR TITLE
update: Clarify default SASL behavior

### DIFF
--- a/docs/products/kafka/howto/connect-with-command-line.md
+++ b/docs/products/kafka/howto/connect-with-command-line.md
@@ -48,12 +48,12 @@ Topics organize and store the events that you stream to Apache Kafka.
 ## Step 2: Set up an authentication method
 
 1. Select an authentication method:
-   - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for simple
-     username and password authentication.
+   - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for username and
+     password authentication.
 
-     If SASL is not enabled on your service, an option to enable SASL appears
-     under the **SASL** authentication method. Click **Enable SASL**, then
-     continue.
+     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     existing services, check whether SASL is enabled. If **Enable SASL**
+     appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS
      instead of a password.
 

--- a/docs/products/kafka/howto/connect-with-command-line.md
+++ b/docs/products/kafka/howto/connect-with-command-line.md
@@ -51,7 +51,7 @@ Topics organize and store the events that you stream to Apache Kafka.
    - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for username and
      password authentication.
 
-     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     SASL is enabled by default for new Aiven for Apache Kafka services. For
      existing services, check whether SASL is enabled. If **Enable SASL**
      appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS

--- a/docs/products/kafka/howto/connect-with-cpp.md
+++ b/docs/products/kafka/howto/connect-with-cpp.md
@@ -47,7 +47,7 @@ Topics organize and store the events that you stream to Apache Kafka.
    - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for username and
      password authentication.
 
-     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     SASL is enabled by default for new Aiven for Apache Kafka services. For
      existing services, check whether SASL is enabled. If **Enable SASL**
      appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS

--- a/docs/products/kafka/howto/connect-with-cpp.md
+++ b/docs/products/kafka/howto/connect-with-cpp.md
@@ -44,12 +44,12 @@ Topics organize and store the events that you stream to Apache Kafka.
 ## Step 2: Set up an authentication method
 
 1. Choose an authentication method:
-   - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for simple
-     username and password authentication.
+   - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for username and
+     password authentication.
 
-     If SASL is not enabled on your service, an option to enable SASL appears
-     under the **SASL** authentication method. Click **Enable SASL**, then
-     continue.
+     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     existing services, check whether SASL is enabled. If **Enable SASL**
+     appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS
      instead of a password.
 

--- a/docs/products/kafka/howto/connect-with-go.md
+++ b/docs/products/kafka/howto/connect-with-go.md
@@ -43,14 +43,14 @@ Topics organize and store the events that you stream to Apache Kafka.
 ## Step 2: Set up an authentication method
 
 1. Choose an authentication method:
-   - **SASL**: Recommended. Use SASL/SCRAM-SHA-512 for simple username and
+   - **SASL**: Recommended. Use SASL/SCRAM-SHA-512 for username and
      password authentication.
 
      Go code snippets use `SCRAM-SHA-512` for SASL authentication.
 
-     If SASL is not enabled on your service, an option to enable SASL appears
-     under the **SASL** authentication method. Click **Enable SASL**, then
-     continue.
+     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     existing services, check whether SASL is enabled. If **Enable SASL**
+     appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS
      instead of a password.
 

--- a/docs/products/kafka/howto/connect-with-go.md
+++ b/docs/products/kafka/howto/connect-with-go.md
@@ -48,7 +48,7 @@ Topics organize and store the events that you stream to Apache Kafka.
 
      Go code snippets use `SCRAM-SHA-512` for SASL authentication.
 
-     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     SASL is enabled by default for new Aiven for Apache Kafka services. For
      existing services, check whether SASL is enabled. If **Enable SASL**
      appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS

--- a/docs/products/kafka/howto/connect-with-java.md
+++ b/docs/products/kafka/howto/connect-with-java.md
@@ -46,7 +46,7 @@ Topics organize and store the events that you stream to Apache Kafka.
    - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for username and
      password authentication.
 
-     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     SASL is enabled by default for new Aiven for Apache Kafka services. For
      existing services, check whether SASL is enabled. If **Enable SASL**
      appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS

--- a/docs/products/kafka/howto/connect-with-java.md
+++ b/docs/products/kafka/howto/connect-with-java.md
@@ -43,12 +43,12 @@ Topics organize and store the events that you stream to Apache Kafka.
 
 1. Choose an authentication method:
 
-   - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for simple username and
+   - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for username and
      password authentication.
 
-     If SASL is not enabled on your service, an option to enable SASL appears
-     under the **SASL** authentication method. Click **Enable SASL**, then
-     continue.
+     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     existing services, check whether SASL is enabled. If **Enable SASL**
+     appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS
      instead of a password.
 

--- a/docs/products/kafka/howto/connect-with-klaw.md
+++ b/docs/products/kafka/howto/connect-with-klaw.md
@@ -49,7 +49,7 @@ Topics organize and store the events that you stream to Apache Kafka.
    - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for username and
      password authentication.
 
-     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     SASL is enabled by default for new Aiven for Apache Kafka services. For
      existing services, check whether SASL is enabled. If **Enable SASL**
      appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS

--- a/docs/products/kafka/howto/connect-with-klaw.md
+++ b/docs/products/kafka/howto/connect-with-klaw.md
@@ -46,12 +46,12 @@ Topics organize and store the events that you stream to Apache Kafka.
 ## Step 2: Set up an authentication method
 
 1. Choose an authentication method:
-   - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for simple
-     username and password authentication.
+   - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for username and
+     password authentication.
 
-     If SASL is not enabled on your service, an option to enable SASL appears
-     under the **SASL** authentication method. Click **Enable SASL**, then
-     continue.
+     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     existing services, check whether SASL is enabled. If **Enable SASL**
+     appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS
      instead of a password.
 

--- a/docs/products/kafka/howto/connect-with-nodejs.md
+++ b/docs/products/kafka/howto/connect-with-nodejs.md
@@ -46,7 +46,7 @@ Topics organize and store the events that you stream to Apache Kafka.
    - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for username and
      password authentication.
 
-     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     SASL is enabled by default for new Aiven for Apache Kafka services. For
      existing services, check whether SASL is enabled. If **Enable SASL**
      appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS

--- a/docs/products/kafka/howto/connect-with-nodejs.md
+++ b/docs/products/kafka/howto/connect-with-nodejs.md
@@ -43,12 +43,12 @@ Topics organize and store the events that you stream to Apache Kafka.
 ## Step 2: Set up an authentication method
 
 1. Select an authentication method:
-   - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for simple
-     username and password authentication.
+   - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for username and
+     password authentication.
 
-     If SASL is not enabled on your service, an option to enable SASL appears
-     under the **SASL** authentication method. Click **Enable SASL**, then
-     continue.
+     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     existing services, check whether SASL is enabled. If **Enable SASL**
+     appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS
      instead of a password.
 

--- a/docs/products/kafka/howto/connect-with-python.md
+++ b/docs/products/kafka/howto/connect-with-python.md
@@ -46,7 +46,7 @@ Topics organize and store the events that you stream to Apache Kafka.
    - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for username and
      password authentication.
 
-     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     SASL is enabled by default for new Aiven for Apache Kafka services. For
      existing services, check whether SASL is enabled. If **Enable SASL**
      appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS

--- a/docs/products/kafka/howto/connect-with-python.md
+++ b/docs/products/kafka/howto/connect-with-python.md
@@ -43,12 +43,12 @@ Topics organize and store the events that you stream to Apache Kafka.
 ## Step 2: Set up an authentication method
 
 1. Select an authentication method:
-   - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for simple
-     username and password authentication.
+   - **SASL**: Recommended. Use SASL/SCRAM-SHA-256 for username and
+     password authentication.
 
-     If SASL is not enabled on your service, an option to enable SASL appears
-     under the **SASL** authentication method. Click **Enable SASL**, then
-     continue.
+     SASL is enabled by default for new Aiven for Apache Kafka® services. For
+     existing services, check whether SASL is enabled. If **Enable SASL**
+     appears, click **Enable SASL**, then continue.
    - **Client certificate**: Use certificate-based authentication with mTLS
      instead of a password.
 


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
