### PR TITLE
update: add Aiven MCP internal links across key pages

### DIFF
--- a/docs/platform/concepts/byoc.md
+++ b/docs/platform/concepts/byoc.md
@@ -51,9 +51,9 @@ infrastructure on the Aiven platform while keeping your data in your own cloud.
    services and infrastructure in your cloud account.
 
 :::tip
-Services running in your custom clouds can also be managed from **AI assistants**. Use
-[Aiven MCP](/docs/tools/mcp-server) to create, update, and inspect Aiven services in
-natural language from clients such as Cursor and Claude Code.
+Use an AI assistant connected to [Aiven MCP](/docs/tools/mcp-server) to create,
+update, and view details for services running in your custom clouds from clients
+such as Cursor and Claude Code.
 :::
 
 ## Why use BYOC

--- a/docs/platform/concepts/byoc.md
+++ b/docs/platform/concepts/byoc.md
@@ -50,6 +50,12 @@ infrastructure on the Aiven platform while keeping your data in your own cloud.
 1. **View Aiven-managed assets in your cloud account**: You can preview Aiven-managed
    services and infrastructure in your cloud account.
 
+:::tip
+Services running in your custom clouds can also be managed from AI assistants. Use
+[Aiven MCP](/docs/tools/mcp-server) to create, update, and inspect Aiven services in
+natural language from clients such as Cursor and Claude Code.
+:::
+
 ## Why use BYOC
 
 Consider using BYOC and custom clouds if you have specific business

--- a/docs/platform/concepts/byoc.md
+++ b/docs/platform/concepts/byoc.md
@@ -51,7 +51,7 @@ infrastructure on the Aiven platform while keeping your data in your own cloud.
    services and infrastructure in your cloud account.
 
 :::tip
-Services running in your custom clouds can also be managed from AI assistants. Use
+Services running in your custom clouds can also be managed from **AI assistants**. Use
 [Aiven MCP](/docs/tools/mcp-server) to create, update, and inspect Aiven services in
 natural language from clients such as Cursor and Claude Code.
 :::

--- a/docs/platform/concepts/service-integration.md
+++ b/docs/platform/concepts/service-integration.md
@@ -5,6 +5,12 @@ sidebar_label: Overview
 
 Service integrations provide additional functionality and features by connecting different Aiven services together.
 
+:::tip
+Prefer to set up and inspect integrations from an AI assistant? Use
+[Aiven MCP](/docs/tools/mcp-server) to create and manage service integrations in
+natural language from clients such as Cursor and Claude Code.
+:::
+
 ## About service integrations
 
 Service integrations include:

--- a/docs/platform/concepts/service-integration.md
+++ b/docs/platform/concepts/service-integration.md
@@ -6,7 +6,7 @@ sidebar_label: Overview
 Service integrations provide additional functionality and features by connecting different Aiven services together.
 
 :::tip
-Prefer to set up and inspect integrations from an AI assistant? Use
+Prefer to set up and inspect integrations from an **AI assistant**? Use
 [Aiven MCP](/docs/tools/mcp-server) to create and manage service integrations in
 natural language from clients such as Cursor and Claude Code.
 :::

--- a/docs/platform/concepts/service-integration.md
+++ b/docs/platform/concepts/service-integration.md
@@ -6,9 +6,9 @@ sidebar_label: Overview
 Service integrations provide additional functionality and features by connecting different Aiven services together.
 
 :::tip
-Prefer to set up and inspect integrations from an **AI assistant**? Use
-[Aiven MCP](/docs/tools/mcp-server) to create and manage service integrations in
-natural language from clients such as Cursor and Claude Code.
+Use an AI assistant connected to [Aiven MCP](/docs/tools/mcp-server) to create,
+manage, and view details for service integrations from clients such as Cursor
+and Claude Code.
 :::
 
 ## About service integrations

--- a/docs/products/kafka.md
+++ b/docs/products/kafka.md
@@ -5,7 +5,7 @@ title: Aiven for Apache Kafka®
 Aiven for Apache Kafka® is a fully managed Apache Kafka service for building event-driven applications, data pipelines, and stream processing systems.
 
 :::tip
-Want to manage Apache Kafka from an AI assistant? Use
+Want to manage Apache Kafka from an **AI assistant**? Use
 [Aiven MCP](/docs/tools/mcp-server) to create services, manage topics, and inspect
 your Kafka clusters in natural language from clients such as Cursor and Claude Code.
 :::

--- a/docs/products/kafka.md
+++ b/docs/products/kafka.md
@@ -4,6 +4,12 @@ title: Aiven for Apache Kafka®
 
 Aiven for Apache Kafka® is a fully managed Apache Kafka service for building event-driven applications, data pipelines, and stream processing systems.
 
