### PR TITLE
feat: add Karapace version management docs

### DIFF
--- a/docs/products/kafka/karapace/howto/manage-karapace-version.md
+++ b/docs/products/kafka/karapace/howto/manage-karapace-version.md
@@ -6,30 +6,22 @@ sidebar_label: Manage the Karapace version
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Karapace is the schema registry and REST proxy service for Aiven for Apache Kafka®.
-By default, your service uses the latest supported Karapace version
-automatically.
+You can pin your Aiven for Apache Kafka® service to a specific Karapace version.
 
-To use a fixed version, pin your service to a specific Karapace version. Your
-service keeps using the pinned version until you remove the setting. Pinning can
-help you delay an upgrade until you have tested compatibility. You can return to
-automatic updates at any time.
+By default, your service uses the latest supported Karapace version and upgrades
+automatically. A pinned version stays in effect until you remove the setting.
+Pin a version to test compatibility before you accept a Karapace upgrade. You can
+return to automatic updates at any time.
 
 ## Prerequisites
 
 - An [Aiven for Apache Kafka® service](/docs/products/kafka/get-started/get-started-kafka)
   with Karapace enabled
+- The [service maintenance update](/docs/products/kafka/howto/maintenance-updates#maintenance-updates)
+  that adds Karapace version pinning. If the update is not applied, Aiven returns
+  an error when you try to pin a version.
 - [Aiven CLI](/docs/tools/cli)
 - [Aiven API](/docs/tools/api)
-
-## Key considerations
-
-- You can pin your service to one of the following Karapace versions: `6.1.4`,
-  `6.2.0`, `6.2.1`, or `6.2.2`.
-- Karapace version pinning requires a service maintenance update that includes
-  this feature. If your service has not received this update, Aiven returns an
-  error when you try to pin the Karapace version. Apply the required maintenance
-  update before you pin the Karapace version.
 
 :::note
 Karapace version selection is not available in the Aiven Console. Use the Aiven
@@ -45,15 +37,15 @@ configuration option.
 <TabItem value="cli" label="Aiven CLI" default>
 
 ```shell
-avn service update <SERVICE_NAME> --project <PROJECT_NAME> \
-  -c karapace_version=<VERSION>
+avn service update SERVICE_NAME --project PROJECT_NAME \
+  -c karapace_version=VERSION
 ```
 
-Replace the following placeholders:
+Replace the following:
 
-- `<SERVICE_NAME>`: Name of your Aiven for Apache Kafka® service.
-- `<PROJECT_NAME>`: Name of your Aiven project.
-- `<VERSION>`: Karapace version to use, for example, `6.2.0`.
+- `SERVICE_NAME`: name of your Aiven for Apache Kafka® service
+- `PROJECT_NAME`: name of your Aiven project
+- `VERSION`: Karapace version to use, for example, `6.2.2`
 
 </TabItem>
 <TabItem value="api" label="Aiven API">
@@ -62,32 +54,32 @@ Use the [Aiven API](https://api.aiven.io/doc/) to update the service configurati
 
 ```shell
 curl --request PUT \
-  --url "https://api.aiven.io/v1/project/<PROJECT_NAME>/service/<SERVICE_NAME>" \
-  --header "Authorization: Bearer <API_TOKEN>" \
+  --url "https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME" \
+  --header "Authorization: Bearer API_TOKEN" \
   --header "Content-Type: application/json" \
-  --data '{"user_config": {"karapace_version": "<VERSION>"}}'
+  --data '{"user_config": {"karapace_version": "VERSION"}}'
 ```
 
-Replace the following placeholders:
+Replace the following:
 
-- `<PROJECT_NAME>`: Name of your Aiven project.
-- `<SERVICE_NAME>`: Name of your Aiven for Apache Kafka® service.
-- `<API_TOKEN>`: Your [Aiven API token](/docs/platform/howto/create_authentication_token).
-- `<VERSION>`: Karapace version to use, for example, `6.2.0`.
+- `PROJECT_NAME`: name of your Aiven project
+- `SERVICE_NAME`: name of your Aiven for Apache Kafka® service
+- `API_TOKEN`: your [Aiven API token](/docs/platform/howto/create_authentication_token)
+- `VERSION`: Karapace version to use, for example, `6.2.2`
 
 </TabItem>
 </Tabs>
 
-## Roll back to the latest version
+## Return to automatic updates
 
-To stop pinning and let your service follow the latest supported version
-automatically, set `karapace_version` to `null`.
+To stop pinning and return to automatic Karapace version updates, set
+`karapace_version` to `null`.
 
 <Tabs groupId="tool">
 <TabItem value="cli" label="Aiven CLI" default>
 
 ```shell
-avn service update <SERVICE_NAME> --project <PROJECT_NAME> \
+avn service update SERVICE_NAME --project PROJECT_NAME \
   -c karapace_version=null
 ```
 
@@ -96,8 +88,8 @@ avn service update <SERVICE_NAME> --project <PROJECT_NAME> \
 
 ```shell
 curl --request PUT \
-  --url "https://api.aiven.io/v1/project/<PROJECT_NAME>/service/<SERVICE_NAME>" \
-  --header "Authorization: Bearer <API_TOKEN>" \
+  --url "https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME" \
+  --header "Authorization: Bearer API_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{"user_config": {"karapace_version": null}}'
 ```
@@ -113,7 +105,7 @@ To confirm which version your service is set to use, review the service configur
 <TabItem value="cli" label="Aiven CLI" default>
 
 ```shell
-avn service get <SERVICE_NAME> --project <PROJECT_NAME> --json
+avn service get SERVICE_NAME --project PROJECT_NAME --json
 ```
 
 </TabItem>
@@ -121,8 +113,8 @@ avn service get <SERVICE_NAME> --project <PROJECT_NAME> --json
 
 ```shell
 curl --request GET \
-  --url "https://api.aiven.io/v1/project/<PROJECT_NAME>/service/<SERVICE_NAME>" \
-  --header "Authorization: Bearer <API_TOKEN>"
+  --url "https://api.aiven.io/v1/project/PROJECT_NAME/service/SERVICE_NAME" \
+  --header "Authorization: Bearer API_TOKEN"
 ```
 
 </TabItem>
@@ -134,6 +126,6 @@ version number, your service is pinned to that Karapace version. If it shows
 
 ## Related pages
 
-- [Apache Kafka maintenance updates](/docs/platform/concepts/maintenance-window)
+- [Apache Kafka maintenance updates](/docs/products/kafka/howto/maintenance-updates#maintenance-updates)
 - [Aiven CLI reference: avn service update](/docs/tools/cli/service-cli#avn-cli-service-update)
 - [Aiven API documentation](https://api.aiven.io/doc/)

--- a/docs/products/kafka/karapace/howto/manage-karapace-version.md
+++ b/docs/products/kafka/karapace/howto/manage-karapace-version.md
@@ -5,36 +5,42 @@ sidebar_label: Manage the Karapace version
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
 
 You can pin your Aiven for Apache Kafka® service to a specific Karapace version.
 
-By default, your service uses the latest supported Karapace version and upgrades
-automatically. A pinned version stays in effect until you remove the setting.
-Pin a version to test compatibility before you accept a Karapace upgrade. You can
-return to automatic updates at any time.
+Pin a version to test compatibility or to control which Karapace version the
+service runs. If you do not pin a version, the service uses the most recent
+Karapace version Aiven provides through maintenance updates. A pinned version
+stays in use until you change `karapace_version` or set it to `null`.
 
 ## Prerequisites
 
 - An [Aiven for Apache Kafka® service](/docs/products/kafka/get-started/get-started-kafka)
   with Karapace enabled
-- The [service maintenance update](/docs/products/kafka/howto/maintenance-updates#maintenance-updates)
-  that adds Karapace version pinning. If the update is not applied, Aiven returns
-  an error when you try to pin a version.
-- [Aiven CLI](/docs/tools/cli)
-- [Aiven API](/docs/tools/api)
+- A [maintenance update](/docs/products/kafka/howto/maintenance-updates#maintenance-updates)
+  that includes Karapace version pinning
 
-:::note
-Karapace version selection is not available in the Aiven Console. Use the Aiven
-CLI or Aiven API instead.
-:::
+## Set the version
 
-## Set the Karapace version
-
-To pin your service to a specific Karapace version, set the `karapace_version`
-configuration option.
+Set `karapace_version` to the version you want the service to run. Use the same
+setting to pin a version, upgrade, or roll back.
 
 <Tabs groupId="tool">
-<TabItem value="cli" label="Aiven CLI" default>
+<TabItem value="console" label="Console" default>
+
+1. Log in to the [Aiven Console](https://console.aiven.io/).
+1. Select your project and your Aiven for Apache Kafka service.
+1. Click <ConsoleLabel name="service settings"/>.
+1. Click **Advanced configuration** > **Configure**.
+1. Click <ConsoleLabel name="Add config options"/>.
+1. Set **`karapace_version`** to a supported version, for example, `6.2.2`.
+1. Click **Save configuration**.
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+Run the following command:
 
 ```shell
 avn service update SERVICE_NAME --project PROJECT_NAME \
@@ -43,14 +49,14 @@ avn service update SERVICE_NAME --project PROJECT_NAME \
 
 Replace the following:
 
-- `SERVICE_NAME`: name of your Aiven for Apache Kafka® service
+- `SERVICE_NAME`: name of your Aiven for Apache Kafka service
 - `PROJECT_NAME`: name of your Aiven project
 - `VERSION`: Karapace version to use, for example, `6.2.2`
 
 </TabItem>
-<TabItem value="api" label="Aiven API">
+<TabItem value="api" label="API">
 
-Use the [Aiven API](https://api.aiven.io/doc/) to update the service configuration:
+Send the following `PUT` request:
 
 ```shell
 curl --request PUT \
@@ -63,28 +69,48 @@ curl --request PUT \
 Replace the following:
 
 - `PROJECT_NAME`: name of your Aiven project
-- `SERVICE_NAME`: name of your Aiven for Apache Kafka® service
+- `SERVICE_NAME`: name of your Aiven for Apache Kafka service
 - `API_TOKEN`: your [Aiven API token](/docs/platform/howto/create_authentication_token)
 - `VERSION`: Karapace version to use, for example, `6.2.2`
 
 </TabItem>
 </Tabs>
 
-## Return to automatic updates
+### Troubleshoot a failed change
 
-To stop pinning and return to automatic Karapace version updates, set
-`karapace_version` to `null`.
+If Aiven returns an error when you set the version, apply a
+[maintenance update](/docs/products/kafka/howto/maintenance-updates#maintenance-updates).
+The update enables Karapace version pinning or installs the selected version on
+the service nodes. You can also replace a node to install the required version.
+Then set the version again.
+
+## Remove the version pin
+
+Set `karapace_version` to `null` to stop pinning a version. The service then
+uses the most recent Karapace version Aiven provides through maintenance updates.
+
+The Aiven Console cannot set `karapace_version` to `null`. Use the Aiven CLI or
+Aiven API.
 
 <Tabs groupId="tool">
-<TabItem value="cli" label="Aiven CLI" default>
+<TabItem value="cli" label="CLI" default>
+
+Run the following command:
 
 ```shell
 avn service update SERVICE_NAME --project PROJECT_NAME \
   -c karapace_version=null
 ```
 
+Replace the following:
+
+- `SERVICE_NAME`: name of your Aiven for Apache Kafka service
+- `PROJECT_NAME`: name of your Aiven project
+
 </TabItem>
-<TabItem value="api" label="Aiven API">
+<TabItem value="api" label="API">
+
+Send the following `PUT` request:
 
 ```shell
 curl --request PUT \
@@ -94,22 +120,46 @@ curl --request PUT \
   --data '{"user_config": {"karapace_version": null}}'
 ```
 
+Replace the following:
+
+- `PROJECT_NAME`: name of your Aiven project
+- `SERVICE_NAME`: name of your Aiven for Apache Kafka service
+- `API_TOKEN`: your [Aiven API token](/docs/platform/howto/create_authentication_token)
+
 </TabItem>
 </Tabs>
 
-## Verify the Karapace version
+## Verify the pinned version
 
-To confirm which version your service is set to use, review the service configuration.
+Check `karapace_version` to see whether the service is pinned.
 
 <Tabs groupId="tool">
-<TabItem value="cli" label="Aiven CLI" default>
+<TabItem value="console" label="Console" default>
+
+1. Log in to the [Aiven Console](https://console.aiven.io/).
+1. Select your project and your Aiven for Apache Kafka service.
+1. Click <ConsoleLabel name="service settings"/>.
+1. Click **Advanced configuration**.
+1. Check the **`karapace_version`** value.
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+Run the following command:
 
 ```shell
 avn service get SERVICE_NAME --project PROJECT_NAME --json
 ```
 
+Replace the following:
+
+- `SERVICE_NAME`: name of your Aiven for Apache Kafka service
+- `PROJECT_NAME`: name of your Aiven project
+
 </TabItem>
-<TabItem value="api" label="Aiven API">
+<TabItem value="api" label="API">
+
+Send the following `GET` request:
 
 ```shell
 curl --request GET \
@@ -117,15 +167,25 @@ curl --request GET \
   --header "Authorization: Bearer API_TOKEN"
 ```
 
+Replace the following:
+
+- `PROJECT_NAME`: name of your Aiven project
+- `SERVICE_NAME`: name of your Aiven for Apache Kafka service
+- `API_TOKEN`: your [Aiven API token](/docs/platform/howto/create_authentication_token)
+
 </TabItem>
 </Tabs>
 
-In the response, find `karapace_version` in `user_config`. If it shows a
-version number, your service is pinned to that Karapace version. If it shows
-`null`, your service uses automatic Karapace version updates.
+In the Aiven Console, a version number means the service is pinned to that
+version. If **`karapace_version`** is not listed or has no value, the service is
+not pinned.
+
+In the CLI output or API response, check `karapace_version` in `user_config`.
+A version number means the service is pinned. If the value is `null` or the
+field is not present, the service is not pinned.
 
 ## Related pages
 
 - [Apache Kafka maintenance updates](/docs/products/kafka/howto/maintenance-updates#maintenance-updates)
 - [Aiven CLI reference: avn service update](/docs/tools/cli/service-cli#avn-cli-service-update)
-- [Aiven API documentation](https://api.aiven.io/doc/)
+- [Aiven REST API reference](https://api.aiven.io/doc/)

--- a/docs/products/kafka/karapace/howto/manage-karapace-version.md
+++ b/docs/products/kafka/karapace/howto/manage-karapace-version.md
@@ -1,0 +1,139 @@
+---
+title: Manage the Karapace version
+sidebar_label: Manage the Karapace version
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Karapace is the schema registry and REST proxy service for Aiven for Apache Kafka®.
+By default, your service uses the latest supported Karapace version
+automatically.
+
+To use a fixed version, pin your service to a specific Karapace version. Your
+service keeps using the pinned version until you remove the setting. Pinning can
+help you delay an upgrade until you have tested compatibility. You can return to
+automatic updates at any time.
+
+## Key considerations
+
+- You can pin your service to one of the following Karapace versions: `6.1.4`,
+  `6.2.0`, or `6.2.1`.
+- Karapace version pinning requires a service maintenance update that includes
+  this feature. If your service has not received this update, Aiven returns an
+  error when you try to pin the Karapace version. Apply the required maintenance
+  update before you pin the Karapace version.
+
+:::note
+Karapace version selection is not available in the Aiven Console. Use the Aiven
+CLI or Aiven API instead.
+:::
+
+## Prerequisites
+
+- An [Aiven for Apache Kafka® service](/docs/products/kafka/get-started/get-started-kafka)
+  with Karapace enabled
+- [Aiven CLI](/docs/tools/cli)
+- [Aiven API](/docs/tools/api)
+
+## Set the Karapace version
+
+To pin your service to a specific Karapace version, set the `karapace_version`
+configuration option.
+
+<Tabs groupId="tool">
+<TabItem value="cli" label="Aiven CLI" default>
+
+```shell
+avn service update <SERVICE_NAME> --project <PROJECT_NAME> \
+  -c karapace_version=<VERSION>
+```
+
+Replace the following placeholders:
+
+- `<SERVICE_NAME>`: Name of your Aiven for Apache Kafka® service.
+- `<PROJECT_NAME>`: Name of your Aiven project.
+- `<VERSION>`: Karapace version to use, for example, `6.2.0`.
+
+</TabItem>
+<TabItem value="api" label="Aiven API">
+
+Use the [Aiven API](https://api.aiven.io/doc/) to update the service configuration:
+
+```shell
+curl --request PUT \
+  --url "https://api.aiven.io/v1/project/<PROJECT_NAME>/service/<SERVICE_NAME>" \
+  --header "Authorization: Bearer <API_TOKEN>" \
+  --header "Content-Type: application/json" \
+  --data '{"user_config": {"karapace_version": "<VERSION>"}}'
+```
+
+Replace the following placeholders:
+
+- `<PROJECT_NAME>`: Name of your Aiven project.
+- `<SERVICE_NAME>`: Name of your Aiven for Apache Kafka® service.
+- `<API_TOKEN>`: Your [Aiven API token](/docs/platform/howto/create_authentication_token).
+- `<VERSION>`: Karapace version to use, for example, `6.2.0`.
+
+</TabItem>
+</Tabs>
+
+## Roll back to the latest version
+
+To stop pinning and let your service follow the latest supported version
+automatically, set `karapace_version` to `null`.
+
+<Tabs groupId="tool">
+<TabItem value="cli" label="Aiven CLI" default>
+
+```shell
+avn service update <SERVICE_NAME> --project <PROJECT_NAME> \
+  -c karapace_version=null
+```
+
+</TabItem>
+<TabItem value="api" label="Aiven API">
+
+```shell
+curl --request PUT \
+  --url "https://api.aiven.io/v1/project/<PROJECT_NAME>/service/<SERVICE_NAME>" \
+  --header "Authorization: Bearer <API_TOKEN>" \
+  --header "Content-Type: application/json" \
+  --data '{"user_config": {"karapace_version": null}}'
+```
+
+</TabItem>
+</Tabs>
+
+## Verify the Karapace version
+
+To confirm which version your service is set to use, review the service configuration.
+
+<Tabs groupId="tool">
+<TabItem value="cli" label="Aiven CLI" default>
+
+```shell
+avn service get <SERVICE_NAME> --project <PROJECT_NAME> --json
+```
+
+</TabItem>
+<TabItem value="api" label="Aiven API">
+
+```shell
+curl --request GET \
+  --url "https://api.aiven.io/v1/project/<PROJECT_NAME>/service/<SERVICE_NAME>" \
+  --header "Authorization: Bearer <API_TOKEN>"
+```
+
+</TabItem>
+</Tabs>
+
+In the response, find `karapace_version` in `user_config`. If it shows a
+version number, your service is pinned to that Karapace version. If it shows
+`null`, your service uses automatic Karapace version updates.
+
+## Related pages
+
+- [Apache Kafka maintenance updates](/docs/platform/concepts/maintenance-window)
+- [Aiven CLI reference: avn service update](/docs/tools/cli/service-cli#avn-cli-service-update)
+- [Aiven API documentation](https://api.aiven.io/doc/)

--- a/docs/products/kafka/karapace/howto/manage-karapace-version.md
+++ b/docs/products/kafka/karapace/howto/manage-karapace-version.md
@@ -15,10 +15,17 @@ service keeps using the pinned version until you remove the setting. Pinning can
 help you delay an upgrade until you have tested compatibility. You can return to
 automatic updates at any time.
 
+## Prerequisites
+
+- An [Aiven for Apache Kafka® service](/docs/products/kafka/get-started/get-started-kafka)
+  with Karapace enabled
+- [Aiven CLI](/docs/tools/cli)
+- [Aiven API](/docs/tools/api)
+
 ## Key considerations
 
 - You can pin your service to one of the following Karapace versions: `6.1.4`,
-  `6.2.0`, or `6.2.1`.
+  `6.2.0`, `6.2.1`, or `6.2.2`.
 - Karapace version pinning requires a service maintenance update that includes
   this feature. If your service has not received this update, Aiven returns an
   error when you try to pin the Karapace version. Apply the required maintenance
@@ -28,13 +35,6 @@ automatic updates at any time.
 Karapace version selection is not available in the Aiven Console. Use the Aiven
 CLI or Aiven API instead.
 :::
-
-## Prerequisites
-
-- An [Aiven for Apache Kafka® service](/docs/products/kafka/get-started/get-started-kafka)
-  with Karapace enabled
-- [Aiven CLI](/docs/tools/cli)
-- [Aiven API](/docs/tools/api)
 
 ## Set the Karapace version
 

--- a/docs/products/kafka/karapace/howto/set-karapace-version.md
+++ b/docs/products/kafka/karapace/howto/set-karapace-version.md
@@ -1,30 +1,30 @@
 ---
-title: Manage the Karapace version
-sidebar_label: Manage the Karapace version
+title: Set the Karapace version
+sidebar_label: Set the Karapace version
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
 
-You can pin your Aiven for Apache Kafka® service to a specific Karapace version.
+You can set which Karapace version your Aiven for Apache Kafka® service runs.
 
-Pin a version to test compatibility or to control which Karapace version the
-service runs. If you do not pin a version, the service uses the most recent
-Karapace version Aiven provides through maintenance updates. A pinned version
-stays in use until you change `karapace_version` or set it to `null`.
+Set a specific version to test compatibility or to control upgrades. If you do
+not set a version, the service uses the latest Karapace version available
+through maintenance updates. After you set `karapace_version`, the service
+keeps that version until you change the setting or set it to `null`.
 
 ## Prerequisites
 
 - An [Aiven for Apache Kafka® service](/docs/products/kafka/get-started/get-started-kafka)
   with Karapace enabled
 - A [maintenance update](/docs/products/kafka/howto/maintenance-updates#maintenance-updates)
-  that includes Karapace version pinning
+  that includes Karapace version selection
 
-## Set the version
+## Set a Karapace version
 
-Set `karapace_version` to the version you want the service to run. Use the same
-setting to pin a version, upgrade, or roll back.
+Set `karapace_version` to the version you want the service to run. To upgrade
+or roll back, change the setting to another supported version.
 
 <Tabs groupId="tool">
 <TabItem value="console" label="Console" default>
@@ -80,17 +80,14 @@ Replace the following:
 
 If Aiven returns an error when you set the version, apply a
 [maintenance update](/docs/products/kafka/howto/maintenance-updates#maintenance-updates).
-The update enables Karapace version pinning or installs the selected version on
-the service nodes. You can also replace a node to install the required version.
-Then set the version again.
+The update enables Karapace version selection or installs the selected version
+on the service nodes. You can also replace a node to install the required
+version. Then set the version again.
 
-## Remove the version pin
+## Stop using a specific Karapace version
 
-Set `karapace_version` to `null` to stop pinning a version. The service then
-uses the most recent Karapace version Aiven provides through maintenance updates.
-
-The Aiven Console cannot set `karapace_version` to `null`. Use the Aiven CLI or
-Aiven API.
+Set `karapace_version` to `null` to stop using a specific version. The service
+then uses the latest Karapace version available through maintenance updates.
 
 <Tabs groupId="tool">
 <TabItem value="cli" label="CLI" default>
@@ -129,9 +126,10 @@ Replace the following:
 </TabItem>
 </Tabs>
 
-## Verify the pinned version
+## Check the Karapace version
 
-Check `karapace_version` to see whether the service is pinned.
+Check `karapace_version` to see whether the service is set to a specific
+version.
 
 <Tabs groupId="tool">
 <TabItem value="console" label="Console" default>
@@ -176,13 +174,14 @@ Replace the following:
 </TabItem>
 </Tabs>
 
-In the Aiven Console, a version number means the service is pinned to that
-version. If **`karapace_version`** is not listed or has no value, the service is
-not pinned.
+In the Aiven Console, if **`karapace_version`** shows a version number, the
+service is set to that version. If the option is not listed or has no value,
+the service is not set to a specific version.
 
 In the CLI output or API response, check `karapace_version` in `user_config`.
-A version number means the service is pinned. If the value is `null` or the
-field is not present, the service is not pinned.
+If it contains a version number, the service is set to that version. If the
+value is `null` or the field is not present, the service is not set to a
+specific version.
 
 ## Related pages
 

--- a/docs/products/kafka/karapace/howto/set-karapace-version.md
+++ b/docs/products/kafka/karapace/howto/set-karapace-version.md
@@ -23,8 +23,13 @@ keeps that version until you change the setting or set it to `null`.
 
 ## Set a Karapace version
 
-Set `karapace_version` to the version you want the service to run. To upgrade
-or roll back, change the setting to another supported version.
+Set `karapace_version` to one of the Karapace versions currently available for
+selection. Aiven makes the two most recent Karapace versions available for
+selection. To upgrade or roll back, change the setting to another version that
+is currently available.
+
+Older Karapace versions can remain supported for services already running them.
+They might no longer be available for version selection.
 
 <Tabs groupId="tool">
 <TabItem value="console" label="Console" default>
@@ -34,7 +39,8 @@ or roll back, change the setting to another supported version.
 1. Click <ConsoleLabel name="service settings"/>.
 1. Click **Advanced configuration** > **Configure**.
 1. Click <ConsoleLabel name="Add config options"/>.
-1. Set **`karapace_version`** to a supported version, for example, `6.2.2`.
+1. Set **`karapace_version`** to a version currently available for selection, for
+   example, `6.2.2`.
 1. Click **Save configuration**.
 
 </TabItem>
@@ -51,7 +57,7 @@ Replace the following:
 
 - `SERVICE_NAME`: name of your Aiven for Apache Kafka service
 - `PROJECT_NAME`: name of your Aiven project
-- `VERSION`: Karapace version to use, for example, `6.2.2`
+- `VERSION`: Karapace version currently available for selection, for example, `6.2.2`
 
 </TabItem>
 <TabItem value="api" label="API">
@@ -71,7 +77,7 @@ Replace the following:
 - `PROJECT_NAME`: name of your Aiven project
 - `SERVICE_NAME`: name of your Aiven for Apache Kafka service
 - `API_TOKEN`: your [Aiven API token](/docs/platform/howto/create_authentication_token)
-- `VERSION`: Karapace version to use, for example, `6.2.2`
+- `VERSION`: Karapace version currently available for selection, for example, `6.2.2`
 
 </TabItem>
 </Tabs>
@@ -80,11 +86,10 @@ Replace the following:
 
 If Aiven returns an error when you set the version, apply a
 [maintenance update](/docs/products/kafka/howto/maintenance-updates#maintenance-updates).
-The update enables Karapace version selection or installs the selected version
-on the service nodes. You can also replace a node to install the required
-version. Then set the version again.
+The update enables Karapace version selection or makes the selected version
+available on the service. Then set the version again.
 
-## Stop using a specific Karapace version
+## Stop using a specific version
 
 Set `karapace_version` to `null` to stop using a specific version. The service
 then uses the latest Karapace version available through maintenance updates.

--- a/docs/products/kafka/karapace/howto/set-karapace-version.md
+++ b/docs/products/kafka/karapace/howto/set-karapace-version.md
@@ -16,17 +16,17 @@ keeps that version until you change the setting or set it to `null`.
 
 ## Prerequisites
 
-- An [Aiven for Apache Kafka® service](/docs/products/kafka/get-started/get-started-kafka)
+- An [Aiven for Apache Kafka service](/docs/products/kafka/get-started/get-started-kafka)
   with Karapace enabled
 - A [maintenance update](/docs/products/kafka/howto/maintenance-updates#maintenance-updates)
   that includes Karapace version selection
 
 ## Set a Karapace version
 
-Set `karapace_version` to one of the Karapace versions currently available for
+Set `karapace_version` to one of the Karapace versions available for
 selection. Aiven makes the two most recent Karapace versions available for
-selection. To upgrade or roll back, change the setting to another version that
-is currently available.
+selection. To upgrade or roll back, change the setting to another available
+version.
 
 Older Karapace versions can remain supported for services already running them.
 They might no longer be available for version selection.
@@ -39,7 +39,7 @@ They might no longer be available for version selection.
 1. Click <ConsoleLabel name="service settings"/>.
 1. Click **Advanced configuration** > **Configure**.
 1. Click <ConsoleLabel name="Add config options"/>.
-1. Set **`karapace_version`** to a version currently available for selection, for
+1. Set **`karapace_version`** to a version available for selection, for
    example, `6.2.2`.
 1. Click **Save configuration**.
 
@@ -57,7 +57,7 @@ Replace the following:
 
 - `SERVICE_NAME`: name of your Aiven for Apache Kafka service
 - `PROJECT_NAME`: name of your Aiven project
-- `VERSION`: Karapace version currently available for selection, for example, `6.2.2`
+- `VERSION`: Karapace version available for selection, for example, `6.2.2`
 
 </TabItem>
 <TabItem value="api" label="API">
@@ -77,7 +77,7 @@ Replace the following:
 - `PROJECT_NAME`: name of your Aiven project
 - `SERVICE_NAME`: name of your Aiven for Apache Kafka service
 - `API_TOKEN`: your [Aiven API token](/docs/platform/howto/create_authentication_token)
-- `VERSION`: Karapace version currently available for selection, for example, `6.2.2`
+- `VERSION`: Karapace version available for selection, for example, `6.2.2`
 
 </TabItem>
 </Tabs>

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -719,7 +719,7 @@ const sidebars: SidebarsConfig = {
               items: [
                 'products/kafka/karapace',
                 'products/kafka/karapace/howto/enable-karapace',
-                'products/kafka/karapace/howto/manage-karapace-version',
+                'products/kafka/karapace/howto/set-karapace-version',
                 {
                   type: 'category',
                   label: 'Schema registry',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -719,6 +719,7 @@ const sidebars: SidebarsConfig = {
               items: [
                 'products/kafka/karapace',
                 'products/kafka/karapace/howto/enable-karapace',
+                'products/kafka/karapace/howto/manage-karapace-version',
                 {
                   type: 'category',
                   label: 'Schema registry',


### PR DESCRIPTION
## Describe your changes

Documents Karapace multiversion support for Aiven for Apache Kafka®. By default,
services use the latest supported Karapace version. You can pin a service to a
specific version. 

Jira: https://aiven.atlassian.net/browse/EC-1368

Preview - https://ec-1368-docs-and-changelog-m.aiven-docs.pages.dev/docs/products/kafka/karapace/howto/set-karapace-version

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](styleguide.md).
- [ ] My links start with `/docs/`.
