### PR TITLE
update: BYOC diskless metadata service tags

### DIFF
--- a/docs/products/kafka/diskless/concepts/limitations.md
+++ b/docs/products/kafka/diskless/concepts/limitations.md
@@ -35,11 +35,10 @@ console or billing.
 In BYOC deployments, enabling diskless topics automatically creates an
 Aiven for PostgreSQL® service in the project. This PostgreSQL service:
 
-- Is required for diskless topics to function.
 - Stores metadata required for diskless topics.
 - Appears as a separate service in the project.
 - Is created and managed automatically by Aiven.
-- Do not configure or manage independently.
+- Inherits tags from the linked Kafka service.
 
 ### Maintenance behavior
 

--- a/docs/products/kafka/get-started/create-kafka-service-byoc.md
+++ b/docs/products/kafka/get-started/create-kafka-service-byoc.md
@@ -111,8 +111,9 @@ Replace `INKLESS_PLAN_NAME` with a plan such as `business-8-inkless`.
 </TabItem>
 </Tabs>
 
-For more information about diskless topics, see
-[Diskless topics for Apache Kafka®](/docs/products/kafka/diskless/concepts/diskless-topic-overview).
+Enabling diskless topics creates an Aiven for PostgreSQL® service in the project.
+For details, see
+[Diskless topic limitations and behavior](/docs/products/kafka/diskless/concepts/limitations#internal-metadata-service).
 
 ## Request BYOC access {#request-byoc-access}
 


### PR DESCRIPTION
## Describe your changes

BYOC diskless PostgreSQL service inherits tags from the linked Kafka service, and link to that from the BYOC create page.

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [ ] My links start with `/docs/`.
