### PR TITLE
update: fix ClickHouse materialized views diagram

### DIFF
--- a/docs/products/clickhouse/howto/materialized-views.md
+++ b/docs/products/clickhouse/howto/materialized-views.md
@@ -26,9 +26,9 @@ diagram:
 ```mermaid
 flowchart LR
   a[Kafka topic]
-  b{{Kafka table engine}}
+  b[Kafka table engine]
   c[Materialized view]
-  d{{Merge Tree<br /> family table}}
+  d[Merge Tree family table]
   a --> b --> c --> d
 ```
 


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [ ] My links start with `/docs/`.
