### PR TITLE
update: ignore content in backticks in Vale

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -10,7 +10,7 @@ mdx = md
 
 [*.{md,mdx}]
 BlockIgnores = (?s)(^---$.*^---$)
-TokenIgnores = (import\s+.*?from\s+['"].*?['"];?)
+TokenIgnores = (import\s+.*?from\s+['"].*?['"];?)|(\`[^\`]*\`)
 BasedOnStyles = Google, Aiven
 Google.Acronyms = NO
 Google.Contractions = NO


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [ ] My links start with `/docs/`.
