### PR TITLE
update: version lifecycle articles for Kafka and ClickHouse

### DIFF
--- a/docs/products/clickhouse/reference/upgrade-to-26-3.md
+++ b/docs/products/clickhouse/reference/upgrade-to-26-3.md
@@ -316,6 +316,6 @@ Aiven adopts and that can affect workloads.
 
 <RelatedPages/>
 
-- [Aiven for ClickHouse version support policy](/docs/products/clickhouse/reference/version-lifecycle)
+- [Aiven for ClickHouse® version support policy](/docs/products/clickhouse/reference/version-support-policy)
 - [Fork your Aiven for ClickHouse® service](/docs/products/clickhouse/howto/fork-service)
 - [Supported table engines](/docs/products/clickhouse/reference/supported-table-engines)

--- a/docs/products/clickhouse/reference/version-lifecycle.md
+++ b/docs/products/clickhouse/reference/version-lifecycle.md
@@ -1,79 +1,31 @@
 ---
-title: Aiven for ClickHouse® version support policy
-sidebar_label: Version support policy
+title: Aiven for ClickHouse® version lifecycle
+sidebar_label: Version EOL dates
 ---
 
+import EolPolicyMultiVersioned from "@site/static/includes/eol-policy-multi-versioned.md";
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Aiven for ClickHouse® follows the upstream ClickHouse long-term support, or LTS, release model.
-This helps you use stable, supported versions and plan upgrades before versions
-reach end of life.
+Learn how Aiven manages Aiven for ClickHouse® version support, end of life (EOL) dates, and what happens to your service after a version reaches EOL.
 
-Aiven for ClickHouse versions move through defined lifecycle stages, from
-availability to end of life. Each stage determines whether you can create new
-services, receive security updates, or need to plan an upgrade.
+<EolPolicyMultiVersioned/>
 
-## Upstream LTS releases
+## Version EOL dates
 
-Upstream ClickHouse typically releases two LTS versions each year, one in March
-and one in August. The March release uses the `.3` prefix, and the August
-release uses the `.8` prefix.
+The following table lists the EOL and service creation dates for supported
+Aiven for ClickHouse versions. For the long-term support release model, lifecycle
+stages, and security updates, see
+[Aiven for ClickHouse version support policy](/docs/products/clickhouse/reference/version-support-policy).
 
