### PR TITLE
fix: link to runtime from homepage

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -35,15 +35,12 @@ const FeatureList: FeatureItem[] = [
     description: <>Discover our managed services and how to set them up.</>,
   },
   {
-    title: 'Apps',
+    title: 'Runtime applications',
     Svg: require('@site/static/images/icons/home/console.svg').default,
     to: '/docs/products/aiven-apps',
     accent: 'purple',
     description: (
-      <>
-        Connect your Aiven organization with your own cloud account by creating
-        custom clouds.
-      </>
+      <>Run stateless apps within your existing Aiven project infrastructure.</>
     ),
   },
   {


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [ ] My links start with `/docs/`.
