### PR TITLE
update: Valkey defragmentation and memory management

### DIFF
--- a/.github/vale/styles/config/vocabularies/Aiven/accept.txt
+++ b/.github/vale/styles/config/vocabularies/Aiven/accept.txt
@@ -98,6 +98,7 @@ DBMSs
 deallocation
 Debezium
 deduplicate
+defragmentation
 depends_on
 deserialization
 deserialize

--- a/docs/products/valkey/concepts/memory-usage.md
+++ b/docs/products/valkey/concepts/memory-usage.md
@@ -151,9 +151,7 @@ system.
 
 :::note
 Active memory defragmentation is disabled by default. It runs on the main thread and
-consumes CPU, so it can increase latency under load. Test the option on a
-[forked service](/docs/products/valkey/howto/fork-service) before enabling it on a
-production service.
+consumes CPU, so it can increase latency under load.
 :::
 
 For the full list of configuration options, including `valkey_activedefrag`, see
@@ -172,4 +170,3 @@ For the full list of configuration options, including `valkey_activedefrag`, see
 - [Change the service plan](/docs/products/valkey/howto/change-service-plan)
 - [Scale disk storage](/docs/products/valkey/howto/scale-disk-storage)
 - [Advanced parameters for Aiven for Valkey™](/docs/products/valkey/reference/advanced-params)
-- [Fork a service](/docs/products/valkey/howto/fork-service)

--- a/docs/products/valkey/concepts/memory-usage.md
+++ b/docs/products/valkey/concepts/memory-usage.md
@@ -137,6 +137,28 @@ If you frequently need to write large volumes of data, contact Aiven support to
 discuss service configuration options that can accommodate your needs.
 :::
 
+## Memory fragmentation and active defragmentation
+
+As keys are written, updated, and deleted, the memory allocator can end up with data
+spread across sparsely used memory pages. This fragmentation increases the memory a
+service uses beyond the size of the data it stores, and it tends to grow on
+long-running services with a high rate of change.
+
+To reduce fragmentation, enable the **Active memory defragmentation**
+(`valkey_activedefrag`) advanced configuration option. When enabled, Valkey relocates
+objects off sparsely used memory pages and returns the freed memory to the operating
+system.
+
+:::note
+Active memory defragmentation is disabled by default. It runs on the main thread and
+consumes CPU, so it can increase latency under load. Test the option on a
+[forked service](/docs/products/valkey/howto/fork-service) before enabling it on a
+production service.
+:::
+
+For the full list of configuration options, including `valkey_activedefrag`, see
+[Advanced parameters for Aiven for Valkey™](/docs/products/valkey/reference/advanced-params).
+
 ## Service memory limits
 
 <ServiceMemoryLimits/>
@@ -149,3 +171,5 @@ discuss service configuration options that can accommodate your needs.
 
 - [Change the service plan](/docs/products/valkey/howto/change-service-plan)
 - [Scale disk storage](/docs/products/valkey/howto/scale-disk-storage)
+- [Advanced parameters for Aiven for Valkey™](/docs/products/valkey/reference/advanced-params)
+- [Fork a service](/docs/products/valkey/howto/fork-service)


### PR DESCRIPTION
https://aiven.atlassian.net/browse/VK-273

Added a new "Memory fragmentation and active defragmentation" section explaining why fragmentation grows on long-running, high-churn services, documenting the new valkey_activedefrag config option (off by default, main-thread CPU cost), and recommending testing on a forked service first.