### PR TITLE
update: remove LA tag from DataHub docs

### DIFF
--- a/docs/products/datahub.md
+++ b/docs/products/datahub.md
@@ -1,6 +1,5 @@
 ---
 title: Aiven for DataHub
-limited: true
 ---
 
 Aiven for [DataHub](https://docs.datahub.com/docs/features) is a cost-effective data catalog that integrates seamlessly with Aiven services.
@@ -13,12 +12,6 @@ reduce operational overhead.
 
 You can [add an unlimited number of users](/docs/products/datahub/manage-datahub-users)
 with no per-user licensing costs.
-
-:::note
-Aiven for DataHub is in
-[limited availability](/docs/platform/concepts/service-and-feature-releases#limited-availability-).
-To request access, [contact Aiven](https://aiven.io/datahub#contact-us).
-:::
 
 ## Features
 

--- a/docs/products/datahub/change-cloud.md
+++ b/docs/products/datahub/change-cloud.md
@@ -1,7 +1,6 @@
 ---
 title: Change cloud for Aiven for DataHub
 sidebar_label: Change cloud
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";

--- a/docs/products/datahub/configure-slack-notifications.md
+++ b/docs/products/datahub/configure-slack-notifications.md
@@ -1,7 +1,6 @@
 ---
 title: Configure Slack notifications for DataHub activity
 sidebar_label: Configure Slack notifications
-limited: true
 ---
 
 import RelatedPages from "@site/src/components/RelatedPages";

--- a/docs/products/datahub/configure-teams-notifications.md
+++ b/docs/products/datahub/configure-teams-notifications.md
@@ -1,7 +1,6 @@
 ---
 title: Configure Teams notifications for DataHub activity
 sidebar_label: Configure Teams notifications
-limited: true
 ---
 
 import RelatedPages from "@site/src/components/RelatedPages";

--- a/docs/products/datahub/connect-datahub-to-services.md
+++ b/docs/products/datahub/connect-datahub-to-services.md
@@ -1,6 +1,5 @@
 ---
 title: Connect DataHub to services
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";

--- a/docs/products/datahub/datahub-lineage.md
+++ b/docs/products/datahub/datahub-lineage.md
@@ -1,7 +1,6 @@
 ---
 title: View data lineage in DataHub
 sidebar_label: View data lineage
-limited: true
 ---
 
 Data lineage is a map of how each of your data assets moves across your systems. Lineage can help you:

--- a/docs/products/datahub/datahub-mcp-server.md
+++ b/docs/products/datahub/datahub-mcp-server.md
@@ -2,7 +2,7 @@
 title: Use the DataHub MCP server
 ---
 
-Use the DataHub MCP server to empower AI agents with deep visibility into your data ecosystem, enabling natural language search, end-to-end lineage tracking, and context-aware SQL generation.
+Make your data ecosystem visible to AI agents with the DataHub MCP server, enabling natural language search, end-to-end lineage tracking, and context-aware SQL generation.
 
 ## Prerequisites
 

--- a/docs/products/datahub/datahub-mcp-server.md
+++ b/docs/products/datahub/datahub-mcp-server.md
@@ -1,6 +1,5 @@
 ---
 title: Use the DataHub MCP server
-limited: true
 ---
 
 Use the DataHub MCP server to empower AI agents with deep visibility into your data ecosystem, enabling natural language search, end-to-end lineage tracking, and context-aware SQL generation.

--- a/docs/products/datahub/delete-service.md
+++ b/docs/products/datahub/delete-service.md
@@ -1,12 +1,12 @@
 ---
 title: Delete an Aiven for DataHub service
 sidebar_label: Delete service
-limited: true
 ---
 
 import DeleteService from "@site/static/includes/delete-services.md"
 
-When you delete an Aiven for DataHub service, all service data and configuration are permanently deleted.
+When you delete an Aiven for DataHub service, all service data and configuration are permanently deleted.
+
 The underlying Aiven for Apache Kafka®, Aiven for OpenSearch®
 and Aiven for PostgreSQL® services are also deleted at the same time.
 

--- a/docs/products/datahub/enable-oidc-auth-datahub.md
+++ b/docs/products/datahub/enable-oidc-auth-datahub.md
@@ -1,7 +1,6 @@
 ---
 title: Enable OIDC authentication for Aiven for DataHub
 sidebar_label: Enable OIDC authentication
-limited: true
 ---
 
 import RelatedPages from "@site/src/components/RelatedPages";

--- a/docs/products/datahub/fork-datahub-service.md
+++ b/docs/products/datahub/fork-datahub-service.md
@@ -1,6 +1,5 @@
 ---
 title: Fork DataHub services
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";

--- a/docs/products/datahub/get-started.md
+++ b/docs/products/datahub/get-started.md
@@ -1,7 +1,6 @@
 ---
 title: Get started with Aiven for DataHub
 sidebar_label: Get started
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";

--- a/docs/products/datahub/maintenance-updates.md
+++ b/docs/products/datahub/maintenance-updates.md
@@ -1,7 +1,6 @@
 ---
 title: Maintenance updates for Aiven for DataHub
 sidebar_label: Maintenance updates
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";

--- a/docs/products/datahub/manage-datahub-users.md
+++ b/docs/products/datahub/manage-datahub-users.md
@@ -1,7 +1,6 @@
 ---
 title: Manage DataHub users
 sidebar_label: Manage users
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";

--- a/docs/products/datahub/power-off-service.md
+++ b/docs/products/datahub/power-off-service.md
@@ -1,7 +1,6 @@
 ---
 title: Power an Aiven for DataHub service off or on
 sidebar_label: Power off or on
-limited: true
 ---
 
 import PowerOffOnService from "@site/static/includes/power-off-services.md"

--- a/docs/products/datahub/restore-datahub-indices.md
+++ b/docs/products/datahub/restore-datahub-indices.md
@@ -1,7 +1,6 @@
 ---
 title: Reindex Aiven for DataHub search and graph indices
 sidebar_label: Reindex search and graph indices
-limited: true
 ---
 
 Rebuild your OpenSearch indices for search and graph data if your search results or relationship graphs differ from the data in your metadata database.

--- a/docs/products/datahub/rotate-secrets.md
+++ b/docs/products/datahub/rotate-secrets.md
@@ -1,7 +1,6 @@
 ---
 title: Rotate Aiven for DataHub secrets
 sidebar_label: Rotate secrets
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";

--- a/docs/products/datahub/scale-datahub-service.md
+++ b/docs/products/datahub/scale-datahub-service.md
@@ -1,7 +1,6 @@
 ---
 title: Scale Aiven for DataHub services
 sidebar_label: Scale DataHub services
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";

--- a/docs/products/datahub/tag-services.md
+++ b/docs/products/datahub/tag-services.md
@@ -1,7 +1,6 @@
 ---
 title: Tag Aiven for DataHub services
 sidebar_label: Tag services
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";

--- a/docs/products/datahub/upgrade-datahub-version.md
+++ b/docs/products/datahub/upgrade-datahub-version.md
@@ -1,7 +1,6 @@
 ---
 title: Upgrade Aiven for DataHub
 sidebar_label: Upgrade DataHub
-limited: true
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [ ] My links start with `/docs/`.