+:::tip
+Want to manage Apache Kafka from an AI assistant? Use
+[Aiven MCP](/docs/tools/mcp-server) to create services, manage topics, and inspect
+your Kafka clusters in natural language from clients such as Cursor and Claude Code.
+:::
+
 You create Kafka services using one of two **cluster types**: **Inkless Kafka** or
 **Classic Kafka**.
 

--- a/docs/products/kafka.md
+++ b/docs/products/kafka.md
@@ -5,9 +5,9 @@ title: Aiven for Apache Kafka®
 Aiven for Apache Kafka® is a fully managed Apache Kafka service for building event-driven applications, data pipelines, and stream processing systems.
 
 :::tip
-Want to manage Apache Kafka from an **AI assistant**? Use
-[Aiven MCP](/docs/tools/mcp-server) to create services, manage topics, and inspect
-your Kafka clusters in natural language from clients such as Cursor and Claude Code.
+Use an AI assistant connected to [Aiven MCP](/docs/tools/mcp-server) to create
+Kafka services, manage topics, and view cluster details from clients such as
+Cursor and Claude Code.
 :::
 
 You create Kafka services using one of two **cluster types**: **Inkless Kafka** or

--- a/docs/products/kafka/kafka-connect.md
+++ b/docs/products/kafka/kafka-connect.md
@@ -28,7 +28,7 @@ more:
 -   Our code samples repository, to get you started:
     [https://github.com/aiven/aiven-examples](https://github.com/aiven/aiven-examples)
 -   [Aiven MCP](/docs/tools/mcp-server), to manage your Apache Kafka Connect
-    services and connectors from AI assistants such as Cursor and Claude Code
+    services and connectors from **AI assistants** such as Cursor and Claude Code
 
 import ElasticSearch from "@site/static/includes/trademark-elasticsearch.md"
 import CouchBase from "@site/static/includes/trademark-couchbase.md"

--- a/docs/products/kafka/kafka-connect.md
+++ b/docs/products/kafka/kafka-connect.md
@@ -27,6 +27,8 @@ more:
     [https://karapace.io/](https://karapace.io/)
 -   Our code samples repository, to get you started:
     [https://github.com/aiven/aiven-examples](https://github.com/aiven/aiven-examples)
+-   [Aiven MCP](/docs/tools/mcp-server), to manage your Apache Kafka Connect
+    services and connectors from AI assistants such as Cursor and Claude Code
 
 import ElasticSearch from "@site/static/includes/trademark-elasticsearch.md"
 import CouchBase from "@site/static/includes/trademark-couchbase.md"

--- a/docs/tools/aiven-console.md
+++ b/docs/tools/aiven-console.md
@@ -5,6 +5,11 @@ sidebar_label: Aiven Console
 
 In the [Aiven Console](https://console.aiven.io) you can create and manage Aiven services, update your user profile, manage settings across organizations and projects, set up billing groups, view invoices, and more.
 
+:::tip
+Prefer to work from an AI assistant instead of the web console? Use
+[Aiven MCP](/docs/tools/mcp-server) to create, update, and inspect Aiven services
+in natural language from clients such as Cursor and Claude Code.
+:::
 
 ## User profile
 

--- a/docs/tools/aiven-console.md
+++ b/docs/tools/aiven-console.md
@@ -6,9 +6,9 @@ sidebar_label: Aiven Console
 In the [Aiven Console](https://console.aiven.io) you can create and manage Aiven services, update your user profile, manage settings across organizations and projects, set up billing groups, view invoices, and more.
 
 :::tip
-Prefer to work from an **AI assistant** instead of the web console? Use
-[Aiven MCP](/docs/tools/mcp-server) to create, update, and inspect Aiven services
-in natural language from clients such as Cursor and Claude Code.
+Use an AI assistant connected to [Aiven MCP](/docs/tools/mcp-server) to create,
+update, and view details for Aiven services from clients such as Cursor and
+Claude Code.
 :::
 
 ## User profile

--- a/docs/tools/aiven-console.md
+++ b/docs/tools/aiven-console.md
@@ -6,7 +6,7 @@ sidebar_label: Aiven Console
 In the [Aiven Console](https://console.aiven.io) you can create and manage Aiven services, update your user profile, manage settings across organizations and projects, set up billing groups, view invoices, and more.
 
 :::tip
-Prefer to work from an AI assistant instead of the web console? Use
+Prefer to work from an **AI assistant** instead of the web console? Use
 [Aiven MCP](/docs/tools/mcp-server) to create, update, and inspect Aiven services
 in natural language from clients such as Cursor and Claude Code.
 :::

--- a/docs/tools/terraform.md
+++ b/docs/tools/terraform.md
@@ -7,6 +7,12 @@ import TerraformSample from '@site/src/components/CodeSamples/TerraformSample';
 
 Use the [Aiven Provider for Terraform](https://registry.terraform.io/providers/aiven/aiven/latest/docs) to provision and manage your Aiven infrastructure.
 
+:::tip
+Prefer natural language over configuration files? Use
+[Aiven MCP](/docs/tools/mcp-server) to create, update, and inspect Aiven services
+from AI assistants such as Cursor and Claude Code.
+:::
+
 ## Get started
 
 The Aiven Platform uses
@@ -40,3 +46,5 @@ The following example file is also available in the
   to learn how to create a service or integration using the Aiven Terraform Provider.
 - Get details about all the available resources and data sources in the
   [Aiven Provider for Terraform documentation](https://registry.terraform.io/providers/aiven/aiven/latest/docs).
+- Manage Aiven services in natural language from AI assistants with
+  [Aiven MCP](/docs/tools/mcp-server).

--- a/docs/tools/terraform.md
+++ b/docs/tools/terraform.md
@@ -10,7 +10,7 @@ Use the [Aiven Provider for Terraform](https://registry.terraform.io/providers/a
 :::tip
 Prefer natural language over configuration files? Use
 [Aiven MCP](/docs/tools/mcp-server) to create, update, and inspect Aiven services
-from AI assistants such as Cursor and Claude Code.
+from **AI assistants** such as Cursor and Claude Code.
 :::
 
 ## Get started
@@ -46,5 +46,5 @@ The following example file is also available in the
   to learn how to create a service or integration using the Aiven Terraform Provider.
 - Get details about all the available resources and data sources in the
   [Aiven Provider for Terraform documentation](https://registry.terraform.io/providers/aiven/aiven/latest/docs).
-- Manage Aiven services in natural language from AI assistants with
+- Manage Aiven services in natural language from **AI assistants** with
   [Aiven MCP](/docs/tools/mcp-server).

--- a/docs/tools/terraform.md
+++ b/docs/tools/terraform.md
@@ -8,9 +8,9 @@ import TerraformSample from '@site/src/components/CodeSamples/TerraformSample';
 Use the [Aiven Provider for Terraform](https://registry.terraform.io/providers/aiven/aiven/latest/docs) to provision and manage your Aiven infrastructure.
 
 :::tip
-Prefer natural language over configuration files? Use
-[Aiven MCP](/docs/tools/mcp-server) to create, update, and inspect Aiven services
-from **AI assistants** such as Cursor and Claude Code.
+You can also use an AI assistant connected to
+[Aiven MCP](/docs/tools/mcp-server) to create, update, and view details for
+Aiven services from clients such as Cursor and Claude Code.
 :::
 
 ## Get started
@@ -46,5 +46,5 @@ The following example file is also available in the
   to learn how to create a service or integration using the Aiven Terraform Provider.
 - Get details about all the available resources and data sources in the
   [Aiven Provider for Terraform documentation](https://registry.terraform.io/providers/aiven/aiven/latest/docs).
-- Manage Aiven services in natural language from **AI assistants** with
+- Learn how to manage Aiven services with AI assistance using
   [Aiven MCP](/docs/tools/mcp-server).


### PR DESCRIPTION
## Summary

Adds contextual internal links to the [Aiven MCP page](/docs/tools/mcp-server) from six high-traffic / high-inlink docs pages, so users on product, tools, and platform docs can discover the Aiven MCP server. Comes out of an internal linking audit for MCP discoverability.

Anchor text is descriptive and query-matching, and each link sits in a self-contained sentence (good for AI/LLM extraction), reusing the existing `:::tip` pattern already on `tools/api.md`.

## Changes

| Page | Live URL | Placement |
|------|----------|-----------|
| `platform/concepts/service-integration.md` | https://aiven.io/docs/platform/concepts/service-integration | Tip after intro |
| `products/kafka.md` | https://aiven.io/docs/products/kafka | Tip after intro |
| `tools/terraform.md` | https://aiven.io/docs/tools/terraform | Tip after intro + Next steps bullet |
| `tools/aiven-console.md` | https://aiven.io/docs/tools/aiven-console | Tip after intro |
| `products/kafka/kafka-connect.md` | https://aiven.io/docs/products/kafka/kafka-connect | Resources list entry |
| `platform/concepts/byoc.md` | https://aiven.io/docs/platform/concepts/byoc | Tip after "How it works" |

## Notes

- All links target `/docs/tools/mcp-server` (the docs MCP page), matching the existing convention in `tools/api.md` and `tools.md`.
- MCP is intentionally **not** added to the "Service integrations include:" list, since it is an interface rather than a service-to-service integration.
- `tools/api.md` and `tools.md` already linked to the MCP page, so they were left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)