### PR TITLE
update: add Debezium 3.5.2 connector version

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mysql.md
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mysql.md
@@ -45,7 +45,6 @@ documentation](https://debezium.io/docs/connectors/mysql/).
 - `MYSQL_PORT`: The database port
 - `MYSQL_USER`: The database user to connect
 - `MYSQL_PASSWORD`: The database password for the `MYSQL_USER`
-- `MYSQL_DATABASE_NAME`: The database name
 - `SSL_MODE`: The [SSL
   mode](https://dev.mysql.com/doc/refman/5.7/en/connection-options.html)
 - `MYSQL_TABLES`: The list of database tables to be included in Apache Kafka. Format
@@ -63,7 +62,7 @@ documentation](https://debezium.io/docs/connectors/mysql/).
 - `SCHEMA_REGISTRY_PASSWORD`: The Apache Kafka's schema registry user
   password is only needed when using Avro as a data format
 - `TOPIC_PREFIX`: The namespace for the MySQL database server from which
-  Debezium captures changes. It should be unique across all connectors.
+  Debezium captures changes. Make it unique across all connectors.
 
 :::note
 When using Aiven for MySQL and Aiven for Apache Kafka, you can gather the necessary
@@ -96,8 +95,7 @@ settings in one place and copy/paste them into the
   "database.port": "MYSQL_PORT",
   "database.user": "MYSQL_USER",
   "database.password": "MYSQL_PASSWORD",
-  "database.dbname": "MYSQL_DATABASE_NAME",
-  "database.sslmode": "SSL_MODE",
+  "database.ssl.mode": "SSL_MODE",
   "database.server.id": "MYSQL_SERVER_ID",
   "topic.prefix": "TOPIC_PREFIX",
   "table.include.list": "MYSQL_TABLES",
@@ -141,8 +139,7 @@ settings in one place and copy/paste them into the
   "database.port": "MYSQL_PORT",
   "database.user": "MYSQL_USER",
   "database.password": "MYSQL_PASSWORD",
-  "database.dbname": "MYSQL_DATABASE_NAME",
-  "database.sslmode": "SSL_MODE",
+  "database.ssl.mode": "SSL_MODE",
   "database.server.name": "TOPIC_PREFIX",
   "table.include.list": "MYSQL_TABLES",
   "tasks.max": "NR_TASKS",
@@ -182,17 +179,17 @@ The configuration file contains the following entries:
 -   `name`: The connector name, replace CONNECTOR_NAME with the name you
     want to use for the connector.
 
--   `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_DATABASE_NAME`, `SSL_MODE`,
-    `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_TABLES`: Source database
+-   `MYSQL_HOST`, `MYSQL_PORT`, `SSL_MODE`, `MYSQL_USER`,
+    `MYSQL_PASSWORD`, `MYSQL_TABLES`: Source database
     parameters collected in the
-    [prerequisite](/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mysql#connect_debezium_mysql_source_prereq) phase.
+    [prerequisite](#connect_debezium_mysql_source_prereq) phase.
 
 -   `database.server.name` (Debezium v1): The logical name of the database,
     which also determines the prefix used in combination with table names
     for Apache Kafka topic names.
 
 -   `database.server.id` (Debezium v2): The numeric ID of the MySQL client.
-    It must be unique across all currently-running database processes in
+    It must be unique across all currently running database processes in
     the MySQL cluster.
 
 -   `topic.prefix` (Debezium v2): The prefix used in combination with table
@@ -244,20 +241,20 @@ To create a Kafka Connect connector:
 1.  Select the Aiven for Apache Kafka® or Aiven for Apache Kafka Connect® service
     to define the connector.
 
-1. Select <ConsoleLabel name="manage stream" /> > **Connectors** from the sidebar.
+1. Click <ConsoleLabel name="manage stream" /> > **Connectors** from the sidebar.
 
-1. Select **Create New Connector**, which is available only for
+1. Click **Create New Connector**, which is available only for
    services [that have Apache Kafka Connect enabled](enable-connect).
 
 1. Select the **Debezium - MySQL**.
 
 1. In the **Common** tab, locate the **Connector configuration** text
-    box and select on **Edit**.
+    box and click **Edit**.
 
 1. Paste the connector configuration (stored in the
     `debezium_source_mysql.json` file) in the form.
 
-1. Select **Apply**.
+1. Click **Apply**.
 
    :::note
    The Aiven Console reads through the configuration file and automatically populates
@@ -266,7 +263,7 @@ To create a Kafka Connect connector:
    within the **Connector configuration** text box.
    :::
 
-1. After all the settings are correctly configured, select **Create connector**
+1. After all the settings are correctly configured, click **Create connector**
 
    :::tip
    With Aiven for Apache Kafka, topics are not created automatically. You have two options:

--- a/docs/products/kafka/kafka-connect/howto/manage-connector-versions.md
+++ b/docs/products/kafka/kafka-connect/howto/manage-connector-versions.md
@@ -34,8 +34,8 @@ service configuration.
 - Multi-version support is available for all connectors where Aiven has published and
   supports more than one version. Support will continue to expand as new versions are
   released.
-- Set a specific version to prevent automatic upgrades. If not set, the latest published
-  version is used.
+- Set a specific version to prevent automatic upgrades. If not set, the connector uses
+  the default version for that plugin.
 - See [Check available connector versions](#check-available-connector-versions) to
   confirm which versions are supported before setting a version.
 - Setting `plugin_version` in the connector configuration (for example, in
@@ -58,9 +58,12 @@ in production.
 
 :::note
 Aiven supports multiple Debezium versions through multi-version support, including
-versions 1.9.7, 2.5.0, 2.7.4, and 3.1.0.
+versions 1.9.7, 2.5.0, 2.7.4, 3.1.0, and 3.5.2.
 
 To prevent automatic upgrades during maintenance, pin the connector version using
+the `plugin_versions` property.
+
+Debezium 3.1.0 remains the default version. To use Debezium 3.5.2, set it with
 the `plugin_versions` property.
 
 If you use Debezium for PostgreSQL with version 1.9.7 and the `wal2json` format, do not
@@ -68,7 +71,6 @@ upgrade to version 2.0 or later until you migrate to `pgoutput`.
 
 For upgrade steps, see [Set a connector version](#set-version).
 :::
-
 
 ## Limitations
 
@@ -100,7 +102,6 @@ must all use the same plugin version.
 - [Aiven API](/docs/tools/api)
 - [Aiven Provider for Terraform](/docs/tools/terraform)
 
-
 ## Check available connector versions {#check-available-connector-versions}
 
 Before selecting a connector version, check which versions are available for your
@@ -114,8 +115,8 @@ supported and can be set if needed. Use one of the following methods:
 1. Select your Aiven for Apache Kafka Connect service.
 1. Click <ConsoleLabel name="manage stream" /> > **Connectors**.
 
-Connectors that support multiple versions display **2 versions** next to their names on
-the <ConsoleLabel name="manage stream" /> > **Connectors** page.
+Connectors that support multiple versions display the number of available versions next
+to their names on the <ConsoleLabel name="manage stream" /> > **Connectors** page.
 
 :::note
 When setting up a new connector, a default version is selected. To change it, go to the
@@ -215,13 +216,14 @@ Connector version selection in the Aiven Console is available only for
 1. Click <ConsoleLabel name="actions"/> > **Change connector version**.
 1. In the **Version setup** window:
    - Select the version to use.
-   - Optional: If you select the latest version, you can turn on
+   - Optional: If you select the latest available version, you can turn on
      **Enable version updates** to automatically update the connector to newer
      versions during maintenance updates.
 
      :::note
-     **Enable version updates** is available only for the latest (default) version. This
-     option is unavailable for older versions because automatic updates apply only to the latest version.
+     **Enable version updates** is available only for the latest available version. This
+     option is unavailable for older versions because automatic updates apply only to the
+     latest available version.
      :::
 1. Depending on your selection, click:
    - **Install version and restart service** to apply the selected version.

--- a/static/includes/debezium-breakingchange.md
+++ b/static/includes/debezium-breakingchange.md
@@ -1,11 +1,15 @@
 :::note
 Aiven supports multiple Debezium versions through multi-version support, including
-versions 1.9.7, 2.5.0, 2.7.4, and 3.1.0.
+versions 1.9.7, 2.5.0, 2.7.4, 3.1.0, and 3.5.2.
 
 Debezium 2.5 introduced changes to connector configuration and behavior. To prevent
 unintentional upgrades during maintenance updates, pin the connector version using the
 `plugin_versions` configuration property.
-For details, see [Manage connector versions](/docs/products/kafka/kafka-connect/howto/manage-connector-versions).
+For details, see
+[Manage connector versions](/docs/products/kafka/kafka-connect/howto/manage-connector-versions).
+
+Debezium 3.1.0 remains the default version. To use Debezium 3.5.2, set it with
+the `plugin_versions` configuration property.
 
 If you use Debezium for PostgreSQL version 1.9.7 with the `wal2json` replication format,
 do not upgrade to version 2.0 or later until you migrate to a supported format such as


### PR DESCRIPTION
## Describe your changes

Adds Debezium 3.5.2 to the connector version docs and shared Debezium note, clarifying that 3.1.0 remains the default unless `plugin_versions` is set.

Also fixes the Debezium MySQL example by using `database.ssl.mode` and removing the unsupported `database.dbname` property.

JIRA - https://aiven.atlassian.net/browse/EC-1374

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
