### PR TITLE
fix: Broaden tiered storage plan limitation to all startup plans

### DIFF
--- a/docs/products/kafka/concepts/kafka-tiered-storage.md
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.md
@@ -22,7 +22,7 @@ storage by default and you cannot disable it.
   3.6 or later. It is recommended to upgrade to the latest default version and apply
   [maintenance updates](/docs/platform/concepts/maintenance-window#maintenance-updates)
   when using tiered storage for the latest fixes and improvements.
-- Tiered storage is not available on startup-2 plans.
+- Tiered storage is not available on startup plans.
 
 :::
 

--- a/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
+++ b/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
@@ -25,7 +25,7 @@ Enable tiered storage for your Aiven for Apache Kafka service to set up the nece
 - Aiven for Apache Kafka® supports tiered storage starting from Apache Kafka® version
   3.6 or later. Upgrade to the latest default version and apply
   [maintenance updates](/docs/platform/concepts/maintenance-window#maintenance-updates) when using tiered storage for the latest fixes and improvements.
-- Tiered storage is not available on startup-2 plans.
+- Tiered storage is not available on startup plans.
 
 :::
 


### PR DESCRIPTION
Updates tiered storage documentation to clarify that the feature is unavailable on all startup plans, not just startup-2 plans.
