### PR TITLE
chore: Migrate onBrokenMarkdownLinks to markdown.hooks structure

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -37,7 +37,6 @@ const config: Config = {
   organizationName: 'Aiven',
   projectName: 'docs',
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
   onBrokenAnchors: 'throw',
   trailingSlash: false,
   i18n: {
@@ -46,6 +45,9 @@ const config: Config = {
   },
   markdown: {
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
   },
   headTags: [
     {


### PR DESCRIPTION
Moves the deprecated top-level onBrokenMarkdownLinks configuration into the new markdown.hooks structure to comply with Docusaurus v4 requirements and eliminate the deprecation warning.

## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
