### PR TITLE
update: note that mcp.aiven.live is Aiven-operated

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -37,6 +37,12 @@ Authentication uses OAuth 2.0 with PKCE. When you authenticate a client for the
 first time, your browser opens so you can sign in and authorize MCP access. This
 is usually a one-time setup step per client.
 
+:::note
+The hosted MCP server at `mcp.aiven.live` is operated by Aiven. The `aiven.live`
+domain is owned by Aiven, and the server delegates authorization to the Aiven API
+at `api.aiven.io`.
+:::
+
 ## Install the Aiven MCP {#configure-aiven-mcp}
 
 <Tabs>

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -38,9 +38,9 @@ first time, your browser opens so you can sign in and authorize MCP access. This
 is usually a one-time setup step per client.
 
 :::note
-The hosted MCP server at `mcp.aiven.live` is operated by Aiven. The `aiven.live`
-domain is owned by Aiven, and the server delegates authorization to the Aiven API
-at `api.aiven.io`.
+Aiven owns the `aiven.live` domain and operates the hosted MCP server at
+`mcp.aiven.live`. The server uses the Aiven API at `api.aiven.io` for
+authorization.
 :::
 
 ## Install the Aiven MCP {#configure-aiven-mcp}


### PR DESCRIPTION
## Describe your changes

Adds a note to the Aiven MCP page stating that the hosted server at `mcp.aiven.live` is operated by Aiven and delegates authorization to `api.aiven.io`.

Requested by the Anthropic MCP directory review: the server domain (`aiven.live`) differs from the company domain (`aiven.io`), and a documentation note confirming Aiven operates it removes the ambiguity.

## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](styleguide.md).
- [x] My links start with `/docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)