### PR TITLE
update: Kafka docs for Console navigation labels

### DIFF
--- a/docs/products/kafka/diskless/howto/create-diskless-topics-automatically.md
+++ b/docs/products/kafka/diskless/howto/create-diskless-topics-automatically.md
@@ -206,7 +206,7 @@ created as a diskless topic.
 
 1. In the [Aiven Console](https://console.aiven.io/), click your Aiven for Apache Kafka
    service.
-1. Click <ConsoleLabel name="Topics"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Topics**.
 1. Check the **Topic type** column.
 
 Topics that match a configured regular expression show **Diskless**.

--- a/docs/products/kafka/howto/add-manage-service-users.md
+++ b/docs/products/kafka/howto/add-manage-service-users.md
@@ -73,7 +73,7 @@ Replace the following:
 
 1. Open your Aiven for Apache Kafka service in the
    [Aiven Console](https://console.aiven.io).
-1. Click <ConsoleLabel name="serviceusers" /> in the sidebar to view the list of users.
+1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="serviceusers" /> in the sidebar to view the list of users.
 1. To view the password, click <ConsoleLabel name="show password" /> in the password
    field for the respective user.
 1. Click <ConsoleLabel name="actions" /> in the user row and choose an action:

--- a/docs/products/kafka/howto/add-manage-service-users.md
+++ b/docs/products/kafka/howto/add-manage-service-users.md
@@ -73,7 +73,8 @@ Replace the following:
 
 1. Open your Aiven for Apache Kafka service in the
    [Aiven Console](https://console.aiven.io).
-1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="serviceusers" /> in the sidebar to view the list of users.
+1. Click <ConsoleLabel name="Access & Control" /> > **Users** in the sidebar to
+   view the list of users.
 1. To view the password, click <ConsoleLabel name="show password" /> in the password
    field for the respective user.
 1. Click <ConsoleLabel name="actions" /> in the user row and choose an action:

--- a/docs/products/kafka/howto/best-practices.md
+++ b/docs/products/kafka/howto/best-practices.md
@@ -1,6 +1,7 @@
 ---
 title: Optimize Apache Kafka® performance
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 Follow these best practices to optimize the performance and reliability of your Aiven for Apache Kafka® service.
 
@@ -52,8 +53,9 @@ partitions. This results in uneven load distribution and reduces parallel proces
 efficiency.
 
 You can view the size of each partition by selecting the
-[topic](/docs/products/kafka/howto/create-topic) in the Topics list and opening
-the **Partitions** tab in the [Aiven Console](https://console.aiven.io/).
+[topic](/docs/products/kafka/howto/create-topic) in the
+<ConsoleLabel name="manage stream" /> > **Topics** list and opening the **Partitions**
+tab in the [Aiven Console](https://console.aiven.io/).
 
 ## Balance between throughput and latency
 

--- a/docs/products/kafka/howto/change-retention-period.md
+++ b/docs/products/kafka/howto/change-retention-period.md
@@ -1,6 +1,7 @@
 ---
 title: Change data retention period
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 To avoid running out of disk space, by default, Apache Kafka® drops the oldest messages from the beginning of each log after their retention period expires.
 **Aiven for Apache Kafka®** allows you to configure the
@@ -16,65 +17,58 @@ retention period of any previously created topics.
 
 To change the retention period for a single topic:
 
-1.  In the [Aiven Console](https://console.aiven.io/), select your
-    project and choose your Aiven for Apache Kafka® service.
+1. In the [Aiven Console](https://console.aiven.io/), select your
+   project and choose your Aiven for Apache Kafka® service.
 
-2.  Select **Topics** from the left sidebar.
+1. Select <ConsoleLabel name="manage stream" /> > **Topics** from the left sidebar.
 
-3.  Select the topic from the **Topics** screen for which to
-    modify the retention period.
+1. Select the topic to modify.
 
-4.  In the **Topic info** screen, select **Modify**.
+1. In the **Topic info** screen, select **Modify**.
 
-5.  In the modify topic screen, update the value of **Retention ms** to
-    the desired retention length in milliseconds. If you cannot find
-    **Retention ms**, use the search bar to locate it
+1. In the modify topic screen, update the value of **Retention ms** to
+   the desired retention length in milliseconds. If you cannot find
+   **Retention ms**, use the search bar to locate it
 
-    :::note
-    The **Retention ms** option is displayed in the modify topic screen
-    for topics where advanced configuration was enabled during topic
-    creation.
-    :::
+   :::note
+   The **Retention ms** option is displayed in the modify topic screen
+   for topics where advanced configuration was enabled during topic
+   creation.
+   :::
 
-6.  Select **Update** to save your changes.
+1. Select **Update** to save your changes.
 
-7.  In the *Advanced configuration* view find **Retention ms**.
+1. In the *Advanced configuration* view find **Retention ms**.
 
-8.  Change the value of **Retention ms** value to the desired retention
-    length in milliseconds.
+1. Change the value of **Retention ms** value to the desired retention
+   length in milliseconds.
 
-    :::tip
-    You can also change **Retention bytes** setting to limit
-    amount of data retained based on the storage usage.
-    :::
+   :::tip
+   You can also change **Retention bytes** setting to limit
+   amount of data retained based on the storage usage.
+   :::
 
 ## At a service level
 
-1.  In the [Aiven Console](https://console.aiven.io/), select your
-    project and choose your Aiven for Apache Kafka® service.
-2.  In the service page, select **Service settings** from the sidebar.
-3.  On the **Service settings** page, scroll down to the **Advanced
-    configuration** section, and click **Configure**.
-4.  In the **Advanced configuration** dialog, click **Add configuration
-    options**.
-5.  You have two options to configure the retention period for Apache
-    Kafka® logs:
-    -   You can either find `kafka.log_retention_hours` or
-        `kafka.log_retention_ms` and set the desired length of time for
-        retention.
-    -   Alternatively, if you prefer to limit the amount of data
-        retained based on storage usage, you can specify the value for
-        `kafka.log_retention_bytes`.
-6.  Click **Save configuration**.
+1. In the [Aiven Console](https://console.aiven.io/), select your project and choose
+   your Aiven for Apache Kafka® service.
+1. Click <ConsoleLabel name="service settings" />, scroll to
+   **Advanced configuration**, and click **Configure**.
+1. In the **Advanced configuration** dialog, click
+   <ConsoleLabel name="addadvancedconfiguration" />.
+1. Configure the retention period for Apache Kafka® logs:
+   - Find `kafka.log_retention_hours` or `kafka.log_retention_ms`, and set the
+     retention period.
+   - To limit retention by storage usage, set `kafka.log_retention_bytes`.
+1. Click **Save configuration**.
 
 ## Unlimited retention
 
-We do not limit the maximum retention period in any way, and in order to
-disable time-based content expiration altogether set the retention value
-to `-1`.
+Aiven does not limit the maximum retention period. To turn off time-based content
+expiration, set the retention value to `-1`.
 
 :::warning
 Using high retention periods without monitoring the available storage
 space can cause your service to run out of disk space. These situations
-are not covered by our SLA.
+are not covered by the Aiven SLA.
 :::

--- a/docs/products/kafka/howto/configure-audit-logging.md
+++ b/docs/products/kafka/howto/configure-audit-logging.md
@@ -190,7 +190,7 @@ Audit entries appear in the service logs with the `AUDIT:` prefix. To view them,
 one of the following methods:
 
 - In the [Aiven Console](https://console.aiven.io/), open your service and click
-  <ConsoleLabel name="logs"/>.
+  <ConsoleLabel name="observe" /> > <ConsoleLabel name="logs"/>.
 - With the Aiven CLI, run:
 
   ```bash

--- a/docs/products/kafka/howto/configure-log-cleaner.md
+++ b/docs/products/kafka/howto/configure-log-cleaner.md
@@ -1,6 +1,7 @@
 ---
 title: Configure the log cleaner for topic compaction
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 import RelatedPages from "@site/src/components/RelatedPages";
 
@@ -30,7 +31,7 @@ configuration override in place.
 
 1.  In the [Aiven Console](https://console.aiven.io/), select your
     project and choose your Aiven for Apache Kafka® service.
-1.  Select **Topics** from the left sidebar.
+1.  Select <ConsoleLabel name="manage stream" /> > **Topics** from the left sidebar.
 1.  Select the topic to modify and select **Modify** in the
     context menu.
 1.  From the drop-down options for the **Cleanup policy**, select the

--- a/docs/products/kafka/howto/configure-topic-tiered-storage.md
+++ b/docs/products/kafka/howto/configure-topic-tiered-storage.md
@@ -31,10 +31,9 @@ using the Aiven Console have tiered storage enabled by default.
 
 1. Access the [Aiven Console](https://console.aiven.io/), select your project,
    and select your Aiven for Apache Kafka service.
-1. Click <ConsoleLabel name="topics" />.
+1. Click <ConsoleLabel name="manage stream" /> > **Topics**.
 
-1. On the **Topics** page, either add a new topic with tiered storage or modify an
-   existing one:
+1. Either add a new topic with tiered storage or modify an existing one:
    - To add a new topic, click **Add topic**.
    - To modify an existing topic, select the topic to modify, then either:
      - Click the topic name to open the **Topic info** screen, and click **Modify**.

--- a/docs/products/kafka/howto/create-topic.md
+++ b/docs/products/kafka/howto/create-topic.md
@@ -90,7 +90,7 @@ create a topic and test producing and consuming messages. For example:
 <TabItem value="classic-service" label="Classic Kafka service" default>
 
 1. In the [Aiven Console](https://console.aiven.io/), select the Aiven for Apache Kafka service.
-1. In the sidebar, click <ConsoleLabel name="topics" />.
+1. In the sidebar, click <ConsoleLabel name="manage stream" /> > **Topics**.
 1. Click **Create topic**.
 1. Enter a name in the **Topic** field.
 1. Optional: Turn on **Enable advanced configurations** to set values such as
@@ -108,7 +108,7 @@ create a topic and test producing and consuming messages. For example:
 <TabItem value="inkless-service" label="Inkless Kafka service">
 
 1. In the [Aiven Console](https://console.aiven.io/), select the Aiven for Apache Kafka service.
-1. In the sidebar, click <ConsoleLabel name="topics" />.
+1. In the sidebar, click <ConsoleLabel name="manage stream" /> > **Topics**.
 1. Click **Create topic**.
 1. Enter a name in the **Topic** field.
 1. In **Topic type**, select one of the following:
@@ -133,7 +133,7 @@ create a topic and test producing and consuming messages. For example:
 </TabItem>
 </Tabs>
 
-After creation, the topic appears on the <ConsoleLabel name="topics" /> page.
+After creation, the topic appears on the <ConsoleLabel name="manage stream" /> > **Topics** page.
 The **Topic type** column shows **Classic** or **Diskless**.
 
 :::tip

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.md
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.md
@@ -54,7 +54,7 @@ section.
 
 :::note
 Alternatively, if tiered storage is not yet active for your service, you can enable
-it by selecting **Tiered storage** from the sidebar.
+it by selecting **Observe** > **Tiered storage** from the sidebar.
 :::
 
 </TabItem>

--- a/docs/products/kafka/howto/generate-java-classes-from-schemas.md
+++ b/docs/products/kafka/howto/generate-java-classes-from-schemas.md
@@ -1,4 +1,4 @@
-  ---
+---
 title: Generate Java classes from schemas
 ---
 

--- a/docs/products/kafka/howto/generate-sample-data-manually.md
+++ b/docs/products/kafka/howto/generate-sample-data-manually.md
@@ -77,7 +77,7 @@ Use the [Dockerized fake data producer for Aiven for Apache Kafka®](https://git
 1. Once the Docker image is running, verify that the topic is receiving messages:
 
    - In the [Aiven Console](https://console.aiven.io), go to your Apache Kafka service
-     and click <ConsoleLabel name="topics" />.
+     and click <ConsoleLabel name="manage stream" /> > **Topics**.
    - Or use a command-line tool such as [kcat](/docs/products/kafka/howto/kcat) to
      consume messages from the topic.
 

--- a/docs/products/kafka/howto/generate-sample-data.md
+++ b/docs/products/kafka/howto/generate-sample-data.md
@@ -101,8 +101,8 @@ time, and a link to review messages.
   the <ConsoleLabel name="overview" /> page. This option is only visible in the browser
   tab where the generator was started.
 - To view topic settings, message details, or the applied schema, click
-  <ConsoleLabel name="topics" /> in the sidebar, then select the topic created by the
-  generator.
+  <ConsoleLabel name="manage stream" /> > **Topics** in the sidebar, then select the
+  topic created by the generator.
 
 <RelatedPages/>
 

--- a/docs/products/kafka/howto/get-topic-partition-details.md
+++ b/docs/products/kafka/howto/get-topic-partition-details.md
@@ -1,6 +1,7 @@
 ---
 title: Get partition details of an Apache Kafka® topic
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -12,9 +13,8 @@ Learn how to get partition details of an Apache Kafka® topic.
 
 1.  Log in to [Aiven Console](https://console.aiven.io/) and select your
     Aiven for Apache Kafka service.
-1.  Select **Topics** from the left sidebar.
-1.  Select a specific topic in the **Topics** screen or click the
-    ellipsis (More options).
+1.  Select <ConsoleLabel name="manage stream" /> > **Topics** from the left sidebar.
+1.  Select a specific topic or click the ellipsis (More options).
 1.  On the **Topics info** screen, select **Partitions** to view
     detailed information about the partitions.
 

--- a/docs/products/kafka/howto/integrate-service-logs-into-kafka-topic.md
+++ b/docs/products/kafka/howto/integrate-service-logs-into-kafka-topic.md
@@ -1,6 +1,7 @@
 ---
 title: Integration of logs into Apache Kafka® topic
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 You can send logs from your Aiven services into a specified Apache Kafka® topic.
 The setup can be done through [Aiven console](https://console.aiven.io).
@@ -31,11 +32,8 @@ create a Kafka topic where to receive the logs.
 
 1.  Log in to [Aiven console](https://console.aiven.io) and select your
     source PostgreSQL service.
-1.  On the **Overview page**, scroll to **Service integrations**.
-1.  Select **Manage Integrations**. You will be redirected to the
-    **Integrations** screen that shows the available
-    integrations for your service.
-1.  Select **Apache Kafka Logs** from this list.
+1.  In the sidebar, click <ConsoleLabel name="connect" /> > **Integrations**.
+1.  In **Aiven services**, select **Apache Kafka Logs**.
 1.  Select the destination Kafka service (or external Kafka integration)
     and select **Continue**.
 1.  Enter the desired **Topic name** where you want the logs to be
@@ -45,8 +43,8 @@ create a Kafka topic where to receive the logs.
 
 1.  Access your destination Apache Kafka service.
 
-1.  Select **Topics** from the left sidebar and locate your topic you
-    specified to send logs.
+1.  Select <ConsoleLabel name="manage stream" /> > **Topics** from the left sidebar and
+    locate the topic you specified to send logs.
 
 1.  From the **Topic info** screen, select **Messages**.
 

--- a/docs/products/kafka/howto/kafka-streams-with-aiven-for-kafka.md
+++ b/docs/products/kafka/howto/kafka-streams-with-aiven-for-kafka.md
@@ -184,7 +184,7 @@ The Docker image uses the same `run.sh` script.
 <TabItem value="console" label="In the Aiven console" default>
 
 1. In the [Aiven console](https://console.aiven.io/), open the **Aiven for Apache Kafka®** service.
-1. In the sidebar, click <ConsoleLabel name="topics" />.
+1. In the sidebar, click <ConsoleLabel name="manage stream" /> > **Topics**.
 1. Select the `logistics_data_delivered` topic.
 1. Click **Messages**.
 1. In **Format**, select `Avro`.

--- a/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
+++ b/docs/products/kafka/howto/kafka-tiered-storage-get-started.md
@@ -24,7 +24,8 @@ Enable tiered storage for your Aiven for Apache Kafka service to set up the nece
 
 - Aiven for Apache Kafka® supports tiered storage starting from Apache Kafka® version
   3.6 or later. Upgrade to the latest default version and apply
-  [maintenance updates](/docs/platform/concepts/maintenance-window#maintenance-updates) when using tiered storage for the latest fixes and improvements.
+  [maintenance updates](/docs/platform/concepts/maintenance-window#maintenance-updates)
+  when using tiered storage for the latest fixes and improvements.
 - Tiered storage is not available on startup plans.
 
 :::
@@ -34,14 +35,14 @@ Enable tiered storage for your Aiven for Apache Kafka service to set up the nece
 Configure tiered storage for specific topics to control your data storage.
 
 - Follow the instructions to [enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage).
-- On the <ConsoleLabel name="topics" /> page, topics using tiered storage display
-  **Active** in the **Tiered storage** column.
+- On the <ConsoleLabel name="manage stream" /> > **Topics** page,
+  topics using tiered storage display **Active** in the **Tiered storage** column.
 
 ## Step 3: Monitor storage usage
 
 Monitor storage usage for your Aiven for Apache Kafka® service.
 
-- Open the <ConsoleLabel name="Tiered storage" />.
+- Open <ConsoleLabel name="observe" /> > **Tiered storage**.
 - Review billing, retention settings, and storage usage details.
 
 ## Related Pages

--- a/docs/products/kafka/howto/keystore-truststore.md
+++ b/docs/products/kafka/howto/keystore-truststore.md
@@ -1,6 +1,7 @@
 ---
 title: Configure Java SSL keystore and truststore to access Apache Kafka®
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 Aiven for Apache Kafka® utilises TLS (SSL) to secure the traffic between its services and client applications.
 This means that clients must be
@@ -12,12 +13,12 @@ client that interacts with the service. To create these files:
 
 ## Access service certificates
 
-1.  Log in to [Aiven Console](https://console.aiven.io/) and select your
-    Apache Kafka service.
-
-1.  Download the **Access Key**, **Access Certificate**, and **CA
-    Certificate**. The files _service.key_, _service.cert_, and
-    _ca.pem_ are necessary.
+1. Log in to [Aiven Console](https://console.aiven.io/) and select your
+   Apache Kafka service.
+1. On the <ConsoleLabel name="overview" /> page, go to the **Connect information** panel.
+1. Select **Client certificate** as the authentication method.
+1. Download the **Access Key**, **Access Certificate**, and **CA Certificate**.
+   The files _service.key_, _service.cert_, and _ca.pem_ are necessary.
 
 ## Create the keystore
 

--- a/docs/products/kafka/howto/kpow.md
+++ b/docs/products/kafka/howto/kpow.md
@@ -1,6 +1,7 @@
 ---
 title: Use Kpow with Aiven for Apache Kafka®
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 [Kpow by Factor House](https://factorhouse.io/products/kpow) is an enterprise solution for Kafka management and monitoring.
 
@@ -114,8 +115,9 @@ integrated offering does not expose this public REST URL.
 
 :::warning Service integration required
 Creating a Standalone Connect service in Aiven is not enough. Link the Connect service to
-your Kafka service in the Aiven Console. Click **Manage Integrations**. If you skip this
-step, Aiven returns a 503 Service Unavailable error, and Kpow fails to start.
+your Kafka service in the Aiven Console. Click <ConsoleLabel name="manage stream" /> > **Integrations**. If
+you skip this step, Aiven returns a 503 Service Unavailable error, and Kpow fails to
+start.
 :::
 
 Configure your Standalone Connect cluster with the following properties:

--- a/docs/products/kafka/howto/manage-acls.md
+++ b/docs/products/kafka/howto/manage-acls.md
@@ -51,7 +51,7 @@ For more information, see
 
 1. Log in to [Aiven Console](https://console.aiven.io/) and select your
    service.
-1. Click <ConsoleLabel name="acl" />.
+1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="acl" />.
 1. Click **Add entry**.
 1. On the **Add access control entry** screen:
    1. Select **Kafka-native ACLs** as the ACL type.
@@ -163,7 +163,7 @@ More information on this resource and its configuration options are available in
 
 1. Log in to [Aiven Console](https://console.aiven.io/) and select your
    service.
-1. Click <ConsoleLabel name="acl" />.
+1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="acl" />.
 1. Click **Add entry**.
 1. On the **Add access control entry** screen:
    1. Select **Aiven ACLs** as the ACL type.
@@ -279,7 +279,7 @@ admin user with wildcard permissions.
 
 1. Log in to the [Aiven Console](https://console.aiven.io/) and select your
    Aiven for Apache Kafka service.
-1. Click <ConsoleLabel name="acl" />.
+1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="acl" />.
 1. Click the **Kafka-native ACLs** tab to view Kafka-native ACL entries or the
    **Aiven ACLs** tab to view Aiven ACL entries.
 1. Use filters to narrow the list by resource type, operation, or permission type.
@@ -340,7 +340,7 @@ Parameters:
 
 1. Log in to the [Aiven Console](https://console.aiven.io/) and select your
    Aiven for Kafka service.
-1. Click <ConsoleLabel name="acl" />
+1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="acl" />
 1. Click the **Kafka-native ACLs** tab to view Kafka-native ACL entries or the
    **Aiven ACLs** tab to view Aiven ACL entries.
 1. Locate the ACL entry to delete.

--- a/docs/products/kafka/howto/manage-acls.md
+++ b/docs/products/kafka/howto/manage-acls.md
@@ -51,7 +51,7 @@ For more information, see
 
 1. Log in to [Aiven Console](https://console.aiven.io/) and select your
    service.
-1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="acl" />.
+1. Click <ConsoleLabel name="Access & Control" /> > **ACL**.
 1. Click **Add entry**.
 1. On the **Add access control entry** screen:
    1. Select **Kafka-native ACLs** as the ACL type.
@@ -163,7 +163,7 @@ More information on this resource and its configuration options are available in
 
 1. Log in to [Aiven Console](https://console.aiven.io/) and select your
    service.
-1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="acl" />.
+1. Click <ConsoleLabel name="Access & Control" /> > **ACL**.
 1. Click **Add entry**.
 1. On the **Add access control entry** screen:
    1. Select **Aiven ACLs** as the ACL type.
@@ -279,7 +279,7 @@ admin user with wildcard permissions.
 
 1. Log in to the [Aiven Console](https://console.aiven.io/) and select your
    Aiven for Apache Kafka service.
-1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="acl" />.
+1. Click <ConsoleLabel name="Access & Control" /> > **ACL**.
 1. Click the **Kafka-native ACLs** tab to view Kafka-native ACL entries or the
    **Aiven ACLs** tab to view Aiven ACL entries.
 1. Use filters to narrow the list by resource type, operation, or permission type.
@@ -340,7 +340,7 @@ Parameters:
 
 1. Log in to the [Aiven Console](https://console.aiven.io/) and select your
    Aiven for Kafka service.
-1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="acl" />
+1. Click <ConsoleLabel name="Access & Control" /> > **ACL**
 1. Click the **Kafka-native ACLs** tab to view Kafka-native ACL entries or the
    **Aiven ACLs** tab to view Aiven ACL entries.
 1. Locate the ACL entry to delete.

--- a/docs/products/kafka/howto/manage-quotas.md
+++ b/docs/products/kafka/howto/manage-quotas.md
@@ -21,7 +21,7 @@ Manage quotas in your Aiven for Apache Kafka® service to control network throug
 <TabItem value="console" label="Aiven Console" default>
 
 1. Log in to [Aiven Console](https://console.aiven.io/) and select your Kafka service.
-1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="quotas" /> in the sidebar.
+1. Click <ConsoleLabel name="Access & Control" /> > **Quotas** in the sidebar.
 1. Click **Add quota**.
 1. Enter the **Client ID** or **User**.
 1. Set one or more quota values:
@@ -88,7 +88,7 @@ name.
 
 1. Access the [Aiven Console](https://console.aiven.io/) and open your Aiven for Apache
    Kafka® service.
-1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="quotas" />.
+1. Click <ConsoleLabel name="Access & Control" /> > **Quotas**.
 
 The page lists all configured quotas.
 
@@ -123,7 +123,7 @@ name.
 
 1. Access the [Aiven Console](https://console.aiven.io/) and open your Aiven for Apache
    Kafka® service.
-1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="quotas" />.
+1. Click <ConsoleLabel name="Access & Control" /> > **Quotas**.
 1. Find the quota to update.
 1. Click <ConsoleLabel name="actions" /> > **Update**.
 1. Update the quota values.
@@ -157,7 +157,7 @@ endpoint with the updated values to overwrite the existing quota.
 
 1. Access the [Aiven Console](https://console.aiven.io/) and open your Aiven for Apache
    Kafka® service.
-1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="quotas" />.
+1. Click <ConsoleLabel name="Access & Control" /> > **Quotas**.
 1. Find the quota to delete.
 1. Click <ConsoleLabel name="actions" /> > **Delete**.
 1. Click **Delete quota** to confirm.

--- a/docs/products/kafka/howto/manage-quotas.md
+++ b/docs/products/kafka/howto/manage-quotas.md
@@ -21,7 +21,7 @@ Manage quotas in your Aiven for Apache Kafka® service to control network throug
 <TabItem value="console" label="Aiven Console" default>
 
 1. Log in to [Aiven Console](https://console.aiven.io/) and select your Kafka service.
-1. Click <ConsoleLabel name="quotas" /> in the sidebar.
+1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="quotas" /> in the sidebar.
 1. Click **Add quota**.
 1. Enter the **Client ID** or **User**.
 1. Set one or more quota values:
@@ -88,7 +88,7 @@ name.
 
 1. Access the [Aiven Console](https://console.aiven.io/) and open your Aiven for Apache
    Kafka® service.
-1. Click <ConsoleLabel name="quotas" />.
+1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="quotas" />.
 
 The page lists all configured quotas.
 
@@ -123,7 +123,7 @@ name.
 
 1. Access the [Aiven Console](https://console.aiven.io/) and open your Aiven for Apache
    Kafka® service.
-1. Click <ConsoleLabel name="quotas" />.
+1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="quotas" />.
 1. Find the quota to update.
 1. Click <ConsoleLabel name="actions" /> > **Update**.
 1. Update the quota values.
@@ -157,7 +157,7 @@ endpoint with the updated values to overwrite the existing quota.
 
 1. Access the [Aiven Console](https://console.aiven.io/) and open your Aiven for Apache
    Kafka® service.
-1. Click <ConsoleLabel name="quotas" />.
+1. Click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="quotas" />.
 1. Find the quota to delete.
 1. Click <ConsoleLabel name="actions" /> > **Delete**.
 1. Click **Delete quota** to confirm.

--- a/docs/products/kafka/howto/prevent-full-disks.md
+++ b/docs/products/kafka/howto/prevent-full-disks.md
@@ -79,7 +79,7 @@ Free up disk space by deleting topics:
 
 1. In the [Aiven Console](https://console.aiven.io/), select your
    project and choose your Aiven for Apache Kafka® service.
-1. On the sidebar, click <ConsoleLabel name="topics" />.
+1. On the sidebar, click <ConsoleLabel name="manage stream" /> > **Topics**.
 1. To delete an existing topic, click the topic to remove.
 
    - In the **Topic info** screen, click **Delete** and confirm the deletion.

--- a/docs/products/kafka/howto/renew-ssl-certs.md
+++ b/docs/products/kafka/howto/renew-ssl-certs.md
@@ -24,7 +24,7 @@ To download the new certificate,
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka service.
-1. Click **Users** in the sidebar.
+1. Click **Access & Control** > **Users** in the sidebar.
 1. Select the required user and click **Show access key** and **Show access cert** to
    download the new certificate.
 

--- a/docs/products/kafka/howto/request-access-topic.md
+++ b/docs/products/kafka/howto/request-access-topic.md
@@ -23,7 +23,8 @@ You can view the service user and ACLs in the following locations in the
 [Aiven Console](https://console.aiven.io/):
 
 - Select your **Aiven for Apache Kafka** service. In the sidebar,
-  click <ConsoleLabel name="acl" /> or <ConsoleLabel name="serviceusers" />.
+  click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="acl" /> or
+  <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="serviceusers" />.
 - Click **Tools** > **Apache Kafka governance operations**. In the sidebar,
   click <ConsoleLabel name="streamingcatalog" /> > **Access**.
 
@@ -180,7 +181,8 @@ service user.
 For security reasons, access certificates and access keys are shown only once to limit
 exposure and prevent unauthorized access. To access credentials later or perform tasks
 like resetting credentials, go to the
-**Aiven for Apache Kafka** service page > <ConsoleLabel name="serviceusers" />.
+**Aiven for Apache Kafka** service page > <ConsoleLabel name="Access & Control" /> >
+<ConsoleLabel name="serviceusers" />.
 For more information, see [Manage service users](/docs/products/kafka/howto/add-manage-service-users#manage-users).
 
 This approach:

--- a/docs/products/kafka/howto/request-access-topic.md
+++ b/docs/products/kafka/howto/request-access-topic.md
@@ -23,8 +23,8 @@ You can view the service user and ACLs in the following locations in the
 [Aiven Console](https://console.aiven.io/):
 
 - Select your **Aiven for Apache Kafka** service. In the sidebar,
-  click <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="acl" /> or
-  <ConsoleLabel name="Access & Control" /> > <ConsoleLabel name="serviceusers" />.
+  click <ConsoleLabel name="Access & Control" /> > **ACL** or
+  <ConsoleLabel name="Access & Control" /> > **Users**.
 - Click **Tools** > **Apache Kafka governance operations**. In the sidebar,
   click <ConsoleLabel name="streamingcatalog" /> > **Access**.
 

--- a/docs/products/kafka/howto/view-kafka-storage-in-console.md
+++ b/docs/products/kafka/howto/view-kafka-storage-in-console.md
@@ -9,8 +9,8 @@ import {ConsoleIcon} from "@site/src/components/ConsoleIcons"
 Use the storage overview page to review storage usage, billing, and retention settings for your Aiven for Apache Kafka® service.
 
 In the Aiven Console, storage is labeled differently based on the service type.
-Classic Kafka service show **Tiered storage**, which can be enabled and configured.
-Inkless Kafka service show **Storage**, reflecting that object storage is always part of
+Classic Kafka services show **Tiered storage**, which can be enabled and configured.
+Inkless Kafka services show **Storage**, reflecting that object storage is always part of
 the data path.
 
 ## Prerequisite
@@ -19,18 +19,22 @@ the data path.
 - For Classic Kafka clusters, tiered storage enabled. For details, see
   [Enable tiered storage](/docs/products/kafka/howto/enable-kafka-tiered-storage).
 
-## Access tiered storage overview page
+## Access the storage overview page
 
-1. In the [Aiven Console](https://console.aiven.io/), select your project and your Aiven for Apache Kafka service.
-1. Click <ConsoleLabel name="Tiered storage" />.
+1. In the [Aiven Console](https://console.aiven.io/), select your project and your
+   Aiven for Apache Kafka service.
+1. In the sidebar, click:
+   - For Classic Kafka services: <ConsoleLabel name="observe" /> > **Tiered storage**
+   - For Inkless Kafka services: <ConsoleLabel name="observe" /> > **Storage**
 
    For Classic Kafka clusters:
 
-  - If tiered storage is not enabled for the service, the option to enable it is shown.
-  - If tiered storage is enabled but not configured for any topics, the option to enable it
-    for topics is shown. For details, see [Enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage).
+   - If tiered storage is not enabled for the service, the option to enable it is shown.
+   - If tiered storage is enabled but not configured for any topics, the option to
+     enable it for topics is shown. For details, see
+     [Enable and configure tiered storage for topics](/docs/products/kafka/howto/configure-topic-tiered-storage).
 
-1. Once configured, you can view an overview of tiered storage and its details.
+1. Once configured, you can view storage usage and settings.
 
 ## Key insights
 
@@ -39,7 +43,6 @@ View essential metrics and details related to tiered storage:
 - **Current billing expenses in USD:** Your tiered storage costs, calculated at hourly rates
 - **Forecasted month cost in USD:** Your upcoming monthly costs based on current usage
 - **Remote tier usage in bytes:** The volume of data that has been tiered
-- **Storage overview:** An overview of how topics use [remote storage](/docs/products/kafka/howto/view-kafka-storage-in-console#remote-storage-overview)
 
 ## Storage settings and retention
 

--- a/docs/products/kafka/kafka-connect/get-started.md
+++ b/docs/products/kafka/kafka-connect/get-started.md
@@ -48,7 +48,7 @@ integration from the Kafka service.
 
 1. Log in to the [Aiven Console](https://console.aiven.io) and open the
    **Aiven for Apache Kafka** service.
-1. In the left sidebar, click <ConsoleLabel name="Connectors"/>.
+1. In the left sidebar, click <ConsoleLabel name="manage stream" /> > **Connectors**.
    - For Classic Kafka services, click **Integrate standalone service**.
    - For Inkless Kafka services, click **Create Kafka Connect**.
 1. In the Kafka Connect integration dialog, do one of the following:

--- a/docs/products/kafka/kafka-connect/howto/amqp-source-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/amqp-source-connector.md
@@ -169,7 +169,7 @@ Parameters:
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -185,7 +185,7 @@ Parameters:
 1. In the **Connector configuration** text box, click <ConsoleLabel name="edit"/>.
 1. Paste the contents of your `amqp_source_connector.json` file.
 1. Click **Create connector**.
-1. Confirm the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Confirm the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 
 </TabItem>
 

--- a/docs/products/kafka/kafka-connect/howto/azure-blob-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/azure-blob-sink.md
@@ -68,7 +68,7 @@ in the [Aiven Azure Blob Storage sink connector GitHub repository](https://githu
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Kafka Connect is already enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -84,7 +84,7 @@ in the [Aiven Azure Blob Storage sink connector GitHub repository](https://githu
 1. Paste the configuration from your `azure_blob_sink_connector.json` file into the
    text box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 
 
 </TabItem>

--- a/docs/products/kafka/kafka-connect/howto/azure-blob-source.md
+++ b/docs/products/kafka/kafka-connect/howto/azure-blob-source.md
@@ -118,7 +118,7 @@ This file is auto-generated and may change when the connector is updated.
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -135,7 +135,7 @@ This file is auto-generated and may change when the connector is updated.
 1. Paste the configuration from your `azure_blob_source_config.json` file into the text
    box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 
 </TabItem>
 <TabItem value="cli" label="CLI">

--- a/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink.md
@@ -148,7 +148,7 @@ You can retrieve these values from the
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -164,7 +164,7 @@ You can retrieve these values from the
 1. Locate the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
 1. Paste the configuration from your `cassandra_sink.json` file into the text box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 1. Confirm that data appears in the Cassandra target table.
 
 </TabItem>

--- a/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-source.md
+++ b/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-source.md
@@ -135,7 +135,7 @@ When using Avro as the output format, set the following fields:
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -151,7 +151,7 @@ When using Avro as the output format, set the following fields:
 1. Locate the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
 1. Paste the configuration from your `cassandra_source.json` file into the text box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 1. Confirm that data appears in the target Kafka topic.
 
 </TabItem>

--- a/docs/products/kafka/kafka-connect/howto/clickhouse-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/clickhouse-sink-connector.md
@@ -53,7 +53,7 @@ Ensure all potential duplicates are processed before removing them:
 1. Verify the committed offset in Aiven for Apache Kafka:
    1. Access the [Aiven Console](https://console.aiven.io/) and select your
       Aiven for Apache Kafka service.
-   1. Click <ConsoleLabel name="topics" /> and select the topic used by the connector.
+   1. Click <ConsoleLabel name="manage stream" /> > **Topics** and select the topic used by the connector.
    1. Go to the **Consumer Group** tab and check the **Offset**  column for the
       committed offset.
 
@@ -125,7 +125,7 @@ For more configuration options, see the
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is already enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -140,7 +140,7 @@ For more configuration options, see the
 1. Locate the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
 1. Paste the configuration from your `clickhouse_sink_connector.json` file into the text box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 
 </TabItem>
 <TabItem value="cli" label="Aiven CLI">

--- a/docs/products/kafka/kafka-connect/howto/couchbase-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/couchbase-sink.md
@@ -2,6 +2,7 @@
 title: Create a sink connector from Apache Kafka® to Couchbase
 sidebar_label: Couchbase sink connector
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 The [Couchbase](https://www.couchbase.com/) sink connector pushes Apache Kafka® data to the NoSQL database.
 
@@ -83,7 +84,7 @@ To create an Apache Kafka Connect connector:
     the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
     service where the connector needs to be defined.
 
-2.  Select **Connectors** from the left sidebar.
+2.  Select <ConsoleLabel name="manage stream" /> > **Connectors** from the left sidebar.
 
 3.  Select **Create New Connector**
 
@@ -111,7 +112,7 @@ To create an Apache Kafka Connect connector:
 8.  After all the settings are correctly configured, select **Create
     connector**.
 
-9.  Verify the connector status under the **Connectors** screen.
+9.  Verify the connector status under <ConsoleLabel name="manage stream" /> > **Connectors**.
 
 10. Verify the presence of the data in the target Couchbase bucket.
 

--- a/docs/products/kafka/kafka-connect/howto/couchbase-source.md
+++ b/docs/products/kafka/kafka-connect/howto/couchbase-source.md
@@ -2,6 +2,7 @@
 title: Create a source connector from Couchbase to Apache Kafka®
 sidebar_label: Couchbase source connector
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 The [Couchbase](https://www.couchbase.com/) source connector pushes data
 from the NoSQL database, to Apache Kafka® where it can be transformed
@@ -106,7 +107,7 @@ To create a Kafka Connect connector:
     the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
     service where the connector needs to be defined.
 
-2.  Select **Connectors** from the left sidebar.
+2.  Select <ConsoleLabel name="manage stream" /> > **Connectors** from the left sidebar.
 
 3.  Select **Create New Connector**, it is enabled only for
     services
@@ -139,7 +140,7 @@ To create a Kafka Connect connector:
     enable the `kafka.auto_create_topics_enable` advanced parameter.
     :::
 
-9.  Verify the connector status under the **Connectors** tab
+9.  Verify the connector status under <ConsoleLabel name="manage stream" /> > **Connectors**
 
 10. Verify the presence of the data in the target Apache Kafka topic
     coming from the MongoDB dataset. The topic name is equal to the

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.md
@@ -2,6 +2,7 @@
 title: Create a Debezium source connector from MongoDB to Apache Kafka®
 sidebar_label: Debezium MongoDB source connector
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 Track and write MongoDB database changes to an Apache Kafka® topic in a standard format with the Debezium source connector, enabling transformation and access by multiple consumers using a MongoDB replica set or sharded cluster.
 
@@ -118,7 +119,7 @@ To create a Kafka Connect connector:
 1.  Select the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service
     to define the connector.
 
-1.  Select **Connectors** from the sidebar.
+1.  Select <ConsoleLabel name="manage stream" /> > **Connectors** from the sidebar.
 
 1.  Select **Create New Connector**, which is available only for
     services [that have Apache Kafka Connect enabled](enable-connect).
@@ -151,7 +152,7 @@ To create a Kafka Connect connector:
      See [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically).
    :::
 
-1. Verify the connector status under the **Connectors** screen.
+1. Verify the connector status under <ConsoleLabel name="manage stream" /> > **Connectors**.
 
 1. Verify the presence of the data in the target Apache Kafka topic
    coming from the MySQL dataset. The topic name is equal to

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mysql.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mysql.md
@@ -2,6 +2,7 @@
 title: Create a Debezium source connector from MySQL to Apache Kafka®
 sidebar_label: Debezium MySQL source connector
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -243,7 +244,7 @@ To create a Kafka Connect connector:
 1.  Select the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service
     to define the connector.
 
-1. Select **Connectors** from the sidebar.
+1. Select <ConsoleLabel name="manage stream" /> > **Connectors** from the sidebar.
 
 1. Select **Create New Connector**, which is available only for
    services [that have Apache Kafka Connect enabled](enable-connect).
@@ -276,7 +277,7 @@ To create a Kafka Connect connector:
 
    :::
 
-1. Verify the connector status under the **Connectors** screen.
+1. Verify the connector status under <ConsoleLabel name="manage stream" /> > **Connectors**.
 
 1. Verify the presence of the data in the target Apache Kafka topic
    coming from the MySQL dataset. The topic name is equal to

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-oracle.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-oracle.md
@@ -187,14 +187,14 @@ and truststore passwords set to `password`.
 
 1. Log in to the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector**.
 1. In the source connectors list, select **Debezium - Oracle**, and click **Get started**.
 1. On the **Oracle Debezium Source Connector** page, open the **Common** tab.
 1. Locate the **Connector configuration** field and click <ConsoleLabel name="edit"/>.
 1. Paste the contents of `oracle_debezium_source_connector.json`.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 
 </TabItem>
 <TabItem value="cli" label="CLI">

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.md
@@ -2,6 +2,8 @@
 title: Create a Debezium source connector from SQL Server to Apache Kafka® with CDC
 sidebar_label: Debezium SQL Server CDC source connector
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
+
 The SQL Server Debezium source connector uses the [change data capture (CDC) ](https://learn.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-data-capture-sql-server?view=sql-server-2017) feature to extract database changes from designated tables and write them to Apache Kafka® topic in a standard format for multiple consumers to read and transform.
 
 import Note from "@site/static/includes/debezium-breakingchange.md"
@@ -240,7 +242,7 @@ To create a Kafka Connect connector:
 1. Select the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service
    to define the connector.
 
-1. Select **Connectors** from the  sidebar.
+1. Select <ConsoleLabel name="manage stream" /> > **Connectors** from the sidebar.
 
 1. Select **Create New Connector**, which is available only for
    services [that have Apache Kafka Connect enabled](enable-connect).
@@ -271,7 +273,7 @@ To create a Kafka Connect connector:
    - Enable the `Kafka topic auto-creation` feature.
      See [Enable automatic topic creation with Aiven CLI](/docs/products/kafka/howto/create-topics-automatically).
 
-1.  Verify the connector status under the **Connectors** screen.
+1.  Verify the connector status under <ConsoleLabel name="manage stream" /> > **Connectors**.
 
 1. Verify the presence of the data in the target Apache Kafka topic
    coming from the MySQL dataset. The topic name is equal to

--- a/docs/products/kafka/kafka-connect/howto/elasticsearch-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/elasticsearch-sink.md
@@ -3,6 +3,7 @@ title: Create a sink connector from Apache Kafka® to Elasticsearch
 sidebar_label: Elasticsearch sink connector
 
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 import RelatedPages from "@site/src/components/RelatedPages";
 
 The Elasticsearch sink connector enables you to move data from an Aiven for Apache Kafka® cluster to an Elasticsearch instance for further processing and analysis.
@@ -134,7 +135,7 @@ To create a Kafka Connect connector:
     the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
     service where the connector needs to be defined.
 
-2.  Select **Connectors** from the left sidebar.
+2.  Select <ConsoleLabel name="manage stream" /> > **Connectors** from the left sidebar.
 
 3.  Select **Create New Connector**, it is enabled only for
     services
@@ -160,7 +161,7 @@ To create a Kafka Connect connector:
 8.  After all the settings are correctly configured, select **Create
     connector**.
 
-9.  Verify the connector status under the **Connectors** screen.
+9.  Verify the connector status under <ConsoleLabel name="manage stream" /> > **Connectors**.
 
 10. Verify the presence of the data in the target Elasticsearch service,
     the index name is equal to the Apache Kafka topic name.

--- a/docs/products/kafka/kafka-connect/howto/enable-automatic-restart.md
+++ b/docs/products/kafka/kafka-connect/howto/enable-automatic-restart.md
@@ -1,42 +1,36 @@
 ---
-title: Enable Apache Kafka® Connect connectors auto restart on failures
+title: Enable automatic restart for Apache Kafka® Connect connectors
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-If you experience an Apache Kafka® Connect connector failure, restarting automatically the task is generally not recommended.
-Perform a proper
-investigation on the problem's cause before attempting the restart to
-avoid experiencing similar problems in the future. However, sometimes a
-task can fail due to a rare problem like the dedicated node going out of
-memory due to a huge surge of data; in such cases, the automatic task
-restart usually solves the issue.
+Automatic restart can help recover a connector task after a rare transient failure, such as an out-of-memory error caused by a sudden data surge.
+
+Before you enable automatic restart, investigate the cause of the connector failure.
+Automatic restart is not recommended for recurring failures because the connector might
+continue to fail until the underlying issue is fixed.
 
 :::note
-We observed cases when the Debezium source connector for PostgreSQL®
-stopped working after the PostgreSQL maintenance update, due to
-PostgreSQL inability to create replication slots before failover. In
-such cases the connector automatic restart can be a solution to
-avoid the problem.
+In some cases, the Debezium source connector for PostgreSQL® can stop after PostgreSQL
+maintenance if PostgreSQL cannot create replication slots before failover. Automatic
+restart can help recover the connector in this scenario.
 :::
 
-## Enable connector automatic restart with Aiven console
+## Enable automatic restart in the Aiven Console
 
-Aiven provides an option to enable automatic connector restart in case
-of edge situations. All our connectors support this option.
+All Aiven-managed Apache Kafka Connect connectors support automatic restart.
 
-For example, you can update of an existing Debezium-PostgreSQL connector:
+To enable automatic restart for an existing connector:
 
-1.  In the [Aiven console](https://console.aiven.io/), select the Aiven
-    for Apache Kafka or Aiven for Apache Kafka Connect service pages
-    where the connector is defined.
-1.  Select **Connectors** from the left sidebar and select the connector
-    to be updated.
-1.  Select the **Aiven** tab on the connectors page.
-1.  Set the **Automatic restart** option to `True`
+1. In the [Aiven Console](https://console.aiven.io/), select the Aiven for Apache Kafka
+   or Aiven for Apache Kafka Connect service where the connector is defined.
+1. Select <ConsoleLabel name="manage stream" /> > **Connectors** from the sidebar.
+1. Open the connector to update.
+1. Select the **Aiven** tab.
+1. For **Automatic restart**, select **True**.
 
-Once you have enabled automatic restart, the connector will be restarted
-automatically whenever a failure is detected.
+After you enable automatic restart, the connector restarts automatically when a failure
+is detected.
 
 :::warning
-Enabling this feature will restart the entire connector, not just the
-failed tasks.
+Automatic restart restarts the entire connector, not only the failed tasks.
 :::

--- a/docs/products/kafka/kafka-connect/howto/enable-connect.md
+++ b/docs/products/kafka/kafka-connect/howto/enable-connect.md
@@ -19,4 +19,4 @@ To enable Apache Kafka Connect on Aiven for Apache Kafka nodes:
     <ConsoleLabel name="Actions"/> > **Enable Connect**.
 
 You can view information about the Apache Kafka Connect service on the
-**Connectors** page.
+<ConsoleLabel name="manage stream" /> > **Connectors** page.

--- a/docs/products/kafka/kafka-connect/howto/gcp-bigquery-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-bigquery-sink.md
@@ -234,14 +234,14 @@ new nullable subfield in the existing metadata `RECORD` schema.
 
 1. Go to the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka® or Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** (enable Kafka Connect if required).
 1. Select **Google BigQuery Sink** from the list.
 1. On the **Common** tab, click <ConsoleLabel name="edit"/> in the
   **Connector configuration** box.
 1. Paste the contents of `bigquery_sink.json`. Replace placeholders with actual values.
 1. Click **Apply**, then **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 1. Check that data appears in the BigQuery dataset. By default, table names match topic
    names. Use the Kafka Connect `RegexRouter` transformation to rename tables if required.
 

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-sink.md
@@ -3,6 +3,7 @@ title: Create a sink connector from Apache Kafka® to Google Pub/Sub Lite
 sidebar_label: Google Pub/Sub Lite sink connector
 
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 The [Google Pub/Sub Lite sink
 connector](https://github.com/googleapis/java-pubsub-group-kafka-connector)
@@ -136,7 +137,7 @@ To create an Apache Kafka Connect connector:
     the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
     service where the connector needs to be defined.
 
-2.  Select **Connectors** from the left sidebar.
+2.  Select <ConsoleLabel name="manage stream" /> > **Connectors** from the left sidebar.
 
 3.  Select **Create New Connector**, it is enabled only for
     services
@@ -157,7 +158,7 @@ To create an Apache Kafka Connect connector:
 8.  After all the settings are correctly configured, select **Create
     connector**.
 
-9.  Verify the connector status under the **Connectors** screen.
+9.  Verify the connector status under <ConsoleLabel name="manage stream" /> > **Connectors**.
 
 10. Verify the presence of the data in the target Pub/Sub Lite topic,
     the table name is equal to the Apache Kafka topic name.

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-source.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-source.md
@@ -2,6 +2,7 @@
 title: Create a Google Pub/Sub Lite source connector to Apache Kafka®
 sidebar_label: Google Pub/Sub Lite source connector
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 The [Google Pub/Sub Lite source
 connector](https://github.com/googleapis/java-pubsub-group-kafka-connector/)
@@ -137,7 +138,7 @@ To create a Kafka Connect connector:
     the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
     service where the connector needs to be defined.
 
-2.  Select **Connectors** from the left sidebar.
+2.  Select <ConsoleLabel name="manage stream" /> > **Connectors** from the left sidebar.
 
 3.  Select **Create New Connector**, it is enabled only for
     services
@@ -163,7 +164,7 @@ To create a Kafka Connect connector:
 8.  After all the settings are correctly configured, select **Create
     connector**.
 
-9.  Verify the connector status under the **Connectors** screen.
+9.  Verify the connector status under <ConsoleLabel name="manage stream" /> > **Connectors**.
 
 10. Verify the presence of the data in the target Pub/Sub dataset, the
     table name is equal to the Apache Kafka topic name. To

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-sink.md
@@ -2,6 +2,7 @@
 title: Create a sink connector from Apache Kafka® to Google Pub/Sub
 sidebar_label: Google Pub/Sub sink connector
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 The [Google Pub/Sub sink
 connector](https://github.com/googleapis/java-pubsub-group-kafka-connector)
@@ -156,7 +157,7 @@ To create an Apache Kafka Connect connector:
     the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
     service where the connector needs to be defined.
 
-2.  Select **Connectors** from the left sidebar.
+2.  Select <ConsoleLabel name="manage stream" /> > **Connectors** from the left sidebar.
 
 3.  Select **Create New Connector**, it is enabled only for
     services
@@ -182,7 +183,7 @@ To create an Apache Kafka Connect connector:
 8.  After all the settings are correctly configured, select **Create
     connector**.
 
-9.  Verify the connector status under the **Connectors** screen.
+9.  Verify the connector status under <ConsoleLabel name="manage stream" /> > **Connectors**.
 
 10. Verify the presence of the data in the target Pub/Sub dataset, the
     table name is equal to the Apache Kafka topic name.

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-source.md
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-source.md
@@ -137,7 +137,7 @@ For a full list of parameters, see the
 
 1. Log in to the [Aiven Console](https://console.aiven.io/) and select the Aiven for
    Apache Kafka® or Aiven for Apache Kafka Connect® service.
-1. Click  <ConsoleLabel name="connectors"/> from the left sidebar.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors** from the left sidebar.
 1. Click **Create New Connector**. If connectors are not enabled,
    click **Enable connector on this service**.
 1. Click **See all connectors** to view all available options.
@@ -154,7 +154,7 @@ For a full list of parameters, see the
    :::
 
 1. After verifying the settings, click **Create connector**.
-1. Check the connector status on the **Connectors** screen.
+1. Check the connector status on <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Verify that data appears in the target Pub/Sub dataset. By default, the table name is
    derived from the Apache Kafka topic name. To change the table name, use the Kafka
    Connect `RegexRouter` transformation. This transformation allows you to rename

--- a/docs/products/kafka/kafka-connect/howto/gcs-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/gcs-sink.md
@@ -124,7 +124,7 @@ You can control file naming and output formats using dedicated parameters. For d
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service.
-1. In the sidebar, click <ConsoleLabel name="Connectors"/>.
+1. In the sidebar, click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is already enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -146,7 +146,7 @@ You can control file naming and output formats using dedicated parameters. For d
    :::
 
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 1. Confirm that data from the Apache Kafka topics appears in the target bucket.
 
 </TabItem>

--- a/docs/products/kafka/kafka-connect/howto/http-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/http-sink.md
@@ -2,6 +2,7 @@
 title: Create a sink connector from Apache Kafka® via HTTP
 sidebar_label: HTTP sink connector
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 The HTTP sink connector enables you to move data from an Aiven for Apache Kafka® cluster to a remote server via HTTP.
 
@@ -109,7 +110,7 @@ To create a Kafka Connect connector:
     the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
     service where the connector needs to be defined.
 
-2.  Select **Connectors** from the left sidebar.
+2.  Select <ConsoleLabel name="manage stream" /> > **Connectors** from the left sidebar.
 
 3.  Select **Create New Connector**, it is enabled only for
     services
@@ -135,7 +136,7 @@ To create a Kafka Connect connector:
 8.  After all the settings are correctly configured, select **Create
     connector**.
 
-9.  Verify the connector status under the **Connectors** screen.
+9.  Verify the connector status under <ConsoleLabel name="manage stream" /> > **Connectors**.
 
 10. Verify the flow of HTTP POST calls in the target server.
 

--- a/docs/products/kafka/kafka-connect/howto/ibm-mq-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/ibm-mq-sink-connector.md
@@ -87,7 +87,7 @@ Parameters:
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is already enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -102,7 +102,7 @@ Parameters:
 1. Locate the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
 1. Paste the configuration from your `ibm_mq_sink_connector.json` file into the text box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 
 Ensure that data from the Apache Kafka topics is successfully transferred to the
 target IBM MQ queue.

--- a/docs/products/kafka/kafka-connect/howto/influx-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/influx-sink.md
@@ -116,7 +116,7 @@ You can get these values from the
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -132,7 +132,7 @@ You can get these values from the
 1. Locate the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
 1. Paste the configuration from your `influxdb_sink.json` file into the text box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 1. Confirm that data is written to the InfluxDB target database.
 
 </TabItem>

--- a/docs/products/kafka/kafka-connect/howto/jdbc-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/jdbc-sink.md
@@ -2,6 +2,7 @@
 title: Create a JDBC sink connector from Apache Kafka® to another database
 sidebar_label: JDBC sink connector
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 import RelatedPages from "@site/src/components/RelatedPages";
 
 The JDBC (Java Database Connectivity) sink connector enables you to move data from an Aiven for Apache Kafka® cluster to any relational database offering JDBC drivers like PostgreSQL® or MySQL.
@@ -164,7 +165,7 @@ To create a Kafka Connect connector:
 1. Log in to the [Aiven Console](https://console.aiven.io/) and select
    the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
    service where the connector needs to be defined.
-1. Click **Connectors** from the sidebar.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors** from the sidebar.
 1. Click **Create connector** to start setting up a new connector. This option is visible
    only if [Kafka Connect](enable-connect) is enabled for your service.
 1. On the **Select connector** page, locate **JDBC Sink** and click **Get started**.
@@ -181,7 +182,8 @@ To create a Kafka Connect connector:
    :::
 
 1. Once you've entered all the required settings, click **Create connector**.
-1. Verify the connector status in the **Connectors** page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> >
+   **Connectors** page.
 1. Confirm that the data has appeared in the target database service.
    The table name should match the Apache Kafka topic name.
 

--- a/docs/products/kafka/kafka-connect/howto/manage-connector-versions.md
+++ b/docs/products/kafka/kafka-connect/howto/manage-connector-versions.md
@@ -112,10 +112,10 @@ supported and can be set if needed. Use one of the following methods:
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 
 Connectors that support multiple versions display **2 versions** next to their names on
-the **Connectors** page.
+the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 
 :::note
 When setting up a new connector, a default version is selected. To change it, go to the

--- a/docs/products/kafka/kafka-connect/howto/mongodb-poll-source-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/mongodb-poll-source-connector.md
@@ -89,7 +89,7 @@ for the full list of available options.
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Kafka Connect is enabled on the service.
    If not, enable Kafka Connect under **Service settings** > **Actions** >
    **Enable Kafka Connect**.
@@ -99,7 +99,7 @@ for the full list of available options.
    click <ConsoleLabel name="edit"/>.
 1. Paste the configuration from your `mongodb_source_config.json` file into the text box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 1. Verify that data appears in the target Kafka topic.
    By default, the connector writes to a topic named after the MongoDB database and
    collection, for example, `districtA.students`.
@@ -190,7 +190,7 @@ topic `districtA.students` every second, based on the polling interval (`poll.aw
 
 After you create the connector:
 
-1. Check the connector status on the **Connectors** page in the Aiven Console.
+1. Check the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page in the Aiven Console.
 1. Confirm that the Kafka topic `districtA.students` exists in your service.
 1. Consume messages from the topic to verify that data from MongoDB is streaming
    correctly.

--- a/docs/products/kafka/kafka-connect/howto/mongodb-sink-lenses.md
+++ b/docs/products/kafka/kafka-connect/howto/mongodb-sink-lenses.md
@@ -124,7 +124,7 @@ see the
 
 1. Go to the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Kafka Connect is enabled on the service.
    If not, enable it under **Service settings** > **Actions** > **Enable Kafka Connect**.
 1. From the list of sink connectors, select **Stream Reactor MongoDB Sink**, and
@@ -133,7 +133,7 @@ see the
    click <ConsoleLabel name="edit"/>.
 1. Paste the configuration from your `mongodb_sink.json` file.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 1. Confirm that data appears in the target MongoDB collection.
    The collection name corresponds to the KCQL mapping.
 

--- a/docs/products/kafka/kafka-connect/howto/mongodb-sink-mongo.md
+++ b/docs/products/kafka/kafka-connect/howto/mongodb-sink-mongo.md
@@ -120,7 +120,7 @@ topic management, refer to the [MongoDB Kafka connector documentation](https://w
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Kafka Connect is enabled on the service.
    If not, enable it under **Service settings** > **Actions** > **Enable Kafka Connect**.
 1. From the list of sink connectors, select **MongoDB sink connector**, and click **Get started**.
@@ -128,7 +128,7 @@ topic management, refer to the [MongoDB Kafka connector documentation](https://w
    <ConsoleLabel name="edit"/>.
 1. Paste the configuration from your `mongodb_sink_config.json` file into the text box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 1. Verify that data from the Kafka topic appears in MongoDB.
 
 </TabItem>
@@ -191,7 +191,7 @@ named `students` in the MongoDB database `school`.
 
 After creating the connector:
 
-1. Check the connector status on the **Connectors** page in the Aiven Console.
+1. Check the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page in the Aiven Console.
 1. Verify that a `students` collection exists in the MongoDB database.
 1. Confirm that records from the Kafka topic are written to the collection.
 

--- a/docs/products/kafka/kafka-connect/howto/mqtt-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/mqtt-sink-connector.md
@@ -88,7 +88,7 @@ For a full list of supported parameters, see the
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -103,7 +103,7 @@ For a full list of supported parameters, see the
 1. Locate the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
 1. Paste the configuration from your `mqtt_sink.json` file into the text box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 1. Confirm that data is delivered to the MQTT topic defined in the `KCQL_STATEMENT`.
 
 </TabItem>

--- a/docs/products/kafka/kafka-connect/howto/mqtt-source-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/mqtt-source-connector.md
@@ -82,7 +82,7 @@ Parameters:
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector**.
    If Kafka Connect is not yet enabled, click **Enable connector on this service**.
 
@@ -97,7 +97,7 @@ Parameters:
    click <ConsoleLabel name="edit"/>.
 1. Paste the contents of your `mqtt_source.json` file.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 
 </TabItem>
 <TabItem value="cli" label="CLI">

--- a/docs/products/kafka/kafka-connect/howto/opensearch-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/opensearch-sink.md
@@ -2,6 +2,7 @@
 title: Create a sink connector from Apache Kafka® to OpenSearch®
 sidebar_label: OpenSearch® sink connector
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 The OpenSearch sink connector enables you to move data from an Aiven for Apache Kafka® cluster to an OpenSearch® instance for further processing and analysis.
 
@@ -141,7 +142,7 @@ To create a Kafka Connect connector:
     the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
     service where the connector needs to be defined.
 
-2.  Select **Connectors** from the left sidebar.
+2.  Select <ConsoleLabel name="manage stream" /> > **Connectors** from the left sidebar.
 
 3.  Select **Create New Connector**, it is enabled only for
     services
@@ -167,7 +168,7 @@ To create a Kafka Connect connector:
 8.  After all the settings are correctly configured, select **Create
     connector**.
 
-9.  Verify the connector status under the **Connectors** screen.
+9.  Verify the connector status under <ConsoleLabel name="manage stream" /> > **Connectors**.
 
 10. Verify the presence of the data in the target OpenSearch service,
     the index name is equal to the Apache Kafka topic name.

--- a/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink.md
@@ -119,7 +119,7 @@ You can retrieve these values from the
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -134,7 +134,7 @@ You can retrieve these values from the
 1. Locate the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
 1. Paste the configuration from your `redis_sink.json` file into the text box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 1. Confirm that data is written to the Redis target database.
 </TabItem>
 <TabItem value="cli" label="Aiven CLI">

--- a/docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven.md
+++ b/docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven.md
@@ -68,7 +68,7 @@ For additional parameters (for example, file naming or output format), see
 
 1. Open the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka® or Apache Kafka Connect® service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector**.
    If connectors are not enabled, click **Enable connectors on this service**.
 1. Search for **Amazon S3 sink** and click **Get started**.

--- a/docs/products/kafka/kafka-connect/howto/s3-sink-connector-confluent.md
+++ b/docs/products/kafka/kafka-connect/howto/s3-sink-connector-confluent.md
@@ -65,14 +65,14 @@ For all options, see the
 
 1. Open the [Aiven Console](https://console.aiven.io/).
 1. Select your Kafka or Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector**.
 1. Search for **Amazon S3 sink (Confluent)** and click **Get started**.
 1. On the connector page, go to the **Common** tab.
 1. Click <ConsoleLabel name="edit"/> in **Connector configuration**.
 1. Paste your `s3_sink_confluent.json` contents.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 
 </TabItem>
 <TabItem value="cli" label="Aiven CLI">

--- a/docs/products/kafka/kafka-connect/howto/s3-source-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/s3-source-connector.md
@@ -178,7 +178,7 @@ Parameters:
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -194,7 +194,7 @@ Parameters:
 1. Locate the **Connector configuration** text box and click <ConsoleLabel name="edit"/>.
 1. Paste the configuration from your `s3_source_connector.json` file into the text box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 
 </TabItem>
 <TabItem value="cli" label="Aiven CLI">

--- a/docs/products/kafka/kafka-connect/howto/salesforce-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/salesforce-sink-connector.md
@@ -110,7 +110,7 @@ For all available configuration options, see the
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is already enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -126,7 +126,7 @@ For all available configuration options, see the
 1. Paste the configuration from your `salesforce_sink_connector.json` file into the
    text box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 
 </TabItem>
   <TabItem value="cli" label="Aiven CLI">

--- a/docs/products/kafka/kafka-connect/howto/salesforce-source-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/salesforce-source-connector.md
@@ -211,7 +211,7 @@ services use [Karapace](/docs/products/kafka/karapace) as the schema registry.
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -228,7 +228,7 @@ services use [Karapace](/docs/products/kafka/karapace) as the schema registry.
 1. Paste the configuration from your `salesforce_source_connector.json` file into the
    text box.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 
 </TabItem>
 <TabItem value="cli" label="Aiven CLI">

--- a/docs/products/kafka/kafka-connect/howto/snowflake-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/snowflake-sink.md
@@ -204,7 +204,7 @@ Snowflake connection parameters:
 
 1. Access the [Aiven Console](https://console.aiven.io/).
 1. Select your Aiven for Apache Kafka or Aiven for Apache Kafka Connect service.
-1. Click <ConsoleLabel name="Connectors"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 1. Click **Create connector** if Apache Kafka Connect is already enabled on the service.
    If not, click **Enable connector on this service**.
 
@@ -220,7 +220,7 @@ Snowflake connection parameters:
    Replace all placeholders with actual values.
 1. Click **Apply**.
 1. Click **Create connector**.
-1. Verify the connector status on the <ConsoleLabel name="Connectors"/> page.
+1. Verify the connector status on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 1. Confirm that data from the Apache Kafka topics appears in the target Snowflake database.
 
 </TabItem>

--- a/docs/products/kafka/kafka-connect/howto/splunk-sink.md
+++ b/docs/products/kafka/kafka-connect/howto/splunk-sink.md
@@ -2,6 +2,7 @@
 title: Create a sink connector from Apache Kafka® to Splunk
 sidebar_label: Splunk sink connector
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 The [Splunk](https://www.splunk.com/) sink connector enables you to move
 data from an Aiven for Apache Kafka® cluster to a remote Splunk server
@@ -101,7 +102,7 @@ To create an Apache Kafka Connect connector:
     the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect®
     service where the connector needs to be defined.
 
-2.  Select **Connectors** from the left sidebar.
+2.  Select <ConsoleLabel name="manage stream" /> > **Connectors** from the left sidebar.
 
 3.  Select **Create New Connector**, it is enabled only for
     services
@@ -127,7 +128,7 @@ To create an Apache Kafka Connect connector:
 8.  After all the settings are correctly configured, select **Create
     connector**.
 
-9.  Verify the connector status under the **Connectors** screen.
+9.  Verify the connector status under <ConsoleLabel name="manage stream" /> > **Connectors**.
 
 10. Verify the data in the target Splunk instance.
 

--- a/docs/products/kafka/kafka-mirrormaker/concepts/replication-flow-topics-regex.md
+++ b/docs/products/kafka/kafka-mirrormaker/concepts/replication-flow-topics-regex.md
@@ -1,21 +1,21 @@
 ---
-title: Topics included in a replication flow
+title: Include or exclude topics in a replication flow
 ---
 
-When [defining a replication flow](/docs/products/kafka/kafka-mirrormaker/howto/setup-replication-flow), define which topics in the source Apache Kafka® cluster to include or exclude from the cross-cluster replica.
+When you [define a replication flow](/docs/products/kafka/kafka-mirrormaker/howto/setup-replication-flow), specify which topics in the source Apache Kafka® cluster to include or exclude from the cross-cluster replica.
 
-The **topics** parameter dictates which topics to include in the replica
-and can be provided as [list of regular expressions in Java
-format](https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern).
-The same is also valid for the **topics blacklist** parameter defining
-which topics to exclude.
+Use the **Topics** field to define the topics to include. You can enter a
+[list of regular expressions in Java format](https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern).
+If you leave **Topics** empty, MirrorMaker 2 uses `.*` and includes all topics.
 
-## Example: topic inclusion and exclusion regular expressions
+Use the **Topic blacklist** field to define the topics to exclude. To exclude
+internal topics, click **Internal topics**, which adds these patterns:
+`.*[\-\.]internal`, `.*\.replica`, and `__.*`.
 
-To define a replication flow including the topic
-`warehouse.operations` and any topic starting with `customer.`, but
-excluding the topic `customer.support` then the following regular
-expression can be used:
+## Example: Include and exclude topics
 
--   **Topics**: `customer\..*` and `warehouse\.operations`
--   **Topics Blacklist**: `customer\.support`
+To replicate the `warehouse.operations` topic and any topic that starts with
+`customer.`, but exclude the `customer.support` topic, use these values:
+
+- **Topics**: `customer\..*` and `warehouse\.operations`
+- **Topic blacklist**: `customer\.support`

--- a/docs/products/kafka/kafka-mirrormaker/get-started.md
+++ b/docs/products/kafka/kafka-mirrormaker/get-started.md
@@ -22,7 +22,7 @@ You can create the service from the Kafka service's integrations page.
 
 1. In the [Aiven Console](https://console.aiven.io), open your project.
 1. Open the Aiven for Apache Kafka® service to replicate.
-1. Click <ConsoleLabel name="integrations" />.
+1. Click <ConsoleLabel name="manage stream" /> > **Integrations**.
 1. Under **Aiven services**, select **Apache Kafka MirrorMaker**.
 1. Choose one of the following:
    - **Existing service** to connect to a MirrorMaker 2 service that is already running
@@ -43,7 +43,7 @@ You can create the service from the Kafka service's integrations page.
 1. Review the **Service summary** for the region, plan, and estimated price.
 1. Click **Create service**.
 
-The service status changes to **Rebuilding**.
+The service status changes to **Building**.
 When it changes to **Running**, the service is ready.
 
 ### Connect the Kafka service to MirrorMaker 2

--- a/docs/products/kafka/kafka-mirrormaker/howto/exactly-once-delivery.md
+++ b/docs/products/kafka/kafka-mirrormaker/howto/exactly-once-delivery.md
@@ -41,7 +41,7 @@ review and adjust these ACLs as needed to enable exactly-once delivery.
 
 1. In the [Aiven Console](https://console.aiven.io/), open your Aiven for Apache Kafka
    service with the Aiven for Apache Kafka MirrorMaker 2 integration.
-1. Click <ConsoleLabel name="integrations"/>.
+1. Click <ConsoleLabel name="manage stream" /> > **Integrations**.
 1. Click the Aiven for Apache Kafka MirrorMaker 2 integration.
 1. Click <ConsoleLabel name="replicationflow" /> in the sidebar.
    - To create a new flow, click **Create replication flow** .

--- a/docs/products/kafka/kafka-mirrormaker/howto/mm2-rack-awareness.md
+++ b/docs/products/kafka/kafka-mirrormaker/howto/mm2-rack-awareness.md
@@ -6,7 +6,6 @@ sidebar_label: Configure rack awareness
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import ConsoleLabel from "@site/src/components/ConsoleIcons"
-import ConsoleIcon from "@site/src/components/ConsoleIcons"
 import RelatedPages from "@site/src/components/RelatedPages";
 
 Configure rack awareness in Aiven for Apache Kafka® MirrorMaker 2 to reduce cross-availability zone (AZ) network traffic by directing MirrorMaker to read from local follower replicas instead of remote partition leaders.
@@ -60,7 +59,7 @@ node runs and prefers reading from in-sync follower replicas in the same availab
 zone. When disabled, MirrorMaker reads from partition leaders for that replication flow.
 
 1. In the [Aiven Console](https://console.aiven.io), open the MirrorMaker 2 service.
-1. Click **Replication flows**.
+1. Click <ConsoleLabel name="replicationflow" />.
 1. Create a replication flow or edit an existing one.
 1. Set **Follower fetching enabled** to on or off.
 1. Click **Create** or **Save**.

--- a/docs/products/kafka/kafka-mirrormaker/howto/remove-mirrormaker-prefix.md
+++ b/docs/products/kafka/kafka-mirrormaker/howto/remove-mirrormaker-prefix.md
@@ -4,38 +4,38 @@ title: Remove topic prefix when replicating with Apache Kafka® MirrorMaker 2
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-When using Apache Kafka® MirrorMaker 2 to replicate topics across Apache Kafka® clusters, the default target topic name is in the form
+When you use Apache Kafka® MirrorMaker 2 to replicate topics across Apache
+Kafka® clusters, the default target topic name uses this format:
 `<SOURCE_CLUSTER_ALIAS>.<TOPIC_NAME>`.
-For example, if the source Apache Kafka
-clusters alias is `src-kafka`, replicating the source topic named
-`orders` via Apache Kafka MirrorMaker 2 creates a target topic named
-`src-kafka.orders`.
+For example, if the source Apache Kafka cluster alias is `src-kafka`,
+replicating the `orders` source topic creates the `src-kafka.orders` target
+topic.
 
-For most use cases, the extra prefix is not an issue. However, you might
-be using a backup Apache Kafka cluster for Disaster Recovery. In this
-scenario, you want your consumers and producers to be able to switch
-with minimal downtime and without needing to modify the topic names in
-their configuration.
+For most use cases, the extra prefix is not an issue. If you use a backup
+Apache Kafka cluster for disaster recovery, you might need consumers and
+producers to switch clusters with minimal downtime and without changing topic
+names in their configuration.
 
 <Tabs groupId="group1">
 <TabItem value="console" label="Console" default>
-In the [Aiven console](https://console.aiven.io/), modify the flow details in the
-service page **Replication Flow** tab:
 
-Remove the topic prefix, you have to change the
-replication flow `replication_policy_class` parameter from the default
-`org.apache.kafka.connect.mirror.DefaultReplicationPolicy` value, which
-includes the source cluster alias in the target topic name to
-`org.apache.kafka.connect.mirror.IdentityReplicationPolicy`.
+1. Log in to the [Aiven Console](https://console.aiven.io/) and click the
+   Aiven for Apache Kafka MirrorMaker 2 service.
+1. Click <ConsoleLabel name="replicationflow" />.
+1. Open the replication flow to update.
+1. In **Replication policy class**, replace the default
+   `org.apache.kafka.connect.mirror.DefaultReplicationPolicy` value with
+   `org.apache.kafka.connect.mirror.IdentityReplicationPolicy`.
 
 </TabItem>
 <TabItem value="api" label="API">
 Replace the
-`<MIRRORMAKER_SERVICE_NAME>`, `<SOURCE_CLUSTER_ALIAS>` and
+`<MIRRORMAKER_SERVICE_NAME>`, `<SOURCE_CLUSTER_ALIAS>`, and
 `<TARGET_CLUSTER_ALIAS>` placeholders:
 
-```
+```bash
 avn MirrorMaker replication-flow update <MIRRORMAKER_SERVICE_NAME> \
     --source-cluster <SOURCE_CLUSTER_ALIAS>                         \
     --target-cluster <TARGET_CLUSTER_ALIAS>                         \
@@ -43,17 +43,17 @@ avn MirrorMaker replication-flow update <MIRRORMAKER_SERVICE_NAME> \
 ```
 
 To revert the policy and include the source cluster
-alias as topic prefix, execute the above command passing the
+alias as the topic prefix, run the command with the
 `org.apache.kafka.connect.mirror.DefaultReplicationPolicy` value.
 
 :::warning
 The `org.apache.kafka.connect.mirror.IdentityReplicationPolicy`
-replication policy **doesn't support active-active replication** as the
-topics keep the same name and offsets can not be accurately tracked.
+replication policy **does not support active-active replication** because the
+topics keep the same name and offsets cannot be accurately tracked.
 
-Creating the same replication flows between a source and a destination
-with `org.apache.kafka.connect.mirror.IdentityReplicationPolicy` policy
-creates an infinite loop.
+Do not create identical replication flows between a source and a destination
+with the `org.apache.kafka.connect.mirror.IdentityReplicationPolicy` policy.
+This configuration creates an infinite loop.
 
 For active-active, use the
 `org.apache.kafka.connect.mirror.DefaultReplicationPolicy`.

--- a/docs/products/kafka/kafka-mirrormaker/howto/setup-replication-flow.md
+++ b/docs/products/kafka/kafka-mirrormaker/howto/setup-replication-flow.md
@@ -1,41 +1,54 @@
 ---
 title: Set up an Apache Kafka® MirrorMaker 2 replication flow
 ---
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-Apache Kafka® MirrorMaker 2 **replication flows** enable the topics sync from a source Apache Kafka® cluster to a target Apache Kafka cluster deployed anywhere in the world.
-Replication flows can be defined against Aiven for Apache Kafka services or
+Apache Kafka® MirrorMaker 2 replication flows sync topics from a source
+Apache Kafka® cluster to a target Apache Kafka® cluster.
+You can define replication flows for Aiven for Apache Kafka services or
 external [Apache Kafka clusters](/docs/products/kafka/howto/integrate-external-kafka-cluster).
 
-To define a replication flow between a source Apache Kafka cluster and a
-target cluster:
+To define a replication flow between a source Apache Kafka cluster and a target
+cluster:
 
-1.  Log in to the [Aiven Console](https://console.aiven.io/) and select
-    the **Aiven for Apache Kafka MirrorMaker 2** service where you want
-    to define the replication flow.
+1. Log in to the [Aiven Console](https://console.aiven.io/) and click the
+   **Aiven for Apache Kafka MirrorMaker 2** service to define the replication
+   flow.
 
-    :::note
-    If no Aiven for Apache Kafka MirrorMaker 2 are already defined,
-    [you can create one in the Aiven console](../get-started).
-    :::
+   :::note
+   If needed, [create an Aiven for Apache Kafka MirrorMaker 2 service](../get-started).
+   :::
 
-2.  In the service **Overview** screen, scroll to the **Service
-    integrations** section and select **Manage integrations**.
-3.  If there is no integration for the source/target Apache Kafka
-    cluster, set up the necessary integrations:
-    -   On the Integrations screen, choose the desired integration from
-        the list for the source Apache Kafka cluster.
-    -   Select an existing Apache Kafka service to use as the
-        source/target for the replication flow.
-    -   Provide a cluster alias name (for example,, source-Kafka) to the
-        integration of the Apache Kafka cluster.
-    -   Repeat the above steps to set up the integration for the target
-        Apache Kafka cluster and provide a cluster alias name.
-4.  Once that the source and target Apache Kafka clusters are configure,
-    select **Replication flows** from the left sidebar.
-5.  Select **Create replication flow**.
-6.  On the Create new replication flow screen, define the replication
-    source and target cluster, the
-    [list of topics to be included or excluded](../concepts/replication-flow-topics-regex) and the sync settings.
-7.  Select **Create**.
-8.  In the target Apache Kafka cluster, verify the replicated topics
-    with the topic name `source-cluster-alias.source-topic-name`.
+1. Click <ConsoleLabel name="integrations" />.
+1. Add the source Apache Kafka cluster:
+   - On the **Integrations** page, click **Cluster for replication**.
+   - Click **Existing service** or **New service**.
+   - Click the Apache Kafka service to use as the source cluster.
+   - Click **Continue**.
+   - Add or confirm the cluster alias.
+1. Repeat the integration steps for the target Apache Kafka cluster.
+
+   The cluster alias identifies the Kafka integration in MirrorMaker 2. Use the
+   same aliases when you click **Source Cluster** and **Target Cluster** in the
+   replication flow. If you do not set an alias, Aiven generates one from the
+   project and service name.
+1. Click <ConsoleLabel name="replicationflow" />.
+1. Click **Create replication flow**.
+1. On the **Create new replication flow** screen, configure the flow:
+   - In **Source Cluster**, click the source Kafka integration alias.
+   - In **Target Cluster**, click the target Kafka integration alias.
+   - In **Topics**, enter the
+     [topics to replicate](../concepts/replication-flow-topics-regex). To
+     replicate all topics, click **All topics**.
+   - In **Topic blacklist**, enter the topics to exclude. To exclude internal
+     topics, click **Internal topics**.
+   - Configure offset sync, delivery, and replication policy options as needed.
+     For new replications, enable message delivery exactly once if it is
+     available for your setup.
+   - Use **Enable** to create the flow as active or inactive.
+1. Click **Create**.
+1. In the target Apache Kafka cluster, verify the replicated topics.
+
+   With the default replication policy, replicated topic names use the
+   `source-cluster-alias.source-topic-name` format. If you use the identity
+   replication policy, topic names stay unchanged.

--- a/docs/products/kafka/karapace/howto/enable-kafka-rest-proxy-authorization.md
+++ b/docs/products/kafka/karapace/howto/enable-kafka-rest-proxy-authorization.md
@@ -4,8 +4,9 @@ title: Enable Apache Kafka® REST proxy authorization
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
-Apache Kafka® REST proxy authorization enables you to use the RESTful interface to connect to Apache Kafka clusters, produce and consume messages, and perform administrative activities via the Aiven CLI.  It secures Apache Kafka resources by ensuring only authorized operations are permitted through the REST interface.
+Apache Kafka® REST proxy authorization lets you use the RESTful interface to connect to Apache Kafka clusters, produce and consume messages, and perform administrative activities with the Aiven CLI. It secures Apache Kafka resources by ensuring that only authorized operations are permitted through the REST interface.
 
 When you enable Apache Kafka REST proxy authorization, Karapace sends
 the HTTP basic authentication credentials to Apache Kafka®. The
@@ -20,17 +21,16 @@ performed without any restrictions.
 
 ## Configure Apache Kafka REST Proxy Authorization
 
-
 <Tabs groupId="sync">
 <TabItem value="Console" label="Console" default>
 
 1. In the [Aiven Console](https://console.aiven.io/), select your project and
    choose your Aiven for Apache Kafka® service.
-1. Click **Service settings** from the sidebar.
-1. Scroll down to the **Advanced configuration** section, and click **Configure**.
-1. In the **Advanced configuration** dialog, click **Add configuration options**.
+1. Click <ConsoleLabel name="service settings" />.
+1. In **Advanced configuration**, click **Configure**.
+1. In **Advanced configuration**, click
+   <ConsoleLabel name="addadvancedconfiguration" />.
 1. Locate the `kafka_rest_authorization` parameter and set it to `True` to enable.
-
 
 </TabItem>
 <TabItem value="CLI" label="CLI">
@@ -47,5 +47,6 @@ To disable REST proxy authorization, use:
 ```bash
 avn service update -c kafka_rest=false SERVICE_NAME
 ```
+
 </TabItem>
 </Tabs>

--- a/docs/products/kafka/karapace/howto/enable-karapace.md
+++ b/docs/products/kafka/karapace/howto/enable-karapace.md
@@ -3,12 +3,13 @@ title: Enable Karapace schema registry and REST APIs
 ---
 
 import RelatedPages from "@site/src/components/RelatedPages";
+import ConsoleLabel from "@site/src/components/ConsoleIcons"
 
 To enable **Karapace schema registry** and **REST APIs** on Aiven for Apache Kafka® from the Aiven Console:
 
 1. In the [Aiven Console](https://console.aiven.io/), select your
    project and choose your Aiven for Apache Kafka® service.
-1. Click **Service settings** on the sidebar.
+1. Click <ConsoleLabel name="service settings" />.
 1. In the **Service management** section, click **Actions** (**...**).
 1. From the dropdown menu, enable the setting for either or both of the
    features based on your requirements:

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -334,6 +334,20 @@ export default function ConsoleLabel({name}): ReactElement {
           <ConsoleIconWrapper icon={ConsoleIcons.key} /> <b>ACL</b>
         </>
       );
+    case 'access&control':
+    case 'accesscontrol':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.key} /> <b>Access & Control</b>
+        </>
+      );
+    case 'managestream':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.kafkaTopic} />{' '}
+          <b>Manage stream</b>
+        </>
+      );
     case 'topics':
       return (
         <>
@@ -577,14 +591,13 @@ export default function ConsoleLabel({name}): ReactElement {
     case 'tieredstorage':
       return (
         <>
-          <ConsoleIconWrapper icon={ConsoleIcons.tiered} />{' '}
           <b>Tiered storage</b>
         </>
       );
     case 'inklessstorage':
       return (
         <>
-          <ConsoleIconWrapper icon={ConsoleIcons.tiered} /> <b>Storage</b>
+          <b>Storage</b>
         </>
       );
     case 'editdatabase':
@@ -677,14 +690,6 @@ export default function ConsoleLabel({name}): ReactElement {
           <b>Activate tiered storage</b>
         </>
       );
-    case 'tieredstorage':
-      return (
-        <>
-          <ConsoleIconWrapper icon={ConsoleIcons.layers} />{' '}
-          <b>Tiered storage</b>
-        </>
-      );
-
     case 'queryeditor':
       return (
         <>
@@ -728,7 +733,7 @@ export default function ConsoleLabel({name}): ReactElement {
       return (
         <>
           <ConsoleIconWrapper icon={ConsoleIcons.replicationFlow} />{' '}
-          <b>Replication flow</b>
+          <b>Replication flows</b>
         </>
       );
     case 'snapshots':

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -366,12 +366,6 @@ export default function ConsoleLabel({name}): ReactElement {
           <ConsoleIconWrapper icon={ConsoleIcons.dataflow03} /> <b>Schemas</b>
         </>
       );
-    case 'quotas':
-      return (
-        <>
-          <ConsoleIconWrapper icon={ConsoleIcons.layers} /> <b>Quotas</b>
-        </>
-      );
     case 'storage':
       return (
         <>


### PR DESCRIPTION
## Describe your changes

- Updated Kafka documentation to match the new Console side navigation labels and grouping. 
- Added Console icon labels where relevant and refreshed affected Kafka, Kafka Connect, MirrorMaker 2, and Karapace instructions for current UI paths.
- Clarified MirrorMaker 2 replication flow setup, including Kafka integration aliases, source and target cluster selection, topic include/exclude behavior, default internal-topic exclusions, and replication policy behavior.


## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
