### PR TITLE
update: service management section for Kafka

### DIFF
--- a/docs/products/kafka/concepts/configuration-backup.md
+++ b/docs/products/kafka/concepts/configuration-backup.md
@@ -2,6 +2,9 @@
 title: Configuration backups for Aiven for Apache Kafka®
 sidebar_label: Configuration backups
 ---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
 Aiven for Apache Kafka® includes **configuration backups** that automatically back up key service configurations at no additional cost.
 
 By eliminating the need for manual reconfiguration, Aiven for Apache Kafka® configuration
@@ -47,3 +50,8 @@ While configuration backups offer significant benefits, there are some limitatio
 
 For additional support with configuration backups for your Aiven for Apache Kafka®
 services, contact [support@aiven.io](mailto:support@aiven.io).
+
+<RelatedPages/>
+
+- [Power on/off and delete your Aiven for Apache Kafka® service](/docs/products/kafka/howto/power-cycle-service)
+- [Diskless topics overview](/docs/products/kafka/diskless/concepts/diskless-topic-overview)

--- a/docs/products/kafka/concepts/tiered-storage-limitations.md
+++ b/docs/products/kafka/concepts/tiered-storage-limitations.md
@@ -31,3 +31,4 @@ latency entirely.
 
 - [Tiered storage in Aiven for Apache Kafka® overview](/docs/products/kafka/concepts/kafka-tiered-storage)
 - [Enabled tiered storage for Aiven for Apache Kafka® service](/docs/products/kafka/howto/enable-kafka-tiered-storage)
+- [Power on/off and delete your Aiven for Apache Kafka® service](/docs/products/kafka/howto/power-cycle-service)

--- a/docs/products/kafka/howto/configure-with-kafka-cli.md
+++ b/docs/products/kafka/howto/configure-with-kafka-cli.md
@@ -1,5 +1,6 @@
 ---
 title: Manage configurations with Apache Kafka® CLI tools
+sidebar_label: Manage configurations with Kafka CLI
 ---
 
 Aiven for Apache Kafka® services are fully manageable and customizable via the [Aiven CLI](/docs/tools/cli).

--- a/docs/products/kafka/howto/maintenance-updates.md
+++ b/docs/products/kafka/howto/maintenance-updates.md
@@ -15,6 +15,12 @@ Kafka® service.
 
 <MaintenanceUpdates/>
 
+:::note
+When Aiven releases a mandatory service update for Apache Kafka®, the
+[Kafka upgrade procedure](/docs/products/kafka/concepts/upgrade-procedure) runs
+automatically.
+:::
+
 ## Maintenance window
 
 <MaintenanceWindowConcepts/>

--- a/docs/products/kafka/howto/power-cycle-service.md
+++ b/docs/products/kafka/howto/power-cycle-service.md
@@ -1,0 +1,38 @@
+---
+title: Power on/off and delete your Aiven for Apache Kafka® service
+sidebar_label: Power on/off and delete
+---
+
+import PowerService from "@site/static/includes/power-off-services.md";
+import DeleteService from "@site/static/includes/delete-services.md";
+import StaticIp from "@site/static/includes/static-ip-cost-warning.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Power off your Aiven for Apache Kafka® service to release resources and save credits, power it back on when you need it, or delete it permanently.
+
+<PowerService/>
+
+:::note
+When you power on an Aiven for Apache Kafka service, Aiven restores
+[configuration backups](/docs/products/kafka/concepts/configuration-backup)
+from the most recent backup.
+Aiven does not restore classic topic data, consumer groups, or offsets.
+[Diskless topic](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
+data remains in object storage and is available after you power the service on.
+:::
+
+:::important
+If the service uses [tiered storage](/docs/products/kafka/concepts/kafka-tiered-storage),
+powering off the service permanently deletes all remote data.
+:::
+
+:::note
+<StaticIp/>
+:::
+
+<DeleteService/>
+
+<RelatedPages/>
+
+- [Configuration backups for Aiven for Apache Kafka®](/docs/products/kafka/concepts/configuration-backup)
+- [Trade-offs and limitations](/docs/products/kafka/concepts/tiered-storage-limitations)

--- a/docs/products/kafka/howto/power-cycle-service.md
+++ b/docs/products/kafka/howto/power-cycle-service.md
@@ -16,7 +16,7 @@ Power off your Aiven for Apache Kafka® service to release resources and save cr
 When you power on an Aiven for Apache Kafka service, Aiven restores
 [configuration backups](/docs/products/kafka/concepts/configuration-backup)
 from the most recent backup.
-Aiven does not restore classic topic data, consumer groups, or offsets.
+Configuration backups do not include classic topic data, consumer groups, or offsets.
 [Diskless topic](/docs/products/kafka/diskless/concepts/diskless-topic-overview)
 data remains in object storage and is available after you power the service on.
 :::

--- a/docs/products/kafka/howto/set-kafka-parameters.md
+++ b/docs/products/kafka/howto/set-kafka-parameters.md
@@ -1,5 +1,6 @@
 ---
 title: Manage Apache Kafka® parameters
+sidebar_label: Manage parameters
 ---
 
 Every Aiven for Apache Kafka® service comes with a set of configuration

--- a/docs/products/kafka/howto/tag-service.md
+++ b/docs/products/kafka/howto/tag-service.md
@@ -1,0 +1,16 @@
+---
+title: Tag your Aiven for Apache Kafka® service
+sidebar_label: Tag a service
+---
+
+import TagService from "@site/static/includes/tag-services.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Add key-value tags to your Aiven for Apache Kafka® service to organize services and track ownership, cost allocation, and governance.
+
+<TagService/>
+
+<RelatedPages/>
+
+- [Use resource tags](/docs/platform/howto/tag-resources)
+- [Power on/off and delete your Aiven for Apache Kafka® service](/docs/products/kafka/howto/power-cycle-service)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -831,15 +831,11 @@ const sidebars: SidebarsConfig = {
               type: 'category',
               label: 'Service management',
               items: [
-                {
-                  type: 'category',
-                  label: 'Service operations',
-                  items: [
-                    'products/kafka/howto/configure-custom-domain',
-                    'products/kafka/howto/set-kafka-parameters',
-                    'products/kafka/howto/configure-with-kafka-cli',
-                  ],
-                },
+                'products/kafka/howto/power-cycle-service',
+                'products/kafka/howto/tag-service',
+                'products/kafka/howto/configure-custom-domain',
+                'products/kafka/howto/set-kafka-parameters',
+                'products/kafka/howto/configure-with-kafka-cli',
                 {
                   type: 'category',
                   label: 'Advanced parameters',


### PR DESCRIPTION
## Describe your changes

- Add kafka service management topics from shared includes. 

Preview: https://doc-2000-kafka-service-maint.aiven-docs.pages.dev/docs/products/kafka


## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [ ] My links start with `/docs/`.
