### PR TITLE
fix: add scopes to mcp installation steps for AI clients such as Kiro

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -154,7 +154,7 @@ For more information, see the [VS Code MCP documentation](https://code.visualstu
    <MCPConfigSection
      baseUrl={mcpUrl}
      format="json"
-     configTemplate={(url) => ({mcpServers: {aiven: {url}}})}
+     configTemplate={(url) => ({mcpServers: {aiven: {url, oauth: {oauthScopes: ["projects", "services", "accounts:read"]}}}})}
    />
 
    Most clients use a configuration similar to the preceding example.


### PR DESCRIPTION
Kiro requires explicit definition of scopes as part of the MCP oauth process, adding a sample config to the docs.