### PR TITLE
update: clarify OIDC service user requirement for Aiven ACLs

### DIFF
--- a/docs/products/kafka/howto/enable-oidc.md
+++ b/docs/products/kafka/howto/enable-oidc.md
@@ -38,6 +38,17 @@ Before you begin, make sure you have:
 Configuration steps vary by identity provider. See your provider's documentation
 for JWKS URL, issuer, and audience values.
 
+:::note
+OAuth 2.0/OIDC authentication works independently of Aiven service users. If you
+use **Aiven ACLs** instead of Kafka-native ACLs to control access, create
+a [matching Aiven service user](/docs/products/kafka/howto/add-manage-service-users)
+with the same identifier as the OIDC principal. This identifier can be the
+identity provider's service principal ID. Aiven enforces the ACL only when this
+matching service user exists. Kafka-native ACLs do not have this requirement.
+For more information, see
+[Manage access control lists](/docs/products/kafka/howto/manage-acls).
+:::
+
 ## Configure OAuth 2.0/OIDC settings
 
 Set `kafka.sasl_oauthbearer_jwks_endpoint_url` to enable `OAUTHBEARER`.

--- a/docs/products/kafka/howto/manage-acls.md
+++ b/docs/products/kafka/howto/manage-acls.md
@@ -158,6 +158,15 @@ More information on this resource and its configuration options are available in
 
 ## Add an Aiven ACL entry
 
+:::note
+When you authenticate with OAuth 2.0/OIDC, an Aiven ACL entry only takes effect when a
+[matching Aiven service user](/docs/products/kafka/howto/add-manage-service-users)
+also exists. Use the OIDC principal identifier, such as the service principal's
+GUID, as the service user username. Kafka-native ACLs do not have this
+requirement. For more information, see
+[Enable OAuth 2.0/OIDC authentication](/docs/products/kafka/howto/enable-oidc).
+:::
+
 <Tabs groupId="acl-methods">
 <TabItem value="console" label="Aiven Console" default>
 


### PR DESCRIPTION
## Describe your changes

- Notes that OAuth 2.0/OIDC works without Aiven service users, but Aiven ACLs only apply when a matching service user exists for the OIDC principal.
- Clarifies Kafka-native ACLs do not need this, with cross-links between the OIDC and ACL docs.


## Related

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