-Upstream LTS versions receive security updates for 12 months.
-
-## Lifecycle stages
-
-Each Aiven for ClickHouse LTS version moves through the following stages:
-
-- **Limited Availability (LA):** The version is available for selected early
-  testing. LA versions are not publicly announced.
-- **Early Availability (EA):** The version is stable and available to all customers.
-  Some settings, features, and UI elements might still change.
-- **General Availability (GA):** The version is stable and fully available.
-- **End of Availability (EOA):** You can no longer create new services with the
-  version. Aiven doesn't guarantee security updates after EOA. EOA starts 3
-  months before End of Life.
-- **End of Life (EOL):** Aiven removes the version from support and
-  automatically upgrades existing services to the next supported version.
-
-## Support policy
-
-Aiven supports two active generally available LTS versions at a time.
-
-New LTS versions become available on Aiven:
-
-- As EA approximately three months after the upstream release.
-- As GA approximately four months after the upstream release.
-
-Aiven announces new EA and GA versions in the
-[Aiven changelog](https://aiven.io/changelog?services=ClickHouse%2CClickHouse%25C2%25AE).
-
-When a new version becomes available, new service creation stops for the oldest
-supported version, and that version enters EOA. EOL follows 3 months later. After
-EOL, Aiven automatically upgrades services running that version to the next
-supported version.
-
-## Security updates
-
-Aiven provides security updates for LTS versions until their EOA date. After EOA,
-Aiven doesn't guarantee security updates.
-
-Aiven delivers security updates as maintenance updates that you can apply during
-the [maintenance window](/docs/platform/concepts/maintenance-window). If you
-don't apply a patch for a critical vulnerability within 14 days, Aiven applies
-it automatically.
-
-## Version lifecycle dates
-
-For End of Availability, End of Life, and new service creation dates for
-supported Aiven for ClickHouse versions, see the
-[Aiven for ClickHouse EOL dates](/docs/platform/reference/eol-for-major-versions#aiven-for-clickhouse)
-in the Aiven service and tool version lifecycle reference.
+| Version | Aiven EOL  | Service creation supported until | Service creation supported from |
+| ------- | ---------- | -------------------------------- | ------------------------------- |
+| 25.3    | 2026-09-30 | 2026-08-17                       | 2025-12-15                      |
+| 25.8    | 2027-02-28 | 2026-11-30                       | 2026-03-25                      |
+| 26.3    | 2027-09-15 | 2027-06-15                       | 2026-08-01                      |
 
 <RelatedPages/>
 
-- [Aiven for ClickHouse EOL dates](/docs/platform/reference/eol-for-major-versions#aiven-for-clickhouse)
+- [Manage Aiven for ClickHouse® versions](/docs/products/clickhouse/howto/manage-clickhouse-versions)
 - [Upgrade to Aiven for ClickHouse 26.3](/docs/products/clickhouse/reference/upgrade-to-26-3)
-- [Service and feature releases](/docs/platform/concepts/service-and-feature-releases)
+- [Service forking](/docs/platform/concepts/service-forking)
 - [Maintenance window](/docs/platform/concepts/maintenance-window)
-- [Fork your Aiven for ClickHouse® service](/docs/products/clickhouse/howto/fork-service)

--- a/docs/products/clickhouse/reference/version-support-policy.md
+++ b/docs/products/clickhouse/reference/version-support-policy.md
@@ -1,0 +1,77 @@
+---
+title: Aiven for ClickHouse® version support policy
+sidebar_label: Version support policy
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Aiven for ClickHouse® follows the upstream ClickHouse long-term support, or LTS, release model.
+This helps you use stable, supported versions and plan upgrades before versions
+reach end of life.
+
+Aiven for ClickHouse versions move through defined lifecycle stages, from
+availability to end of life. Each stage determines whether you can create new
+services, receive security updates, or need to plan an upgrade.
+
+## Upstream LTS releases
+
+Upstream ClickHouse typically releases two LTS versions each year, one in March
+and one in August. The March release uses the `.3` prefix, and the August
+release uses the `.8` prefix.
+
+Upstream LTS versions receive security updates for 12 months.
+
+## Lifecycle stages
+
+Each Aiven for ClickHouse LTS version moves through the following stages:
+
+- **Limited Availability (LA):** The version is available for selected early
+  testing. LA versions are not publicly announced.
+- **Early Availability (EA):** The version is stable and available to all customers.
+  Some settings, features, and UI elements might still change.
+- **General Availability (GA):** The version is stable and fully available.
+- **End of Availability (EOA):** You can no longer create new services with the
+  version. Aiven doesn't guarantee security updates after EOA. EOA starts 3
+  months before End of Life.
+- **End of Life (EOL):** Aiven removes the version from support and
+  automatically upgrades existing services to the next supported version.
+
+## Support policy
+
+Aiven supports two active generally available LTS versions at a time.
+
+New LTS versions become available on Aiven:
+
+- As EA approximately three months after the upstream release.
+- As GA approximately four months after the upstream release.
+
+Aiven announces new EA and GA versions in the
+[Aiven changelog](https://aiven.io/changelog?services=ClickHouse%2CClickHouse%25C2%25AE).
+
+When a new version becomes available, new service creation stops for the oldest
+supported version, and that version enters EOA. EOL follows 3 months later. After
+EOL, Aiven automatically upgrades services running that version to the next
+supported version.
+
+## Security updates
+
+Aiven provides security updates for LTS versions until their EOA date. After EOA,
+Aiven doesn't guarantee security updates.
+
+Aiven delivers security updates as maintenance updates that you can apply during
+the [maintenance window](/docs/platform/concepts/maintenance-window). If you
+don't apply a patch for a critical vulnerability within 14 days, Aiven applies
+it automatically.
+
+## Version lifecycle dates
+
+For EOA, EOL, and new service creation dates for supported Aiven for ClickHouse
+versions, see
+[Aiven for ClickHouse version lifecycle](/docs/products/clickhouse/reference/version-lifecycle).
+
+<RelatedPages/>
+
+- [Manage Aiven for ClickHouse® versions](/docs/products/clickhouse/howto/manage-clickhouse-versions)
+- [Upgrade to Aiven for ClickHouse 26.3](/docs/products/clickhouse/reference/upgrade-to-26-3)
+- [Service and feature releases](/docs/platform/concepts/service-and-feature-releases)
+- [Fork your Aiven for ClickHouse® service](/docs/products/clickhouse/howto/fork-service)

--- a/docs/products/kafka/reference/version-lifecycle.md
+++ b/docs/products/kafka/reference/version-lifecycle.md
@@ -1,0 +1,43 @@
+---
+title: Aiven for Apache Kafka® version lifecycle
+sidebar_label: Version lifecycle
+---
+
+import EolPolicyMultiVersioned from "@site/static/includes/eol-policy-multi-versioned.md";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Learn how Aiven manages Aiven for Apache Kafka® version support, end of life (EOL) dates, and what happens to your service after a version reaches EOL.
+
+<EolPolicyMultiVersioned/>
+
+## Version EOL dates
+
+Aiven for Apache Kafka versions reach EOL one year after they become available on the
+Aiven Platform.
+
+| Version | Aiven EOL  | Service creation supported until | Service creation supported from |
+| ------- | ---------- | -------------------------------- | ------------------------------- |
+| 3.8.x   | 2026-09-30 | 2026-06-30                       | 2024-09-06                      |
+| 3.9.x   | 2027-09-30 | 2027-06-30                       | 2025-03-20                      |
+| 4.0.x   | 2026-09-18 | 2026-06-18                       | 2025-09-18                      |
+| 4.1.x   | 2027-01-31 | 2026-09-10                       | 2025-12-10                      |
+| 4.2.x   | 2027-06-15 | 2027-03-15                       | 2026-06-15                      |
+
+:::note
+Apache Kafka 3.8 is the last version that supports ZooKeeper.
+
+Starting with Apache Kafka 3.9, Aiven for Apache Kafka uses KRaft (Kafka Raft) to manage
+metadata and controllers instead of ZooKeeper. For details about the migration process
+and rollout limitations, see:
+
+- [KRaft in Aiven for Apache Kafka®](/docs/products/kafka/concepts/kraft-mode)
+- [Transitioning to KRaft](/docs/products/kafka/concepts/upgrade-procedure#transitioning-to-kraft)
+
+To support the transition to KRaft, Aiven supports Apache Kafka 3.8 until the EOL date
+shown in the table. The EOL date already includes the extended support period.
+:::
+
+<RelatedPages/>
+
+- [Apache Kafka® upgrade procedure](/docs/products/kafka/concepts/upgrade-procedure)
+- [Maintenance window](/docs/platform/concepts/maintenance-window)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -926,6 +926,7 @@ const sidebars: SidebarsConfig = {
               items: [
                 'products/kafka/howto/maintenance-updates',
                 'products/kafka/concepts/upgrade-procedure',
+                'products/kafka/reference/version-lifecycle',
               ],
             },
             {
@@ -1379,10 +1380,11 @@ const sidebars: SidebarsConfig = {
               type: 'category',
               label: 'Maintenance and lifecycle',
               items: [
-                'products/clickhouse/reference/version-lifecycle',
                 'products/clickhouse/howto/manage-clickhouse-versions',
                 'products/clickhouse/reference/upgrade-to-26-3',
                 'products/clickhouse/reference/25-8-default-settings',
+                'products/clickhouse/reference/version-support-policy',
+                'products/clickhouse/reference/version-lifecycle',
               ],
             },
             {


### PR DESCRIPTION
## Describe your changes

Add a service-specific version lifecycle article for Aiven for Apache Kafka and ClickHouse. 

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [ ] My links start with `/docs/`.
