### PR TITLE
update: ClickHouse docs for new service side nav

### DIFF
--- a/docs/products/clickhouse/concepts/clickhouse-tiered-storage.md
+++ b/docs/products/clickhouse/concepts/clickhouse-tiered-storage.md
@@ -92,12 +92,11 @@ storage.
 ## Access tiered storage details {#access-tiered-storage-details}
 
 When you [enable](/docs/products/clickhouse/howto/enable-tiered-storage) tiered storage,
-you can preview its details in the [Aiven Console](https://console.aiven.io/) from the service
-<ConsoleLabel name="overview"/>:
+you can preview its details in the [Aiven Console](https://console.aiven.io/):
 
-- Click <ConsoleLabel name="tieredstorage"/> or
-- Click <ConsoleLabel name="databasesandtables"/> > your table > <ConsoleLabel name="actions"/> >
-  <ConsoleLabel name="viewdetails"/> > **Tiered storage**.
+- Click <ConsoleLabel name="observe"/> > **Tiered storage** or
+- Click <ConsoleLabel name="data"/> > **Databases and tables** > your table >
+  <ConsoleLabel name="actions"/> > <ConsoleLabel name="viewdetails"/> > **Tiered storage**.
 
 ## Typical use case
 
@@ -135,14 +134,14 @@ threshold to control how your data is stored between the two layers.
 
 -   In the [Aiven Console](https://console.aiven.io/), there can be a mismatch in the
     displayed amount of data in object storage between what's shown in
-    [<ConsoleLabel name="tieredstorage"/>](#access-tiered-storage-details)
+    [<ConsoleLabel name="observe"/> > **Tiered storage**](#access-tiered-storage-details)
     and
     [Storage details](#access-tiered-storage-details).
 
     This is because:
 
     - Information in
-      [<ConsoleLabel name="tieredstorage"/>](#access-tiered-storage-details)
+      [<ConsoleLabel name="observe"/> > **Tiered storage**](#access-tiered-storage-details)
       is updated every hour.
 
       :::tip

--- a/docs/products/clickhouse/concepts/query-kafka-topic-data.md
+++ b/docs/products/clickhouse/concepts/query-kafka-topic-data.md
@@ -3,6 +3,7 @@ title: Query Kafka topic data in Aiven for ClickHouse®
 sidebar_label: Query Kafka topic data
 ---
 
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import RelatedPages from "@site/src/components/RelatedPages";
 
 Query Kafka topic data in Aiven for ClickHouse® by connecting an Aiven for Apache Kafka® topic to a ClickHouse table.
@@ -71,11 +72,13 @@ event analysis, historical reporting, and high-volume log or metrics analysis.
 
 - The Kafka service and the ClickHouse service must be in the same cloud region to
   reduce network latency and data transfer costs.
-- If data does not appear in the destination table after deployment, check the ClickHouse
-  service logs for ingestion errors.
+- If data does not appear in the destination table after deployment, review
+  <ConsoleLabel name="observe"/> > **Logs** for the ClickHouse service for ingestion
+  errors.
 - Failed messages are not sent to a dead letter queue by default. To change this, set
   `handle_error_mode` to `dead_letter_queue` in the Kafka engine advanced configuration. In
-  the Aiven Console, this setting is available under **Databases and tables**.
+  the Aiven Console, this setting is available under <ConsoleLabel name="data"/> >
+  **Databases and tables**.
 - You cannot change some table settings, such as the sorting key, after table creation.
 - Automated schema mapping is available only for Avro messages with Aiven for Apache
   Kafka® Schema Registry when the schema is registered using the topic name strategy,

--- a/docs/products/clickhouse/get-started.md
+++ b/docs/products/clickhouse/get-started.md
@@ -64,8 +64,9 @@ You create the service, two service users, and assign each user a role:
 - Give the ETL user permission to insert data.
 - Give the analyst user access to view data in the measurements database.
 
-The following example files are also available in the
-[Aiven Terraform Provider repository](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/clickhouse) on GitHub.
+The following example files are also available in the Aiven Terraform Provider
+[repository](https://github.com/aiven/terraform-provider-aiven/tree/main/examples/clickhouse)
+on GitHub.
 
 1. Create a file named `provider.tf` and add the following:
 
@@ -142,8 +143,8 @@ Name             Project             Region                 Plan          State
 my-clickhouse    my-aiven-project    google-europe-west1    startup-16    RUNNING
 ```
 
-The resource can stay in the `REBUILDING` state for a couple of minutes. Once the state
-changes to `RUNNING`, you are ready to access it.
+The resource might stay in the `BUILDING` state for a couple of minutes. When the
+state changes to `RUNNING`, you are ready to access it.
 </TabItem>
 </Tabs>
 
@@ -153,10 +154,9 @@ You can change your service settings by updating the service configuration.
 
 <Tabs groupId="group1">
 <TabItem value="console" label="Console" default>
-1. Select the new service from the list of services on
-   the <ConsoleLabel name="Services"/> page.
-1. On the <ConsoleLabel name="overview"/> page, select <ConsoleLabel name="service settings"/>
-   from the sidebar.
+1. Log in to the [Aiven Console](https://console.aiven.io/) and choose your new Aiven for
+   ClickHouse service.
+1. In the service sidebar, click <ConsoleLabel name="service settings"/>.
 1. In the **Advanced configuration** section, make changes to the service configuration.
 
 See the available configuration options in
@@ -212,8 +212,8 @@ for the full schema.
    kubectl get clickhouses my-clickhouse
    ```
 
-The resource can stay in the `REBUILDING` state for a couple of minutes. Once the state
-changes to `RUNNING`, you are ready to access it.
+The resource might stay in the `BUILDING` state for a couple of minutes. When the
+state changes to `RUNNING`, you are ready to access it.
 
 See the available configuration options in
 [Aiven Operator for Kubernetes®: ClickHouse](https://aiven.github.io/aiven-operator/resources/clickhouse.html)
@@ -225,11 +225,10 @@ See the available configuration options in
 
 <Tabs groupId="group1">
 <TabItem value="console" label="Console" default>
-1. Log in to the [Aiven Console](https://console.aiven.io/), and go to your
-   organization > project > Aiven for ClickHouse service.
-1. On the <ConsoleLabel name="overview"/> page of your service, click
-   **Quick connect**.
-1. In the **Connect** window, select a tool or language to connect to your service, follow
+1. Log in to the [Aiven Console](https://console.aiven.io/) and choose your Aiven for
+   ClickHouse service.
+1. On the <ConsoleLabel name="overview"/> page, click **Quick connect**.
+1. In the **Connect** window, click a tool or language to connect to your service, follow
    the connection instructions, and click **Done**.
 
    ```bash
@@ -290,8 +289,10 @@ Discover more tools for connecting to Aiven for ClickHouse in
    using cURL:
 
    ```bash
-   curl https://datasets.clickhouse.com/hits/tsv/hits_v1.tsv.xz | unxz --threads=`nproc` > hits_v1.tsv
-   curl https://datasets.clickhouse.com/visits/tsv/visits_v1.tsv.xz | unxz --threads=`nproc` > visits_v1.tsv
+   curl https://datasets.clickhouse.com/hits/tsv/hits_v1.tsv.xz \
+     | unxz --threads="$(nproc)" > hits_v1.tsv
+   curl https://datasets.clickhouse.com/visits/tsv/visits_v1.tsv.xz \
+     | unxz --threads="$(nproc)" > visits_v1.tsv
    ```
 
    :::note
@@ -300,15 +301,16 @@ Discover more tools for connecting to Aiven for ClickHouse in
    `nproc` into your `~/.zshrc` file: `alias nproc="sysctl -n hw.logicalcpu"`.
    :::
 
-   Once done, you should have two files: `hits_v1.tsv` and `visits_v1.tsv`.
+   When the download is complete, you have two files: `hits_v1.tsv` and
+   `visits_v1.tsv`.
 
 1. Create tables `hits_v1` and `visits_v1` in the `default` database, which has been
-   created automatically upon the creation of your Aiven for ClickHouse service.
+   created automatically when you create your Aiven for ClickHouse service.
 
-    <!-- vale off -->
-    <details><summary>
-    Expand for the `CREATE TABLE default.hits_v1` sample
-    </summary>
+   <!-- vale off -->
+   <details><summary>
+   Expand for the `CREATE TABLE default.hits_v1` sample
+   </summary>
     ```sql
     CREATE TABLE default.hits_v1 (
       WatchID UInt64,
@@ -452,11 +454,11 @@ Discover more tools for connecting to Aiven for ClickHouse in
     ORDER BY
       (CounterID, EventDate, intHash32(UserID));
     ```
-    </details>
+   </details>
 
-    <details><summary>
-    Expand for the `CREATE TABLE default.visits_v1` sample
-    </summary>
+   <details><summary>
+   Expand for the `CREATE TABLE default.visits_v1` sample
+   </summary>
     ```sql
     CREATE TABLE default.visits_v1 (
       CounterID UInt32,
@@ -654,41 +656,41 @@ Discover more tools for connecting to Aiven for ClickHouse in
     ORDER BY
       (CounterID, StartDate, intHash32(UserID), VisitID)
     ```
-    </details>
-    <!-- vale on -->
+   </details>
+   <!-- vale on -->
 
 1. Load data into tables `hits_v1` and `visits_v1`.
 
-    1.  Go to the folder where you stored the downloaded files for
-        `hits_v1.tsv` and `visits_v1.tsv`.
+   1. Go to the folder where you stored the downloaded files for
+      `hits_v1.tsv` and `visits_v1.tsv`.
 
-    1.  Run the following commands:
+   1. Run the following commands:
 
-        ```bash
-        cat hits_v1.tsv | docker run        \
-        --interactive                       \
-        --rm clickhouse/clickhouse-server clickhouse-client  \
-        --user USERNAME                     \
-        --password PASSWORD                 \
-        --host HOST                         \
-        --port PORT                         \
-        --secure                            \
-        --max_insert_block_size=100000      \
-        --query="INSERT INTO default.hits_v1 FORMAT TSV"
-        ```
+      ```bash
+      cat hits_v1.tsv | docker run        \
+      --interactive                       \
+      --rm clickhouse/clickhouse-server clickhouse-client  \
+      --user USERNAME                     \
+      --password PASSWORD                 \
+      --host HOST                         \
+      --port PORT                         \
+      --secure                            \
+      --max_insert_block_size=100000      \
+      --query="INSERT INTO default.hits_v1 FORMAT TSV"
+      ```
 
-        ```bash
-        cat visits_v1.tsv | docker run      \
-        --interactive                       \
-        --rm clickhouse/clickhouse-server clickhouse-client   \
-        --user USERNAME                     \
-        --password PASSWORD                 \
-        --host HOST                         \
-        --port PORT                         \
-        --secure                            \
-        --max_insert_block_size=100000      \
-        --query="INSERT INTO default.visits_v1 FORMAT TSV"
-        ```
+      ```bash
+      cat visits_v1.tsv | docker run      \
+      --interactive                       \
+      --rm clickhouse/clickhouse-server clickhouse-client   \
+      --user USERNAME                     \
+      --password PASSWORD                 \
+      --host HOST                         \
+      --port PORT                         \
+      --secure                            \
+      --max_insert_block_size=100000      \
+      --query="INSERT INTO default.visits_v1 FORMAT TSV"
+      ```
 
 ## Query data
 

--- a/docs/products/clickhouse/howto/check-data-tiered-storage.md
+++ b/docs/products/clickhouse/howto/check-data-tiered-storage.md
@@ -32,11 +32,14 @@ tiered storage is enabled on a table and, if it is, how much
 storage is used on each tier (network-attached block storage and object storage)
 for this particular table.
 
-To access tiered storage's status information, go to
-the [Aiven Console](https://console.aiven.io/) > your Aiven for ClickHouse service's
-<ConsoleLabel name="overview"/> > <ConsoleLabel name="databasesandtables"/> > your database >
-your table > <ConsoleLabel name="actions"/> > <ConsoleLabel name="viewdetails"/> >
-**Tiered storage**.
+To access tiered storage status information:
+
+1. Log in to the [Aiven Console](https://console.aiven.io/) and choose your Aiven for
+   ClickHouse service.
+1. In the service sidebar, click <ConsoleLabel name="data"/> > **Databases and tables**.
+1. Open the database and table that you want to check.
+1. Click <ConsoleLabel name="actions"/> > <ConsoleLabel name="viewdetails"/> >
+   **Tiered storage**.
 
 ## Run a data distribution check with the ClickHouse client
 

--- a/docs/products/clickhouse/howto/data-service-integration.md
+++ b/docs/products/clickhouse/howto/data-service-integration.md
@@ -26,12 +26,9 @@ Learn about [managed databases integrations](/docs/products/clickhouse/concepts/
 
 Make Apache Kafka data available in Aiven for ClickHouse using the Kafka engine:
 
-1. Log in to the [Aiven Console](https://console.aiven.io/), and go to an organization
-   and a project.
-1. From <ConsoleLabel name="services"/>, select an Aiven for ClickHouse service to integrate
-   with a data source.
-1. On the service's <ConsoleLabel name="overview"/> page, click
-   <ConsoleLabel name="integrations"/> in the sidebar.
+1. Log in to the [Aiven Console](https://console.aiven.io/) and choose the Aiven for
+   ClickHouse service that you want to integrate with a data source.
+1. In the service sidebar, click <ConsoleLabel name="data"/> > **Integrations**.
 1. On the **Integrations** page, go to the **Data sources** section and click
    **Apache Kafka**.
 
@@ -82,12 +79,9 @@ Learn about [managed databases integrations](/docs/products/clickhouse/concepts/
 
 Make PostgreSQL data available in Aiven for ClickHouse using the PostgreSQL engine:
 
-1. Log in to the [Aiven Console](https://console.aiven.io/), and go to an organization
-   and a project.
-1. From <ConsoleLabel name="services"/>, select an Aiven for ClickHouse service to integrate
-   with a data source.
-1. On the service's <ConsoleLabel name="overview"/> page, click
-   <ConsoleLabel name="integrations"/> in the sidebar.
+1. Log in to the [Aiven Console](https://console.aiven.io/) and choose the Aiven for
+   ClickHouse service that you want to integrate with a data source.
+1. In the service sidebar, click <ConsoleLabel name="data"/> > **Integrations**.
 1. On the **Integrations** page, go to the **Data sources** section and click
    **PostgreSQL**.
 
@@ -124,8 +118,9 @@ Make PostgreSQL data available in Aiven for ClickHouse using the PostgreSQL engi
       :::note
       You can
       [create such integration databases](/docs/products/clickhouse/howto/integration-databases)
-      any time later, for example, by finding your integration on the **Integrations** page
-      and clicking <ConsoleLabel name="actions"/> > <ConsoleLabel name="editdatabase"/>.
+      any time later, for example, by finding your integration on the
+      <ConsoleLabel name="data"/> > **Integrations** page and clicking
+      <ConsoleLabel name="actions"/> > <ConsoleLabel name="editdatabase"/>.
       ::::
 
    1. Click **Enable integration** > **Close**.
@@ -144,12 +139,9 @@ for the data to be made available through the integration.
 
 ### Create managed-credentials integrations
 
-1. Log in to the [Aiven Console](https://console.aiven.io/), and go to an organization
-   and a project.
-1. From <ConsoleLabel name="services"/>, select an Aiven for ClickHouse service to integrate
-   with a data source.
-1. On the service's <ConsoleLabel name="overview"/> page, click
-   <ConsoleLabel name="integrations"/> in the sidebar.
+1. Log in to the [Aiven Console](https://console.aiven.io/) and choose the Aiven for
+   ClickHouse service that you want to integrate with a data source.
+1. In the service sidebar, click <ConsoleLabel name="data"/> > **Integrations**.
 1. On the **Integrations** page, go to the **Data sources** section and click
    **ClickHouse Credentials**.
 
@@ -175,7 +167,8 @@ for the data to be made available through the integration.
 
       :::note[Alternative]
       You can test the connection any time later by going to your Aiven for ClickHouse
-      service's **Integrations** page, finding the credentials integration, and clicking
+      service's <ConsoleLabel name="data"/> > **Integrations** page, finding the
+      credentials integration, and clicking
        <ConsoleLabel name="actions"/> > <ConsoleLabel name="testconnection"/>.
       :::
 
@@ -241,14 +234,9 @@ error message related to grants.
 
 ## View data source integrations
 
-1. Log in to the [Aiven Console](https://console.aiven.io/), and go to an organization
-   and a project.
-1. From <ConsoleLabel name="services"/>, select an Aiven for ClickHouse service to display
-   integrations for.
-1. On the service's page, go to one of the following:
-
-   - <ConsoleLabel name="overview"/> in the sidebar > **Integrations**
-   - <ConsoleLabel name="integrations"/> in the sidebar
+1. Log in to the [Aiven Console](https://console.aiven.io/) and choose the Aiven for
+   ClickHouse service whose integrations you want to view.
+1. In the service sidebar, click <ConsoleLabel name="data"/> > **Integrations**.
 
 ## Stop data source integrations
 
@@ -257,17 +245,11 @@ By terminating a data source integration, you disconnect from the data source, w
 all databases and configuration information from Aiven for ClickHouse.
 :::
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/), and go to an organization
-    and a project.
-1.  From <ConsoleLabel name="services"/>, select an Aiven for ClickHouse service you
-    want to stop integrations for.
-1.  On the service's page, take one of the following courses of action:
-
-    - Click <ConsoleLabel name="overview"/> > **Integrations**, find an
-      integration to be stopped, and click <ConsoleLabel name="actions"/> >
-      <ConsoleLabel name="disconnect"/>.
-    - Click <ConsoleLabel name="integrations"/>, find an integration to be stopped,
-      and click <ConsoleLabel name="actions"/> > <ConsoleLabel name="disconnect"/>.
+1.  Log in to the [Aiven Console](https://console.aiven.io/) and choose the Aiven for
+    ClickHouse service whose integrations you want to stop.
+1.  In the service sidebar, click <ConsoleLabel name="data"/> > **Integrations**.
+1.  Find an integration to be stopped, and click <ConsoleLabel name="actions"/> >
+    <ConsoleLabel name="disconnect"/>.
 
 Your integration is terminated and all the corresponding databases and configuration
 information are deleted.

--- a/docs/products/clickhouse/howto/enable-tiered-storage.md
+++ b/docs/products/clickhouse/howto/enable-tiered-storage.md
@@ -19,8 +19,9 @@ Before you enable tiered storage, review the [limitations](/docs/products/clickh
     - [Aiven Console](https://console.aiven.io) or
     - SQL and an SQL client (for example, the [ClickHouse client](/docs/products/clickhouse/howto/connect-with-clickhouse-cli)).
 -   All maintenance updates are applied on your service (check in the
-    [Aiven Console](https://console.aiven.io): your service's <ConsoleLabel name="overview"/> >
-    <ConsoleLabel name="service settings"/> > **Service management** > **Maintenance updates**).
+    [Aiven Console](https://console.aiven.io): your service's
+    <ConsoleLabel name="service settings"/> > **Service management** >
+    **Maintenance updates**).
 
 ## Activate tiered storage on a table
 
@@ -29,11 +30,10 @@ you can use either CLI or the [Aiven Console](https://console.aiven.io).
 
 <Tabs groupId="group1">
 <TabItem value="1" label="Console" default>
-1. Log in to the [Aiven Console](https://console.aiven.io), and go to your organization,
-   project, and service.
-1. On the <ConsoleLabel name="overview"/> of your service, select
-   <ConsoleLabel name="databasesandtables"/> from the sidebar.
-1. In the <ConsoleLabel name="databasesandtables"/> view, find a table on which to activate tiered
+1. Log in to the [Aiven Console](https://console.aiven.io) and choose your Aiven for
+   ClickHouse service.
+1. In the service sidebar, click <ConsoleLabel name="data"/> > **Databases and tables**.
+1. In the **Databases and tables** view, find a table on which to activate tiered
    storage, and click <ConsoleLabel name="actions"/> > <ConsoleLabel name="activatetieredstorage"/>
    \> **Activate**.
 </TabItem>
@@ -52,11 +52,6 @@ you can use either CLI or the [Aiven Console](https://console.aiven.io).
 
 Tiered storage is activated on your table and data in this table is now
 distributed between two tiers: Network-attached block storage and object storage.
-
-You can check if tiered storage is now supported (**Active**/**Not active**) on
-your table in the [Aiven Console](https://console.aiven.io) > your service's page >
-<ConsoleLabel name="databasesandtables"/> > Your database > Your table
-\> **Tiered storage** column.
 
 ## What's next
 

--- a/docs/products/clickhouse/howto/fetch-query-statistics.md
+++ b/docs/products/clickhouse/howto/fetch-query-statistics.md
@@ -3,6 +3,7 @@ title: Fetch query statistics for Aiven for ClickHouse®
 sidebar_label: Fetch query statistics
 ---
 
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import RelatedPages from "@site/src/components/RelatedPages";
 
 Usually, query statistics in ClickHouse can be obtained using the `system.query_log` table, which stores statistics of each executed query, including memory usage and duration.
@@ -15,10 +16,10 @@ Aiven Console or Aiven API.
 
 ## Use Aiven Console
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/), choose the
-    right project, and select your Aiven for ClickHouse service.
-1.  In your service's page, select **Query statistics** from the
-    sidebar and view the content in the dashboard.
+1.  Log in to the [Aiven Console](https://console.aiven.io/) and choose your Aiven for
+    ClickHouse service.
+1.  In the service sidebar, click <ConsoleLabel name="observe"/> > **Query statistics**.
+1.  View the query statistics in the dashboard.
 
 ## Use Aiven API
 

--- a/docs/products/clickhouse/howto/integrate-kafka.md
+++ b/docs/products/clickhouse/howto/integrate-kafka.md
@@ -83,11 +83,9 @@ on a table level either in the [Aiven Console](https://console.aiven.io/) or the
 <Tabs groupId="group1">
 <TabItem value="gui" label="Console" default>
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/), and go to your project.
-1.  On the <ConsoleLabel name="Services"/> page, select an Aiven for ClickHouse service
-    that includes a table to be edited.
-1.  On your service's page, click <ConsoleLabel name="databasesandtables"/> in the
-    sidebar.
+1.  Log in to the [Aiven Console](https://console.aiven.io/) and choose the Aiven for
+    ClickHouse service that includes a table to edit.
+1.  In the service sidebar, click <ConsoleLabel name="data"/> > **Databases and tables**.
 1.  Find a database including the table to be edited, and expand the database using
     <ConsoleLabel name="downarrow"/> to display tables inside it.
 1.  Find the table and click:

--- a/docs/products/clickhouse/howto/integration-databases.md
+++ b/docs/products/clickhouse/howto/integration-databases.md
@@ -32,7 +32,7 @@ Depending on your data source, select **PostgreSQL** or **Apache Kafka**.
 <TabItem value="pg" label="PostgreSQL" default>
 1.  Log in to the [Aiven Console](https://console.aiven.io/), and go to your project.
 1.  On the <ConsoleLabel name="Services"/> page, select an Aiven for ClickHouse service.
-1.  In the sidebar, click <ConsoleLabel name="databasesandtables"/>.
+1.  In the sidebar, click <ConsoleLabel name="data"/> > **Databases and tables**.
 1.  Click **Create database** > **PostgreSQL integration database**.
 1.  In the **Create PostgreSQL integration database** wizard:
 
@@ -43,7 +43,7 @@ Depending on your data source, select **PostgreSQL** or **Apache Kafka**.
 <TabItem value="kafka" label="Apache Kafka">
 1.  Log in to the [Aiven Console](https://console.aiven.io/), and go to your project.
 1.  On the <ConsoleLabel name="Services"/> page, select an Aiven for ClickHouse service.
-1.  In the sidebar, click <ConsoleLabel name="integrations"/>.
+1.  In the sidebar, click <ConsoleLabel name="data"/> > **Integrations**.
 1.  On the **Integrations** page, find your data source integration and click
     <ConsoleLabel name="actions"/> > **Create database**.
 1.  In the **Create Kafka integration database** wizard:
@@ -64,7 +64,7 @@ Depending on your data source, select **PostgreSQL** or **Apache Kafka**.
 
 1.  Log in to the [Aiven Console](https://console.aiven.io/), and go to your project.
 1.  On the <ConsoleLabel name="Services"/> page, select an Aiven for ClickHouse service.
-1.  In the sidebar, click <ConsoleLabel name="databasesandtables"/>.
+1.  In the sidebar, click <ConsoleLabel name="data"/> > **Databases and tables**.
 1.  Expand the integration database using <ConsoleLabel name="downarrow"/>.
 1.  Click <ConsoleLabel name="actions"/> > <ConsoleLabel name="viewdetails"/> on the table.
 
@@ -84,14 +84,14 @@ Depending on what you intend to edit, select **Database** or **Table**.
 1.  Log in to the [Aiven Console](https://console.aiven.io/), and go to your project.
 1.  On the <ConsoleLabel name="Services"/> page, select an Aiven for ClickHouse service
     with the database.
-1.  In the sidebar, click <ConsoleLabel name="databasesandtables"/>.
+1.  In the sidebar, click <ConsoleLabel name="data"/> > **Databases and tables**.
 1.  Click <ConsoleLabel name="actions"/> > <ConsoleLabel name="editdatabase"/> on the
     integration database.
 1.  Use <ConsoleLabel name="add"/> or <ConsoleLabel name="delete"/> to add or remove
     integration databases, and click **Save**.
 
 :::note[Alternative for PostgreSQL]
-On the **Integrations** page, find the integration and click
+On the <ConsoleLabel name="data"/> > **Integrations** page, find the integration and click
 <ConsoleLabel name="actions"/> > <ConsoleLabel name="editdatabase"/>.
 :::
 
@@ -103,7 +103,7 @@ On the **Integrations** page, find the integration and click
 1.  Log in to the [Aiven Console](https://console.aiven.io/), and go to your project.
 1.  On the <ConsoleLabel name="Services"/> page, select an Aiven for ClickHouse service
     with the database.
-1.  In the sidebar, click <ConsoleLabel name="databasesandtables"/>.
+1.  In the sidebar, click <ConsoleLabel name="data"/> > **Databases and tables**.
 1.  Click <ConsoleLabel name="actions"/> > <ConsoleLabel name="editdatabase"/> on the
     database.
 1.  Use <ConsoleLabel name="addtable"/> or <ConsoleLabel name="delete"/> to add or remove
@@ -114,7 +114,7 @@ On the **Integrations** page, find the integration and click
 1.  Log in to the [Aiven Console](https://console.aiven.io/), and go to your project.
 1.  On the <ConsoleLabel name="Services"/> page, select an Aiven for ClickHouse service
     with the table.
-1.  In the sidebar, click <ConsoleLabel name="databasesandtables"/>.
+1.  In the sidebar, click <ConsoleLabel name="data"/> > **Databases and tables**.
 1.  Expand the database using <ConsoleLabel name="downarrow"/>.
 1.  Click <ConsoleLabel name="actions"/> > <ConsoleLabel name="edittable"/> on the table.
 1.  Update the table details, and click **Save**.
@@ -132,7 +132,7 @@ Depending on what you intend to delete, select **Database** or **Table**.
 1.  Log in to the [Aiven Console](https://console.aiven.io/), and go to your project.
 1.  On the <ConsoleLabel name="Services"/> page, select an Aiven for ClickHouse service
     with the database.
-1.  In the sidebar, click <ConsoleLabel name="databasesandtables"/>.
+1.  In the sidebar, click <ConsoleLabel name="data"/> > **Databases and tables**.
 1.  Click <ConsoleLabel name="actions"/> > <ConsoleLabel name="deletedatabase"/> on the
     integration database.
 1.  Review the impact in the confirmation dialog, and click **Confirm** to delete the
@@ -144,7 +144,7 @@ Depending on what you intend to delete, select **Database** or **Table**.
 1.  Log in to the [Aiven Console](https://console.aiven.io/), and go to your project.
 1.  On the <ConsoleLabel name="Services"/> page, select an Aiven for ClickHouse service
     with the table.
-1.  In the sidebar, click <ConsoleLabel name="databasesandtables"/>.
+1.  In the sidebar, click <ConsoleLabel name="data"/> > **Databases and tables**.
 1.  Expand the integration database using <ConsoleLabel name="downarrow"/>.
 1.  Click <ConsoleLabel name="actions"/> > <ConsoleLabel name="deletetable"/> on the table.
 1.  Review the impact in the confirmation dialog, and click **Confirm** to delete the table.

--- a/docs/products/clickhouse/howto/manage-databases-tables.md
+++ b/docs/products/clickhouse/howto/manage-databases-tables.md
@@ -31,17 +31,17 @@ Your Aiven for ClickHouse service can support up to 400 databases simultaneously
 1.  Log in to the [Aiven Console](https://console.aiven.io/), and select
     your service from the <ConsoleLabel name="Services"/> page.
 
-1.  In the sidebar, click <ConsoleLabel name="databasesandtables"/>.
+1.  In the sidebar, click <ConsoleLabel name="data"/> > **Databases and tables**.
 
 1.  Click **Create database** > **ClickHouse database**.
 
 1.  In the **Create ClickHouse database** window, enter a name for your
     database and select **Create database**.
 
-    The name of the database appears in the list of databases
-    in the <ConsoleLabel name="databasesandtables"/> page. On our side, we enable
-    necessary customizations and run secondary queries to grant access
-    to the admin user.
+    The database name appears in the list of databases
+    in the **Databases and tables** page. Aiven applies
+    the required customizations and runs secondary queries to grant
+    access to the admin user.
 
 </TabItem>
 <TabItem value="cli" label="SQL">
@@ -83,7 +83,7 @@ using an SQL client such as the
 <TabItem value="console" label="Aiven Console" default>
 1.  Log in to the [Aiven Console](https://console.aiven.io/), and select
     your service from the <ConsoleLabel name="Services"/> page.
-1. In the sidebar, click <ConsoleLabel name="databasesandtables"/>.
+1. In the sidebar, click <ConsoleLabel name="data"/> > **Databases and tables**.
 1. In the **Databases and tables** list, find your database and click
     <ConsoleLabel name="actions"/> > <ConsoleLabel name="deletedatabase"/>.
 </TabItem>
@@ -133,7 +133,7 @@ in Aiven for ClickHouse.
 
 Aiven for ClickHouse uses `replicated` variants of table
 engines to ensure high availability. Even if you select `MergeTree`
-engine, we will automatically use the replicated variant on our side.
+engine, Aiven automatically uses the replicated variant.
 
 :::note
 A non-replicated table, such as `system.query_log`, can be
@@ -164,7 +164,7 @@ To remove your table in the [Aiven Console](https://console.aiven.io/):
 
 1.  Log in to the [Aiven Console](https://console.aiven.io/).
 1.  Go to the table to be removed: organization > project >
-    service > <ConsoleLabel name="databasesandtables"/>.
+    service > <ConsoleLabel name="data"/> > **Databases and tables**.
 1.  In the **Databases and tables** view, go to the table and
     select <ConsoleLabel name="actions"/> > <ConsoleLabel name="deletetable"/>.
 

--- a/docs/products/clickhouse/howto/manage-users-roles.md
+++ b/docs/products/clickhouse/howto/manage-users-roles.md
@@ -3,11 +3,11 @@ title: Manage Aiven for ClickHouse® users and roles
 sidebar_label: Manage users and roles
 ---
 
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
-Create Aiven for ClickHouse® users and roles and grant them specific privileges to efficiently control or restrict access to your service.
+Create Aiven for ClickHouse® users and roles and grant them specific privileges to control or restrict access to your service.
 
 ## Manage users
 
@@ -18,41 +18,41 @@ To create a user account for your service:
 <Tabs groupId="group1">
 <TabItem value="console" label="Console" default>
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/), and
-    select your Aiven for ClickHouse® service.
+1.  Log in to the [Aiven Console](https://console.aiven.io/) and choose your Aiven for
+    ClickHouse service.
 
-1.  Click **Users and roles** in the sidebar.
+1.  In the service sidebar, click <ConsoleLabel name="users"/>.
 
     This shows a list of all users that are currently
     available in your service. The default `avnadmin` user has all
     available access grants to the service.
 
     :::tip
-    To view the roles and grants for any of the listed users, select
+    To view the roles and grants for any of the listed users, click
     **View details & grants** for that user.
     :::
 
-1.  In the **Users and roles** page, select **Add user**.
+1.  On the **Users** page, click **Add user**.
 
 1.  In the **Create a service user** window, enter a name for the
-    new user and select a role.
+    new user and click a role.
 
     The role that you select defines the access grants that are assigned
     to the user. For more information on roles, see
     [Manage roles and privileges](/docs/products/clickhouse/howto/manage-users-roles#manage-roles-and-privileges).
 
-1.  Select **Add user**.
+1.  Click **Add user**.
 
     This creates the new user and shows you a summary of the
     information.
 
-1.  Copy the password on screen to a safe place. It can't be accessed
-    again in future, however it can be reset if needed.
+1.  Copy the password on screen to a safe place. You can't access it again later,
+    but you can reset it if needed.
 
 </TabItem>
 <TabItem value="cli" label="SQL">
 
-To create user using a hash and salt, run:
+To create a user by using a hash and salt, run:
 
 ```sql
 CREATE USER username IDENTIFIED WITH sha256_hash BY 'hash' SALT 'salt';
@@ -67,7 +67,7 @@ CREATE USER username IDENTIFIED BY 'password';
 </TabItem>
 </Tabs>
 
-Users' password digests are stored securely in ZooKeeper. Only super admin can access
+Users' password digests are stored securely in ZooKeeper. Only a super admin can access
 them. For users created in the console, their passwords are also salted with a random
 value. The password digests and salts are stored in backup files so they can be
 recovered.
@@ -106,10 +106,16 @@ Configure user settings, for example, to restrict resource use per user. This ca
 1. Log in as `limited_user` to test the configuration.
 
     ```bash
-    clickhouse-client --host YOUR_HOST --port YOUR_PORT --user limited_user --password PASSWORD --secure
+    clickhouse-client \
+      --host YOUR_HOST \
+      --port YOUR_PORT \
+      --user limited_user \
+      --password PASSWORD \
+      --secure
     ```
 
-    Replace `YOUR_HOST`, `YOUR_PORT`, and `PASSWORD` with your actual service connection details.
+    Replace `YOUR_HOST`, `YOUR_PORT`, and `PASSWORD` with your service connection
+    details.
 
 1. Verify the resource limit setting.
 
@@ -140,7 +146,12 @@ in their user profile.
 1. Test the per-query limits by logging in and running a query.
 
     ```bash
-    clickhouse-client --host YOUR_HOST --port YOUR_PORT --user query_limited_user --password PASSWORD --secure
+    clickhouse-client \
+      --host YOUR_HOST \
+      --port YOUR_PORT \
+      --user query_limited_user \
+      --password PASSWORD \
+      --secure
     ```
 
 1. Verify the query-level settings.
@@ -149,7 +160,7 @@ in their user profile.
     SHOW SETTINGS LIKE '%max_%';
     ```
 
-**Common per-query settings:**
+#### Common per-query settings
 
 - `max_memory_usage`: Maximum memory per query (in bytes)
 - `max_execution_time`: Maximum query execution time (in seconds)
@@ -285,8 +296,8 @@ Revoke all privileges to a table or database simultaneously:
 REVOKE ALL PRIVILEGES ON database.table FROM external;
 ```
 
-See the ClickHouse documentation [for more information on revoking
-privileges](https://clickhouse.com/docs/en/sql-reference/statements/revoke/).
+For more information about revoking privileges, see the
+[ClickHouse documentation](https://clickhouse.com/docs/en/sql-reference/statements/revoke/).
 
 ### Check privileges
 
@@ -310,10 +321,10 @@ SHOW ROLES;
 You can also see the users, their roles, and privileges in the [Aiven
 Console](https://console.aiven.io/).
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/), and
-    select your Aiven for ClickHouse® service.
-1.  Click **Users and roles** in the sidebar.
-1.  Click **View details & grants** next to one of the user listed on the page.
+1.  Log in to the [Aiven Console](https://console.aiven.io/) and choose your Aiven for
+    ClickHouse service.
+1.  In the service sidebar, click <ConsoleLabel name="users"/>.
+1.  Click **View details & grants** next to one of the users listed on the page.
     This shows you a list of all grants for the selected user.
 
 ## Manage using Terraform

--- a/docs/products/clickhouse/howto/monitor-performance.md
+++ b/docs/products/clickhouse/howto/monitor-performance.md
@@ -3,6 +3,7 @@ title: Monitor Aiven for ClickHouse® metrics with Aiven for Grafana®
 sidebar_label: Monitor metrics with Grafana
 ---
 
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import NoThanosAccess from "@site/static/includes/no-thanos-access.md";
 
 Push Aiven for ClickHouse® metrics to Aiven for Metrics or Aiven for PostgreSQL®, and integrate with Aiven for Grafana® to monitor your metrics on Grafana dashboards.
@@ -28,8 +29,10 @@ To collect metrics about your Aiven for ClickHouse service,
 configure a metrics integration and nominate somewhere to store the
 collected metrics.
 
-1.  On the service **Overview** page for your Aiven for ClickHouse service, go to
-    **Integrations**, and click **Go to Integrations** > **Store Metrics**.
+1.  Log in to the [Aiven Console](https://console.aiven.io/) and choose your Aiven for
+    ClickHouse service.
+1.  In the service sidebar, click <ConsoleLabel name="data"/> > **Integrations**.
+1.  In the **Aiven services** section, click **Store Metrics**.
 1.  In the **Metrics integration** window:
     1.  Choose either a new or existing Aiven for Metrics or Aiven for PostgreSQL service.
         -   **For Aiven for Metrics**: This provides a Thanos-based time-series database
@@ -44,19 +47,23 @@ collected metrics.
 
 ## Provision and configure Grafana
 
-1.  In the Aiven Console, go to your metrics storage service (Aiven for Metrics or Aiven
-    for PostgreSQL) page.
-1.  On the service **Overview** page, go to **Integrations**, and click
-    **Go to Integrations** > **Grafana Metrics Dashboard** to make your metrics available
-    in Aiven for Grafana.
-1.  In the **Dashboard integration** window:
-    1.  Choose either a new or existing Aiven for Grafana service.
-        -   If you choose to use a new service, follow instructions on
-            [how to create a service](/docs/platform/howto/create_new_service).
-        -   If you're already using Grafana on Aiven, you can integrate
-            your Aiven for Metrics or Aiven for PostgreSQL as an additional data source for that
-            existing Grafana.
-    1.  Click **Enable**.
+1. In the [Aiven Console](https://console.aiven.io/), choose your Aiven for Metrics or
+   Aiven for PostgreSQL service.
+1. Open the service's **Integrations** page.
+
+   - For Aiven for Metrics, click <ConsoleLabel name="integrations"/> in the service sidebar.
+   - For Aiven for PostgreSQL, in the service sidebar, click **Connect** >
+     **Integrations**.
+
+1. In the **Aiven services** section, click **Grafana Metrics Dashboard**.
+1. In the **Dashboard integration** window:
+   1. Choose either a new or existing Aiven for Grafana service.
+      - If you choose to use a new service, follow instructions on
+        [how to create a service](/docs/platform/howto/create_new_service).
+      - If you're already using Grafana on Aiven, you can integrate
+        your Aiven for Metrics or Aiven for PostgreSQL as an additional data source for that
+        existing Grafana.
+   1. Click **Enable**.
 
 :::note
 Now your Aiven for Grafana service is connected to your metrics storage service as a data

--- a/docs/products/clickhouse/howto/query-databases.md
+++ b/docs/products/clickhouse/howto/query-databases.md
@@ -4,6 +4,8 @@ sidebar_label: Query a database
 keywords: [query log, query_log, log table]
 ---
 
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+
 Run a query against an Aiven for ClickHouse® database using a tool of your choice.
 
 To ensure data security, stability, and its proper replication, we equip
@@ -36,9 +38,9 @@ query editor, the Play UI, and
 
 ### Query editor {#use-query-editor}
 
-Aiven for ClickHouse® includes a web-based query editor, which you can
-find in [Aiven Console](https://console.aiven.io/) by selecting **Query
-editor** from the sidebar of your service's page.
+Aiven for ClickHouse® includes a web-based query editor. To open it, log in to the
+[Aiven Console](https://console.aiven.io/), choose your Aiven for ClickHouse service, and
+click <ConsoleLabel name="data"/> > **Query editor** in the service sidebar.
 
 #### When to use the query editor
 
@@ -78,10 +80,10 @@ if you expect a large size of the response.
 
 #### Use the play UI
 
-1.  Log in to [Aiven Console](https://console.aiven.io/), choose the
-    right project, and select your Aiven for ClickHouse service.
-1.  In the **Overview** page of your service, find the **Connection
-    information** section and select **ClickHouse HTTPS & JDBC**.
+1.  Log in to the [Aiven Console](https://console.aiven.io/) and choose your Aiven for
+    ClickHouse service.
+1.  On the <ConsoleLabel name="overview"/> page, in the **Connection information**
+    section, select **ClickHouse HTTPS & JDBC**.
 1.  Copy **Service URI** and go to `YOUR_SERVICE_URI/play` from a
     web browser.
 1.  Set the name and the password of the user on whose behalf you want

--- a/docs/products/clickhouse/howto/secure-service.md
+++ b/docs/products/clickhouse/howto/secure-service.md
@@ -3,6 +3,8 @@ title: Secure a managed ClickHouse® service
 sidebar_label: Secure a managed service
 ---
 
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+
 You can secure your Aiven for ClickHouse® service in a few different ways, for example by restricting network access, using Virtual Private Cloud (VPC), and enabling service termination protection.
 
 ## Restrict network access to your service
@@ -32,13 +34,12 @@ Termination Protection has no effect on service migrations or upgrades.
 
 ### Enable the termination protection
 
-1.  Log in to [Aiven Console](https://console.aiven.io/), and select
-    your ClickHouse® service from the **Services** view.
-1.  On the **Overview** page of your service, select **Service
-    settings** from the sidebar.
-1.  On the **Service settings** page, go to the **Service status**
-    section, and select **Enable termination protection** from the
-    **Actions** (**...**) menu.
+1. Log in to the [Aiven Console](https://console.aiven.io/) and choose your Aiven for
+   ClickHouse service.
+1. On the <ConsoleLabel name="overview"/> page, click
+   <ConsoleLabel name="service settings"/> in the service sidebar.
+1. On the **Service settings** page, go to the **Service status**
+   section, and click <ConsoleLabel name="actions"/> > **Enable termination protection**.
 
 Termination Protection is enabled for your service: It cannot be
 terminated or powered down from the Aiven Console, via the Aiven

--- a/docs/products/clickhouse/howto/set-up-kafka-topic-querying.md
+++ b/docs/products/clickhouse/howto/set-up-kafka-topic-querying.md
@@ -107,13 +107,13 @@ If you need more configuration options, click **Go to the full service creation*
 
 1. Click **Query**.
 
-   The ClickHouse <ConsoleLabel name="queryeditor" /> opens with a generated `SELECT`
-   query for the table created during setup.
+   The ClickHouse <ConsoleLabel name="data"/> > **Query editor** opens with a generated
+   `SELECT` query for the table created during setup.
 
 1. Review the generated SQL query.
 1. Click **Execute**.
-1. View the integration on the <ConsoleLabel name="integrations" /> page of either the
-   Kafka service or the ClickHouse service.
+1. View the integration on the <ConsoleLabel name="data"/> > **Integrations** page of
+   either the Kafka service or the ClickHouse service.
 
 ## Troubleshoot
 
@@ -140,8 +140,9 @@ service to a supported cloud region.
 
 ### Data not appearing after deployment
 
-If data does not appear in the ClickHouse table after deployment, review the logs for
-the Aiven for ClickHouse® service. Ingestion errors are reported on the ClickHouse side.
+If data does not appear in the ClickHouse table after deployment, review
+<ConsoleLabel name="observe"/> > **Logs** for the Aiven for ClickHouse® service.
+Ingestion errors are reported on the ClickHouse side.
 
 Also ensure the selected ingestion start point includes messages from the topic. For
 example, if you selected **New messages only**, only messages produced after the

--- a/docs/products/clickhouse/howto/vector-similarity-index-cache.md
+++ b/docs/products/clickhouse/howto/vector-similarity-index-cache.md
@@ -87,12 +87,12 @@ per-part HNSW index without eviction.
 You can update `server_settings.vector_similarity_index_cache_size_ratio` without
 restarting the service.
 
-1. In the [Aiven Console](https://console.aiven.io/), open your Aiven for ClickHouse
-   service.
-1. Click <ConsoleLabel name="Service settings"/>.
-1. In <ConsoleLabel name="Advanced configuration"/>, click
-   <ConsoleLabel name="Add config options"/>.
-1. Find `server_settings.vector_similarity_index_cache_size_ratio`.
+1. Log in to the [Aiven Console](https://console.aiven.io/) and choose your Aiven for
+   ClickHouse service.
+1. In the service sidebar, click <ConsoleLabel name="service settings"/>.
+1. In the **Advanced configuration** section, click **Configure**.
+1. Click <ConsoleLabel name="Add config options"/>.
+1. Search for `server_settings.vector_similarity_index_cache_size_ratio`.
 1. Set the value to `0.4` or higher.
 1. Click **Save configuration**.
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1275,17 +1275,20 @@ const sidebars: SidebarsConfig = {
                 'products/clickhouse/howto/secure-service',
                 'products/clickhouse/howto/list-manage-cluster',
                 'products/clickhouse/howto/manage-users-roles',
-                {
-                  type: 'category',
-                  label: 'Versions and upgrades',
-                  items: [
-                    'products/clickhouse/reference/version-lifecycle',
-                    'products/clickhouse/howto/manage-clickhouse-versions',
-                    'products/clickhouse/reference/25-8-default-settings',
-                  ],
-                },
                 'products/clickhouse/reference/advanced-params',
                 'products/clickhouse/reference/limitations',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Maintenance and lifecycle',
+              link: {
+                type: 'doc',
+                id: 'products/clickhouse/reference/version-lifecycle',
+              },
+              items: [
+                'products/clickhouse/howto/manage-clickhouse-versions',
+                'products/clickhouse/reference/25-8-default-settings',
               ],
             },
             {

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1282,11 +1282,8 @@ const sidebars: SidebarsConfig = {
             {
               type: 'category',
               label: 'Maintenance and lifecycle',
-              link: {
-                type: 'doc',
-                id: 'products/clickhouse/reference/version-lifecycle',
-              },
               items: [
+                'products/clickhouse/reference/version-lifecycle',
                 'products/clickhouse/howto/manage-clickhouse-versions',
                 'products/clickhouse/reference/25-8-default-settings',
               ],

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -172,13 +172,14 @@ export default function ConsoleLabel({name}): ReactElement {
     case 'observe':
       return (
         <>
-          <ConsoleIconWrapper icon={ConsoleIcons.pulse} /> <b>Observe</b>
+          <ConsoleIconWrapper icon={ConsoleIcons.timelineAreaChart} />{' '}
+          <b>Observe</b>
         </>
       );
     case 'data':
       return (
         <>
-          <ConsoleIconWrapper icon={ConsoleIcons.dataflow01} /> <b>Data</b>
+          <ConsoleIconWrapper icon={ConsoleIcons.database} /> <b>Data</b>
         </>
       );
     case 'overview':
@@ -247,7 +248,7 @@ export default function ConsoleLabel({name}): ReactElement {
     case 'users':
       return (
         <>
-          <ConsoleIconWrapper icon={ConsoleIcons.user} /> <b>Users</b>
+          <ConsoleIconWrapper icon={ConsoleIcons.people} /> <b>Users</b>
         </>
       );
     case 'makesuperadmin':


### PR DESCRIPTION
## Describe your changes

Updated Aiven for ClickHouse docs to match the new service side navigation in the Aiven Console.

- Updated Console navigation paths for Data, Observe, Users, Backups, and Service settings.
- Updated Console icon labels for the new ClickHouse side nav.
- Improved task steps to follow the docs style guide and current Console flows.
- Moved ClickHouse version lifecycle content under a peer-level Maintenance and lifecycle section, aligned with PostgreSQL.

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.
