### PR TITLE
fix: Remove incorrect statement about KRaft migration sequencing

### DIFF
--- a/docs/products/kafka/concepts/kraft-mode.md
+++ b/docs/products/kafka/concepts/kraft-mode.md
@@ -57,8 +57,14 @@ not supported.
 
 ### How the migration works
 
-- The migration starts automatically when you upgrade your service to Apache Kafka 3.9
-  in the Aiven Console.
+- If you upgrade your service to Apache Kafka 3.9, the upgrade starts immediately.
+  After all service nodes are running on Apache Kafka 3.9, the KRaft migration starts
+  automatically. The configured
+  [maintenance window](/docs/platform/concepts/maintenance-window) does not affect
+  when the upgrade or migration starts.
+- If Aiven upgrades your service because Apache Kafka 3.8 has reached end of life,
+  the version upgrade starts during the configured maintenance window. The KRaft
+  migration starts after the version upgrade completes.
 - During the upgrade, the service status changes to **Rebuilding**.
 - When the upgrade completes, the service status returns to **Running** and the service
   runs in KRaft mode.

--- a/docs/products/kafka/concepts/kraft-mode.md
+++ b/docs/products/kafka/concepts/kraft-mode.md
@@ -59,8 +59,6 @@ not supported.
 
 - The migration starts automatically when you upgrade your service to Apache Kafka 3.9
   in the Aiven Console.
-- The migration runs during your configured
-  [maintenance window](/docs/platform/concepts/maintenance-window).
 - During the upgrade, the service status changes to **Rebuilding**.
 - When the upgrade completes, the service status returns to **Running** and the service
   runs in KRaft mode.


### PR DESCRIPTION
The docs were stating that KRaft migrations run during maintenance windows, this is not how it works and it directly contradicts the surrounding content. The KRaft migration is run as part of the version upgrade, directly after all nodes in the cluster are running on Kafka 3.9.

## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [ ] My links start with `/docs/`.
