### PR TITLE
update: Fix Kafka Java redirect loop

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -209,8 +209,7 @@
 /products/kafka/diskless/concepts/diskless-overview        /docs/products/kafka/diskless/concepts/diskless-topic-overview  301
 /products/kafka/getting-started.html                       /docs/products/kafka/get-started/create-kafka-service  301
 /products/kafka/howto                                      /docs/products/kafka/howto/list-code-samples  301
-/products/kafka/howto/connect-with-java                    /docs/products/kafka/howto/connect-with-java  301
-/docs/products/kafka/howto/connect-with-java-quick-connect /docs/products/kafka/howto/connect-with-java  301
+/products/kafka/howto/connect-with-java-quick-connect      /docs/products/kafka/howto/connect-with-java  301
 /products/kafka/howto/enable-karapace                      /docs/products/kafka/howto/enable-schema-registry  301
 /products/kafka/howto/fake-sample-data                     /docs/products/kafka/howto/generate-sample-data-manually  301
 /products/kafka/howto/list-admin                           /docs/products/kafka/howto/enable-karapace  301


### PR DESCRIPTION
## Describe your changes

https://aiven.atlassian.net/browse/SEO-128

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
