### PR TITLE
update: remove LA tag from Runtime docs

### DIFF
--- a/docs/products/runtime.md
+++ b/docs/products/runtime.md
@@ -1,7 +1,6 @@
 ---
 title: Aiven Runtime overview
 sidebar_label: Overview
-limited: true
 ---
 
 Aiven Runtime lets you deploy and run containerized applications directly within your existing Aiven project infrastructure.
@@ -9,12 +8,6 @@ This means you can host your applications where your data is.
 Aiven automatically handles the underlying networking,
 and container orchestration, enabling developers to focus on application logic
 rather than DevOps overhead.
-
-:::note
-Aiven Runtime is in
-[limited availability](/docs/platform/concepts/service-and-feature-releases).
-To request access, [contact Aiven](https://aiven.io/apps#contact-us).
-:::
 
 ## Key features
 Aiven Runtime offers the following capabilities to streamline your development lifecycle:

--- a/docs/products/runtime/change-cloud.md
+++ b/docs/products/runtime/change-cloud.md
@@ -1,7 +1,6 @@
 ---
 title: Change cloud for Aiven Runtime
 sidebar_label: Change cloud
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";

--- a/docs/products/runtime/connect-services-to-apps.md
+++ b/docs/products/runtime/connect-services-to-apps.md
@@ -1,7 +1,6 @@
 ---
 title: Connect services to Aiven Runtime
 sidebar_label: Connect services
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";

--- a/docs/products/runtime/custom-domain.md
+++ b/docs/products/runtime/custom-domain.md
@@ -1,7 +1,6 @@
 ---
 title: Connect a custom domain to an Aiven Runtime
 sidebar_label: Connect a custom domain
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons"

--- a/docs/products/runtime/deploy-apps.md
+++ b/docs/products/runtime/deploy-apps.md
@@ -1,6 +1,5 @@
 ---
 title: Deploy an application
-limited: true
 ---
 
 import {ConsoleIcon} from "@site/src/components/ConsoleIcons";

--- a/docs/products/runtime/deployment-information.md
+++ b/docs/products/runtime/deployment-information.md
@@ -1,6 +1,5 @@
 ---
 title: Change branch
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons"

--- a/docs/products/runtime/manifest-files/compose-files.md
+++ b/docs/products/runtime/manifest-files/compose-files.md
@@ -1,7 +1,6 @@
 ---
 title: Create Compose files for Aiven Runtime
 sidebar_label: Create Compose files
-limited: true
 ---
 
 import RelatedPages from "@site/src/components/RelatedPages";

--- a/docs/products/runtime/manifest-files/containerfiles.md
+++ b/docs/products/runtime/manifest-files/containerfiles.md
@@ -1,7 +1,6 @@
 ---
 title: Create Containerfiles and Dockerfiles for Aiven Runtime
 sidebar_label: Create Containerfiles and Dockerfiles
-limited: true
 ---
 
 import EnvVarMerging from "@site/static/includes/manifest-env-var-merging.md";

--- a/docs/products/runtime/manifest-files/manifests.md
+++ b/docs/products/runtime/manifest-files/manifests.md
@@ -1,7 +1,6 @@
 ---
 title: Manifest files for Aiven Runtime
 sidebar_label: Overview
-limited: true
 ---
 
 Aiven Runtime uses container manifests to understand how to build and deploy your applications. You can define applications using two types of container manifests that work together to create complete solutions.

--- a/docs/products/runtime/ports.md
+++ b/docs/products/runtime/ports.md
@@ -1,7 +1,6 @@
 ---
 title: Manage ports for Aiven Runtime
 sidebar_label: Manage ports
-limited: true
 ---
 
 import {ConsoleIcon} from "@site/src/components/ConsoleIcons";

--- a/docs/products/runtime/power-off-apps.md
+++ b/docs/products/runtime/power-off-apps.md
@@ -1,7 +1,6 @@
 ---
 title: Power off Aiven Runtime applications
 sidebar_label: Power off applications
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";

--- a/docs/products/runtime/scale-apps.md
+++ b/docs/products/runtime/scale-apps.md
@@ -1,7 +1,6 @@
 ---
 title: Change application plan for Aiven Runtime
 sidebar_label: Change application plan
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons"

--- a/docs/products/runtime/secrets-and-variables.md
+++ b/docs/products/runtime/secrets-and-variables.md
@@ -1,7 +1,6 @@
 ---
 title: Manage secrets and environment variables for Aiven Runtime
 sidebar_label: Manage secrets and variables
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons"


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [ ] My links start with `/docs/`.
