### PR TITLE
feat: add managed Agents documentation

### DIFF
--- a/.github/vale/styles/config/vocabularies/Aiven/accept.txt
+++ b/.github/vale/styles/config/vocabularies/Aiven/accept.txt
@@ -208,6 +208,7 @@ Java
 java_lang_Memory
 JMX
 JobManager
+Jira
 Jolokia
 jq
 json

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -20,6 +20,13 @@ use case.
 
 <GridContainer columns={2}>
   <Card
+    to="/docs/tools/agents"
+    iconComponent={AI}
+    titleHighlight="var(--aiven-brand-teal)"
+    title="Aiven Agents"
+    description="Create and run agents on the Aiven Platform."
+  />
+  <Card
     to="#connect-ai-agents-and-tools-to-aiven"
     iconComponent={AI}
     titleHighlight="var(--aiven-brand-teal)"
@@ -34,6 +41,15 @@ use case.
     description="Use vector search, query optimization, and SQL generation built into supported Aiven services."
   />
 </GridContainer>
+
+## Run agents on Aiven
+
+Create agents on the Aiven Platform, connect the tools they need, and run them on demand
+or on a schedule.
+
+| Tool | What you can do | Get started |
+| --- | --- | --- |
+| Aiven Agents <LimitedBadge/> | Create agents, connect MCP integrations, and run agents on demand or on a schedule | [Aiven Agents](/docs/tools/agents) |
 
 ## Connect AI agents and tools to Aiven
 

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -23,7 +23,7 @@ use case.
     to="/docs/tools/agents"
     iconComponent={AI}
     titleHighlight="var(--aiven-brand-teal)"
-    title="Aiven Agents"
+    title="Managed Agents"
     description="Create and run agents on the Aiven Platform."
   />
   <Card
@@ -49,7 +49,7 @@ or on a schedule.
 
 | Tool | What you can do | Get started |
 | --- | --- | --- |
-| Aiven Agents <LimitedBadge/> | Create agents, connect MCP integrations, and run agents on demand or on a schedule | [Aiven Agents](/docs/tools/agents) |
+| Managed Agents <LimitedBadge/> | Create agents, connect MCP integrations, and run agents on demand or on a schedule | [Managed Agents](/docs/tools/agents) |
 
 ## Connect AI agents and tools to Aiven
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -54,7 +54,7 @@ You can interact with the Aiven platform with various interfaces and tools that 
     <Card
         to="/docs/tools/agents"
         iconComponent={AI}
-        title="Aiven Agents"
+        title="Managed Agents"
         description="Create and run agents on the Aiven Platform."
     />
 </GridContainer>

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -51,4 +51,10 @@ You can interact with the Aiven platform with various interfaces and tools that 
         title="Aiven MCP"
         description="Manage Aiven services and access documentation from AI-powered coding assistants."
     />
+    <Card
+        to="/docs/tools/agents"
+        iconComponent={AI}
+        title="Aiven Agents"
+        description="Create and run agents on the Aiven Platform."
+    />
 </GridContainer>

--- a/docs/tools/agents.md
+++ b/docs/tools/agents.md
@@ -90,13 +90,6 @@ a daily schedule that asks the agent to summarize service health.
 - [Manage an agent](/docs/tools/agents/manage-agent)
 - [Manage integrations](/docs/tools/agents/manage-integrations)
 
-:::caution
-You are interacting with AI. Agents can make mistakes and take actions
-through connected tools, including scheduled actions. Don't enter secrets or
-data you aren't authorized to share. Agents are free for a limited time.
-To get started, add a payment method. You aren't charged.
-:::
-
 <RelatedPages/>
 
 - [AI tools on Aiven](/docs/ai-features)

--- a/docs/tools/agents.md
+++ b/docs/tools/agents.md
@@ -95,9 +95,9 @@ a daily schedule that asks the agent to summarize service health.
 
 - [Create an agent](/docs/tools/agents/create-agent)
 - [Chat with an agent](/docs/tools/agents/chat-with-agent)
+- [Schedule an agent](/docs/tools/agents/schedule-agent)
 - [Manage an agent](/docs/tools/agents/manage-agent)
 - [Manage integrations](/docs/tools/agents/manage-integrations)
-- [Schedule an agent](/docs/tools/agents/schedule-agent)
 
 <RelatedPages/>
 

--- a/docs/tools/agents.md
+++ b/docs/tools/agents.md
@@ -1,0 +1,94 @@
+---
+title: Aiven Agents
+sidebar_label: Aiven Agents
+description: Create and run AI agents on the Aiven Platform with built-in tools and MCP integrations.
+limited: true
+keywords: [Aiven Agents, Agents, MCP, Model Context Protocol]
+---
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Aiven Agents lets you create and run AI agents on the Aiven Platform.
+Agents can use connected tools to gather information, investigate issues, and perform
+tasks across Aiven and other systems.
+
+You define what an agent should do, choose the AI model it uses, and give it access
+to the tools it needs. You can interact with an agent in a chat or configure
+scheduled tasks to run automatically. Aiven manages the infrastructure required to
+run the agent.
+
+:::note
+Aiven Agents is in
+[limited availability](/docs/platform/concepts/service-and-feature-releases#limited-availability-).
+You need access for each project. In the project, click
+<ConsoleLabel name="agents"/> > **Request access**.
+:::
+
+## Example uses
+
+Use agents for tasks that involve gathering information, analyzing it, and taking
+actions through connected tools.
+
+For example, you can create an agent to:
+
+- Review Aiven for PostgreSQL® logs, summarize the findings, and send an update to Slack.
+- Monitor Aiven for Apache Kafka® consumer lag and create a Jira issue when the lag
+  requires action.
+- Investigate an incident using information from multiple systems and summarize the
+  findings.
+- Run recurring operational checks and report the results to your team.
+
+What an agent can do depends on its system instructions, AI model, and available
+tools and integrations.
+
+## How Aiven Agents works
+
+You configure an agent with:
+
+- **System instructions** that define what the agent does and how it behaves.
+- **An AI model** that processes the agent's instructions and requests.
+- **Tools and integrations** that give the agent access to information and external
+  systems.
+- **Schedules** that let the agent perform recurring tasks automatically.
+
+You can also start a chat with an agent to give it a task or ask follow-up
+questions.
+
+## Tools and integrations
+
+Agents can use built-in tools such as **Web Fetch** and **Web Search**.
+
+You can also connect an agent to Aiven through
+[Aiven MCP](/docs/tools/mcp-server), or add other MCP integrations. You choose
+which tools each agent can use. For Aiven MCP, you grant access to services in
+the current project and assign an MCP role. You can grant any role up to your
+own. Aiven creates a scoped token automatically.
+
+Aiven MCP can also connect external AI assistants, such as Cursor, to your Aiven
+services. That is a separate setup from running agents on the Aiven Platform.
+
+## Run agents interactively or on a schedule
+
+You can use an agent in two ways:
+
+- [Chat with an agent](/docs/tools/agents/chat-with-agent) to send requests when
+  needed.
+- [Schedule an agent](/docs/tools/agents/schedule-agent) to run tasks
+  automatically at a specified time or interval.
+
+For example, you can use chat to investigate an incident as it happens, or create
+a daily schedule that asks the agent to summarize service health.
+
+## Next steps
+
+- [Create an agent](/docs/tools/agents/create-agent)
+- [Chat with an agent](/docs/tools/agents/chat-with-agent)
+- [Manage an agent](/docs/tools/agents/manage-agent)
+- [Manage integrations](/docs/tools/agents/manage-integrations)
+- [Schedule an agent](/docs/tools/agents/schedule-agent)
+
+<RelatedPages/>
+
+- [AI tools on Aiven](/docs/ai-features)
+- [Aiven MCP](/docs/tools/mcp-server)

--- a/docs/tools/agents.md
+++ b/docs/tools/agents.md
@@ -13,7 +13,7 @@ Managed Agents lets you create and run AI agents on the Aiven Platform.
 Agents can use connected tools to gather information, investigate issues, and perform
 tasks across Aiven and other systems.
 
-You define what an agent should do, choose the AI model it uses, and give it access
+You define what an agent does, choose the AI model it uses, and give it access
 to the tools it needs. You can interact with an agent in a chat or configure
 scheduled tasks to run automatically. Aiven manages the infrastructure required to
 run the agent.
@@ -22,24 +22,16 @@ run the agent.
 Managed Agents is in
 [limited availability](/docs/platform/concepts/service-and-feature-releases#limited-availability-).
 You need access for each project. In the project, click
-<ConsoleLabel name="agents"/> > **Request access**. Once access is granted,
-select **Enable agents**. To run Managed Agents in a project VPC, select
+<ConsoleLabel name="agents"/> > **Request access**. After you have access,
+click **Enable agents**. To run Managed Agents in a project VPC, click
 **Enable in VPC**.
-
-Managed Agents is free during limited availability. A payment method is
-required to get started. You are not charged for using Managed Agents.
-:::
-
-:::caution
-You are interacting with AI. Agents can make mistakes and take actions
-through connected tools, including scheduled actions. Don't enter secrets or
-data you aren't authorized to share.
 :::
 
 ## Example uses
 
 Use agents for tasks that involve gathering information, analyzing it, and taking
-actions through connected tools.
+actions through connected tools. Run these tasks on demand or
+[on a schedule](/docs/tools/agents/schedule-agent).
 
 For example, you can create an agent to:
 
@@ -71,13 +63,12 @@ questions.
 Agents can use built-in tools such as **Web Fetch** and **Web Search**.
 
 You can also connect an agent to Aiven through
-[Aiven MCP](/docs/tools/mcp-server), or add other MCP integrations. You choose
-which tools each agent can use. For Aiven MCP, you grant access to services in
-the current project and assign an MCP role. You can grant any role up to your
-own. Aiven creates a scoped token automatically.
+[Aiven MCP](/docs/tools/mcp-server), or add other MCP integrations such as
+Slack, GitHub, and Jira. You choose which tools each agent can use.
 
-Aiven MCP can also connect external AI assistants, such as Cursor, to your Aiven
-services. That is a separate setup from running agents on the Aiven Platform.
+When you connect Aiven MCP, you grant access to services in the current project
+and assign an MCP role. You can grant any role up to your own. Aiven creates a
+scoped token automatically.
 
 ## Run agents interactively or on a schedule
 
@@ -98,6 +89,13 @@ a daily schedule that asks the agent to summarize service health.
 - [Schedule an agent](/docs/tools/agents/schedule-agent)
 - [Manage an agent](/docs/tools/agents/manage-agent)
 - [Manage integrations](/docs/tools/agents/manage-integrations)
+
+:::caution
+You are interacting with AI. Agents can make mistakes and take actions
+through connected tools, including scheduled actions. Don't enter secrets or
+data you aren't authorized to share. Agents are free for a limited time.
+To get started, add a payment method. You aren't charged.
+:::
 
 <RelatedPages/>
 

--- a/docs/tools/agents.md
+++ b/docs/tools/agents.md
@@ -1,15 +1,15 @@
 ---
-title: Aiven Agents
-sidebar_label: Aiven Agents
+title: Managed Agents
+sidebar_label: Managed Agents
 description: Create and run AI agents on the Aiven Platform with built-in tools and MCP integrations.
 limited: true
-keywords: [Aiven Agents, Agents, MCP, Model Context Protocol]
+keywords: [Managed Agents, Agents, MCP, Model Context Protocol]
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Aiven Agents lets you create and run AI agents on the Aiven Platform.
+Managed Agents lets you create and run AI agents on the Aiven Platform.
 Agents can use connected tools to gather information, investigate issues, and perform
 tasks across Aiven and other systems.
 
@@ -19,10 +19,21 @@ scheduled tasks to run automatically. Aiven manages the infrastructure required 
 run the agent.
 
 :::note
-Aiven Agents is in
+Managed Agents is in
 [limited availability](/docs/platform/concepts/service-and-feature-releases#limited-availability-).
 You need access for each project. In the project, click
-<ConsoleLabel name="agents"/> > **Request access**.
+<ConsoleLabel name="agents"/> > **Request access**. Once access is granted,
+select **Enable agents**, or **Enable in VPC** to deploy agents and their
+database in a project VPC.
+
+Agents are free for a limited time. A payment method is required to get
+started, and you won't be charged.
+:::
+
+:::caution
+You are interacting with AI. Agents can make mistakes and take actions
+through connected tools, including scheduled actions. Don't enter secrets or
+data you aren't authorized to share.
 :::
 
 ## Example uses
@@ -42,7 +53,7 @@ For example, you can create an agent to:
 What an agent can do depends on its system instructions, AI model, and available
 tools and integrations.
 
-## How Aiven Agents works
+## How Managed Agents works
 
 You configure an agent with:
 
@@ -72,8 +83,8 @@ services. That is a separate setup from running agents on the Aiven Platform.
 
 You can use an agent in two ways:
 
-- [Chat with an agent](/docs/tools/agents/chat-with-agent) to send requests when
-  needed.
+- [Chat with an agent](/docs/tools/agents/chat-with-agent) to send requests
+  when needed.
 - [Schedule an agent](/docs/tools/agents/schedule-agent) to run tasks
   automatically at a specified time or interval.
 

--- a/docs/tools/agents.md
+++ b/docs/tools/agents.md
@@ -23,11 +23,11 @@ Managed Agents is in
 [limited availability](/docs/platform/concepts/service-and-feature-releases#limited-availability-).
 You need access for each project. In the project, click
 <ConsoleLabel name="agents"/> > **Request access**. Once access is granted,
-select **Enable agents**, or **Enable in VPC** to deploy agents and their
-database in a project VPC.
+select **Enable agents**. To run Managed Agents in a project VPC, select
+**Enable in VPC**.
 
-Agents are free for a limited time. A payment method is required to get
-started, and you won't be charged.
+Managed Agents is free during limited availability. A payment method is
+required to get started. You are not charged for using Managed Agents.
 :::
 
 :::caution

--- a/docs/tools/agents/chat-with-agent.md
+++ b/docs/tools/agents/chat-with-agent.md
@@ -1,0 +1,48 @@
+---
+title: Chat with an agent
+sidebar_label: Chat with an agent
+description: Interact with an Aiven Agent on demand.
+limited: true
+keywords: [Aiven Agents, chat, on demand]
+---
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Use chat to send tasks or questions to an agent and continue the conversation with follow-up messages.
+
+## Prerequisites
+
+- Access to Aiven Agents for the project. If you don't have access yet, see
+  [Aiven Agents](/docs/tools/agents).
+- An existing agent. To create one, see
+  [Create an agent](/docs/tools/agents/create-agent).
+
+## Start a chat
+
+1. In the Aiven Console, open your project.
+1. Click <ConsoleLabel name="agents"/>.
+1. Click the agent.
+
+   The agent opens in a new chat.
+
+1. Enter a message and send it.
+
+You can continue the conversation by sending additional messages.
+
+To start a separate conversation, click <ConsoleLabel name="new chat"/>.
+
+## View chat history
+
+1. Click <ConsoleLabel name="chat history"/>.
+1. Click a conversation to open it.
+
+Use chat when you want to interact with the agent on demand. To automate
+recurring tasks, see
+[Schedule an agent](/docs/tools/agents/schedule-agent).
+
+<RelatedPages/>
+
+- [Aiven Agents](/docs/tools/agents)
+- [Create an agent](/docs/tools/agents/create-agent)
+- [Schedule an agent](/docs/tools/agents/schedule-agent)

--- a/docs/tools/agents/chat-with-agent.md
+++ b/docs/tools/agents/chat-with-agent.md
@@ -13,7 +13,7 @@ Use chat to send tasks or questions to an agent and continue the conversation wi
 
 ## Prerequisites
 
-- Access to Managed Agents for the project. If you don't have access yet, see
+- Access to Managed Agents for the project. If you don't have access, see
   [Managed Agents](/docs/tools/agents).
 - An existing agent. To create one, see
   [Create an agent](/docs/tools/agents/create-agent).

--- a/docs/tools/agents/chat-with-agent.md
+++ b/docs/tools/agents/chat-with-agent.md
@@ -1,9 +1,9 @@
 ---
 title: Chat with an agent
 sidebar_label: Chat with an agent
-description: Interact with an Aiven Agent on demand.
+description: Interact with an agent on demand.
 limited: true
-keywords: [Aiven Agents, chat, on demand]
+keywords: [Managed Agents, chat, on demand]
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
@@ -13,8 +13,8 @@ Use chat to send tasks or questions to an agent and continue the conversation wi
 
 ## Prerequisites
 
-- Access to Aiven Agents for the project. If you don't have access yet, see
-  [Aiven Agents](/docs/tools/agents).
+- Access to Managed Agents for the project. If you don't have access yet, see
+  [Managed Agents](/docs/tools/agents).
 - An existing agent. To create one, see
   [Create an agent](/docs/tools/agents/create-agent).
 
@@ -43,6 +43,6 @@ recurring tasks, see
 
 <RelatedPages/>
 
-- [Aiven Agents](/docs/tools/agents)
+- [Managed Agents](/docs/tools/agents)
 - [Create an agent](/docs/tools/agents/create-agent)
 - [Schedule an agent](/docs/tools/agents/schedule-agent)

--- a/docs/tools/agents/chat-with-agent.md
+++ b/docs/tools/agents/chat-with-agent.md
@@ -13,10 +13,8 @@ Use chat to send tasks or questions to an agent and continue the conversation wi
 
 ## Prerequisites
 
-- Access to Managed Agents for the project. If you don't have access, see
-  [Managed Agents](/docs/tools/agents).
-- An existing agent. To create one, see
-  [Create an agent](/docs/tools/agents/create-agent).
+An existing agent. To create one, see
+[Create an agent](/docs/tools/agents/create-agent).
 
 ## Start a chat
 

--- a/docs/tools/agents/create-agent.md
+++ b/docs/tools/agents/create-agent.md
@@ -10,7 +10,6 @@ import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import RelatedPages from "@site/src/components/RelatedPages";
 
 Create an agent by describing a task or by configuring the agent manually.
-
 When you describe a task, Aiven generates a configuration that you can review and
 test before you create the agent.
 
@@ -34,10 +33,15 @@ enabled Managed Agents, see [Managed Agents](/docs/tools/agents).
    > Summarize any issues you find and highlight anything that needs attention.
 
    To start from a suggestion, select an option under **Or start from a suggestion**,
-   such as **Slow-query digest**, **Incident RCA**, or **PR reviewer**.
+   such as **Slow-query digest**, **Incident RCA**, **PR reviewer**,
+   **Sprint status sync**, or **Deep researcher**. Some suggestions use other
+   MCP integrations, such as Slack or Jira.
 
-1. Click **Create agent**. Keep the window open. If you leave before
-   creating the agent, the draft and any test runs are lost.
+1. Click **Create agent**. Do not close this window.
+
+   Aiven prepares a draft. The agent is not saved until you click
+   **Create agent** again. If you leave, the draft and any test runs are
+   lost.
 
 Aiven analyzes the task and prepares the configuration. This can take a few minutes.
 During this process, Aiven:
@@ -62,13 +66,16 @@ You can change:
 **System instructions** define how the agent behaves. The **Task prompt** defines
 the task the agent performs when it runs.
 
-For details on MCP roles and available tools, see
+If a required integration shows **Not connected**, click **set it up now**.
+**Manage integrations** opens. You can also click
+**+ Add other integrations**. For more information, see
 [Manage integrations](/docs/tools/agents/manage-integrations).
 
 ### Test the agent
 
 1. Optional: Click **Run test** to review the output.
-1. Update the configuration if needed, then click **Run test** again.
+1. If you change the configuration, click **Save changes and Run test**.
+   **Create agent** stays unavailable until you save and run the test again.
 
 ### Create the agent
 
@@ -104,7 +111,9 @@ Manual configuration has three steps: **Agent details**, **Integrations**, and
    - **Web Fetch**
    - **Web Search**
    - **Aiven MCP**
-1. Optional: Add other MCP integrations. For more information, see
+   Connected integrations also appear in this list.
+1. Optional: Click **adding or creating MCP integrations**. For more
+   information, see
    [Manage integrations](/docs/tools/agents/manage-integrations).
 1. Click **Continue**.
 

--- a/docs/tools/agents/create-agent.md
+++ b/docs/tools/agents/create-agent.md
@@ -3,7 +3,7 @@ title: Create an agent
 sidebar_label: Create an agent
 description: Create an agent by describing a task or configuring it manually.
 limited: true
-keywords: [Aiven Agents, create agent, AI model, system instructions]
+keywords: [Managed Agents, create agent, AI model, system instructions]
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
@@ -16,8 +16,8 @@ test before you deploy the agent.
 
 ## Prerequisites
 
-- Access to Aiven Agents for the project. If you don't have access yet, see
-  [Aiven Agents](/docs/tools/agents).
+Managed Agents enabled for the project. If you have not requested access or
+enabled Managed Agents yet, see [Managed Agents](/docs/tools/agents).
 
 ## Create an agent by describing a task
 
@@ -36,7 +36,8 @@ test before you deploy the agent.
    To start from a suggestion, select an option under **Or start from a suggestion**,
    such as **Slow-query digest**, **Incident RCA**, or **PR reviewer**.
 
-1. Click **Create agent**. Keep the window open.
+1. Click **Create agent**. Keep the window open. If you leave before
+   deploying, the draft and any test runs are lost.
 
 Aiven analyzes the task and prepares the configuration. This can take a few minutes.
 During this process, Aiven:
@@ -60,6 +61,9 @@ You can change:
 
 **System instructions** define how the agent behaves. The **Task prompt** defines
 the task the agent performs when it runs.
+
+For details on MCP roles and available tools, see
+[Manage integrations](/docs/tools/agents/manage-integrations).
 
 ### Test the agent
 
@@ -126,4 +130,4 @@ The agent appears on the <ConsoleLabel name="agents"/> page with the status
 
 <RelatedPages/>
 
-- [Aiven Agents](/docs/tools/agents)
+- [Managed Agents](/docs/tools/agents)

--- a/docs/tools/agents/create-agent.md
+++ b/docs/tools/agents/create-agent.md
@@ -1,0 +1,129 @@
+---
+title: Create an agent
+sidebar_label: Create an agent
+description: Create an agent by describing a task or configuring it manually.
+limited: true
+keywords: [Aiven Agents, create agent, AI model, system instructions]
+---
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Create an agent by describing a task or by configuring the agent manually.
+
+When you describe a task, Aiven generates a configuration that you can review and
+test before you deploy the agent.
+
+## Prerequisites
+
+- Access to Aiven Agents for the project. If you don't have access yet, see
+  [Aiven Agents](/docs/tools/agents).
+
+## Create an agent by describing a task
+
+1. In the Aiven Console, open your project.
+1. Click <ConsoleLabel name="agents"/> > **Create agent**.
+
+### Describe the task
+
+1. In **Describe what you want this agent to do**, enter the task.
+
+   For example:
+
+   > Check the health of the PostgreSQL services in this project.
+   > Summarize any issues you find and highlight anything that needs attention.
+
+   To start from a suggestion, select an option under **Or start from a suggestion**,
+   such as **Slow-query digest**, **Incident RCA**, or **PR reviewer**.
+
+1. Click **Create agent**. Keep the window open.
+
+Aiven analyzes the task and prepares the configuration. This can take a few minutes.
+During this process, Aiven:
+
+- Determines the agent's goal
+- Generates **System instructions**
+- Selects MCP tools and permissions
+- Creates the **Task prompt**
+
+### Review the generated configuration
+
+When the configuration is ready, review it before you deploy the agent.
+
+You can change:
+
+- AI model
+- System instructions
+- Task prompt
+- Built-in tools and integrations
+- MCP role and available tools
+
+**System instructions** define how the agent behaves. The **Task prompt** defines
+the task the agent performs when it runs.
+
+### Test the agent
+
+1. Optional: Click **Run test** to review the output.
+1. Update the configuration if needed, then click **Run test** again.
+
+### Deploy the agent
+
+1. Click **Deploy agent**.
+1. For **Schedule**, select **On demand** or a recurring schedule. If you select
+   **Custom**, set the cadence and any extra options, such as **Time** and
+   **Time zone**.
+1. Click **Deploy**.
+
+The agent appears on the <ConsoleLabel name="agents"/> page with the status
+**Active**. The agent <ConsoleLabel name="agent overview"/> shows
+**Agent details** and **System instructions**.
+
+## Configure an agent manually
+
+1. In the Aiven Console, open your project.
+1. Click <ConsoleLabel name="agents"/> > **Create agent** > **Configure manually**.
+
+Manual configuration has three steps: **Agent details**, **Integrations**, and
+**Schedule**.
+
+### Configure agent details
+
+1. Enter a **Name** for the agent.
+1. Select the **AI model**.
+1. Enter **System instructions** that describe what the agent does, how it
+   responds, and anything it avoids.
+1. Click **Continue**.
+
+### Select integrations
+
+1. Under **Built-in tools and integrations**, select the tools the agent can use:
+   - **Web Fetch**
+   - **Web Search**
+   - **Aiven MCP**
+1. Optional: Add other MCP integrations. For more information, see
+   [Manage integrations](/docs/tools/agents/manage-integrations).
+1. Click **Continue**.
+
+### Configure the schedule
+
+1. For **How often should this agent run?**, select **On demand** or a
+   recurring schedule. If you select **Custom**, set the cadence and any extra
+   options, such as **Time** and **Time zone**.
+1. For a scheduled agent, enter a **Task prompt**. Aiven sends this message to the
+   agent on each scheduled run. For more information, see
+   [Schedule an agent](/docs/tools/agents/schedule-agent).
+1. Click **Create agent**.
+
+The agent appears on the <ConsoleLabel name="agents"/> page with the status
+**Active**.
+
+## Next steps
+
+- [Chat with an agent](/docs/tools/agents/chat-with-agent)
+- [Manage an agent](/docs/tools/agents/manage-agent)
+- [Manage integrations](/docs/tools/agents/manage-integrations)
+- [Schedule an agent](/docs/tools/agents/schedule-agent)
+
+<RelatedPages/>
+
+- [Aiven Agents](/docs/tools/agents)

--- a/docs/tools/agents/create-agent.md
+++ b/docs/tools/agents/create-agent.md
@@ -133,9 +133,9 @@ The agent appears on the <ConsoleLabel name="agents"/> page with the status
 ## Next steps
 
 - [Chat with an agent](/docs/tools/agents/chat-with-agent)
+- [Schedule an agent](/docs/tools/agents/schedule-agent)
 - [Manage an agent](/docs/tools/agents/manage-agent)
 - [Manage integrations](/docs/tools/agents/manage-integrations)
-- [Schedule an agent](/docs/tools/agents/schedule-agent)
 
 <RelatedPages/>
 

--- a/docs/tools/agents/create-agent.md
+++ b/docs/tools/agents/create-agent.md
@@ -12,7 +12,7 @@ import RelatedPages from "@site/src/components/RelatedPages";
 Create an agent by describing a task or by configuring the agent manually.
 
 When you describe a task, Aiven generates a configuration that you can review and
-test before you deploy the agent.
+test before you create the agent.
 
 ## Prerequisites
 
@@ -37,7 +37,7 @@ enabled Managed Agents, see [Managed Agents](/docs/tools/agents).
    such as **Slow-query digest**, **Incident RCA**, or **PR reviewer**.
 
 1. Click **Create agent**. Keep the window open. If you leave before
-   deploying, the draft and any test runs are lost.
+   creating the agent, the draft and any test runs are lost.
 
 Aiven analyzes the task and prepares the configuration. This can take a few minutes.
 During this process, Aiven:
@@ -49,7 +49,7 @@ During this process, Aiven:
 
 ### Review the generated configuration
 
-When the configuration is ready, review it before you deploy the agent.
+When the configuration is ready, review it before you create the agent.
 
 You can change:
 
@@ -70,13 +70,13 @@ For details on MCP roles and available tools, see
 1. Optional: Click **Run test** to review the output.
 1. Update the configuration if needed, then click **Run test** again.
 
-### Deploy the agent
+### Create the agent
 
-1. Click **Deploy agent**.
+1. Click **Create agent**.
 1. For **Schedule**, select **On demand** or a recurring schedule. If you select
    **Custom**, set the cadence and any extra options, such as **Time** and
    **Time zone**.
-1. Click **Deploy**.
+1. Click **Create**.
 
 The agent appears on the <ConsoleLabel name="agents"/> page with the status
 **Active**. The agent <ConsoleLabel name="agent overview"/> shows

--- a/docs/tools/agents/create-agent.md
+++ b/docs/tools/agents/create-agent.md
@@ -17,7 +17,7 @@ test before you deploy the agent.
 ## Prerequisites
 
 Managed Agents enabled for the project. If you have not requested access or
-enabled Managed Agents yet, see [Managed Agents](/docs/tools/agents).
+enabled Managed Agents, see [Managed Agents](/docs/tools/agents).
 
 ## Create an agent by describing a task
 

--- a/docs/tools/agents/manage-agent.md
+++ b/docs/tools/agents/manage-agent.md
@@ -3,7 +3,7 @@ title: Manage an agent
 sidebar_label: Manage an agent
 description: View and update an agent's configuration, integrations, and schedules.
 limited: true
-keywords: [Aiven Agents, manage agent, edit agent]
+keywords: [Managed Agents, manage agent, edit agent]
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
@@ -17,8 +17,8 @@ schedule, see [Schedule an agent](/docs/tools/agents/schedule-agent).
 
 ## Prerequisites
 
-- Access to Aiven Agents for the project. If you don't have access yet, see
-  [Aiven Agents](/docs/tools/agents).
+- Access to Managed Agents for the project. If you don't have access yet, see
+  [Managed Agents](/docs/tools/agents).
 - An existing agent. To create one, see
   [Create an agent](/docs/tools/agents/create-agent).
 
@@ -69,6 +69,6 @@ For more information, see
 
 <RelatedPages/>
 
-- [Aiven Agents](/docs/tools/agents)
+- [Managed Agents](/docs/tools/agents)
 - [Create an agent](/docs/tools/agents/create-agent)
 - [Chat with an agent](/docs/tools/agents/chat-with-agent)

--- a/docs/tools/agents/manage-agent.md
+++ b/docs/tools/agents/manage-agent.md
@@ -17,7 +17,7 @@ schedule, see [Schedule an agent](/docs/tools/agents/schedule-agent).
 
 ## Prerequisites
 
-- Access to Managed Agents for the project. If you don't have access yet, see
+- Access to Managed Agents for the project. If you don't have access, see
   [Managed Agents](/docs/tools/agents).
 - An existing agent. To create one, see
   [Create an agent](/docs/tools/agents/create-agent).

--- a/docs/tools/agents/manage-agent.md
+++ b/docs/tools/agents/manage-agent.md
@@ -17,10 +17,8 @@ schedule, see [Schedule an agent](/docs/tools/agents/schedule-agent).
 
 ## Prerequisites
 
-- Access to Managed Agents for the project. If you don't have access, see
-  [Managed Agents](/docs/tools/agents).
-- An existing agent. To create one, see
-  [Create an agent](/docs/tools/agents/create-agent).
+An existing agent. To create one, see
+[Create an agent](/docs/tools/agents/create-agent).
 
 ## Open an agent
 

--- a/docs/tools/agents/manage-agent.md
+++ b/docs/tools/agents/manage-agent.md
@@ -1,0 +1,74 @@
+---
+title: Manage an agent
+sidebar_label: Manage an agent
+description: View and update an agent's configuration, integrations, and schedules.
+limited: true
+keywords: [Aiven Agents, manage agent, edit agent]
+---
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Update an existing agent, including its system instructions, AI model, and tools.
+
+To send a task or question, see
+[Chat with an agent](/docs/tools/agents/chat-with-agent). To run a task on a
+schedule, see [Schedule an agent](/docs/tools/agents/schedule-agent).
+
+## Prerequisites
+
+- Access to Aiven Agents for the project. If you don't have access yet, see
+  [Aiven Agents](/docs/tools/agents).
+- An existing agent. To create one, see
+  [Create an agent](/docs/tools/agents/create-agent).
+
+## Open an agent
+
+1. In the Aiven Console, open your project.
+1. Click <ConsoleLabel name="agents"/>.
+1. Click the agent.
+
+The agent opens in a new chat. To chat or open a previous conversation, see
+[Chat with an agent](/docs/tools/agents/chat-with-agent).
+
+## View agent details
+
+Click <ConsoleLabel name="agent overview"/>.
+
+<ConsoleLabel name="agent overview"/> shows **Agent details** and
+**System instructions**. **Agent details** includes the agent name and AI
+model.
+
+### Edit the agent name or model
+
+1. In **Agent details**, click <ConsoleLabel name="edit"/>.
+1. Change the agent name or the **AI model**.
+1. Click **Save**.
+
+### Edit system instructions
+
+1. In **System instructions**, click <ConsoleLabel name="edit"/>.
+1. Update the instructions.
+1. Click **Save**.
+
+## Change tools and integrations
+
+Click <ConsoleLabel name="integrations"/> to change the tools the agent can
+use, including built-in tools and Aiven MCP.
+
+For more information, see
+[Manage integrations](/docs/tools/agents/manage-integrations).
+
+## Manage schedules
+
+Click <ConsoleLabel name="agent schedules"/> to view or create scheduled
+tasks for the agent.
+
+For more information, see
+[Schedule an agent](/docs/tools/agents/schedule-agent).
+
+<RelatedPages/>
+
+- [Aiven Agents](/docs/tools/agents)
+- [Create an agent](/docs/tools/agents/create-agent)
+- [Chat with an agent](/docs/tools/agents/chat-with-agent)

--- a/docs/tools/agents/manage-integrations.md
+++ b/docs/tools/agents/manage-integrations.md
@@ -1,0 +1,58 @@
+---
+title: Manage integrations
+sidebar_label: Manage integrations
+description: Configure the tools and integrations an agent can use, including access to Aiven resources.
+limited: true
+keywords: [Aiven Agents, MCP, integrations, permissions]
+---
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Choose which tools an agent can use, including built-in tools and [Aiven MCP](/docs/tools/mcp-server).
+
+You can also add other Model Context Protocol, also called MCP, integrations.
+
+## Prerequisites
+
+- Access to Aiven Agents for the project. If you don't have access yet, see
+  [Aiven Agents](/docs/tools/agents).
+- An existing agent. To create one, see
+  [Create an agent](/docs/tools/agents/create-agent).
+
+## Change the tools for an agent
+
+1. In the Aiven Console, open your project.
+1. Click <ConsoleLabel name="agents"/>, then click the agent.
+1. Click <ConsoleLabel name="integrations"/>.
+1. Click the tools the agent can use:
+   - **Web Fetch:** Retrieves content from web pages.
+   - **Web Search:** Searches the web for information.
+   - **Aiven MCP:** Grants the agent access to services in the current project.
+1. Click **Save changes**.
+
+## Set the Aiven MCP role and tools
+
+When you turn on **Aiven MCP**, Aiven creates a scoped token automatically. You
+can grant any role up to your own.
+
+The following roles are available:
+
+| Role | Access |
+| --- | --- |
+| **Read-only** | View services, configuration, logs, and metrics. No changes. |
+| **Developer** | Manage databases, topics, connectors, and run queries. Cannot create or delete services. |
+| **Operator** | Full access to all services in the project, including creating and deleting services. |
+
+1. Select an **MCP role**.
+1. Under **Available tools**, select the tool groups the agent can use, such as
+   **Services**, **Kafka**, **PostgreSQL**, **Integrations**, and
+   **Applications**.
+1. Click **Save changes**.
+
+<RelatedPages/>
+
+- [Aiven Agents](/docs/tools/agents)
+- [Aiven MCP](/docs/tools/mcp-server)
+- [Create an agent](/docs/tools/agents/create-agent)
+- [Manage an agent](/docs/tools/agents/manage-agent)

--- a/docs/tools/agents/manage-integrations.md
+++ b/docs/tools/agents/manage-integrations.md
@@ -9,32 +9,52 @@ keywords: [Managed Agents, MCP, integrations, permissions]
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Choose which tools an agent can use, including built-in tools and [Aiven MCP](/docs/tools/mcp-server).
+Choose which tools and integrations an agent can use, including built-in tools
+and [Aiven MCP](/docs/tools/mcp-server).
 
-You can also add other Model Context Protocol (MCP) integrations.
+You can also connect other Model Context Protocol (MCP) integrations.
 
 ## Prerequisites
 
-- Access to Managed Agents for the project. If you don't have access, see
-  [Managed Agents](/docs/tools/agents).
-- An existing agent. To create one, see
-  [Create an agent](/docs/tools/agents/create-agent).
+Managed Agents enabled for the project. If you have not requested access or
+enabled Managed Agents, see [Managed Agents](/docs/tools/agents).
 
-## Change the tools for an agent
+## Configure tools and integrations
 
 1. In the Aiven Console, open your project.
-1. Click <ConsoleLabel name="agents"/>, then click the agent.
-1. Click <ConsoleLabel name="integrations"/>.
-1. Click the tools the agent can use:
-   - **Web Fetch:** Retrieves content from web pages.
-   - **Web Search:** Searches the web for information.
-   - **Aiven MCP:** Grants the agent access to services in the current project.
-1. Click **Save changes**.
+1. Select <ConsoleLabel name="agents"/>, then select the agent.
+1. Select <ConsoleLabel name="integrations"/>.
+1. Select the tools and integrations the agent can use.
+1. Select **Save changes**.
+
+Built-in tools include:
+
+- **Web Fetch**
+- **Web Search**
+- **Aiven MCP**
+
+To add or manage integrations, select **Advanced integration settings**.
+
+## Connect an integration
+
+In **Advanced integration settings**, connected integrations appear at the top
+of the page. The **Integrations catalog** lists other integrations you can
+connect.
+
+To connect an integration:
+
+1. Find the integration in the **Integrations catalog**.
+1. Select **Connect**.
+1. Enter the required details and credentials.
+1. Select **Connect**.
+
+To connect an integration that is not available in the catalog, select
+**Add custom integration**.
 
 ## Set the Aiven MCP role and tools
 
-When you turn on **Aiven MCP**, Aiven creates a scoped token automatically. You
-can grant any role up to your own.
+When you enable **Aiven MCP**, Aiven creates a scoped token automatically. You
+can assign an MCP role up to your own project permissions.
 
 The following roles are available:
 
@@ -45,10 +65,8 @@ The following roles are available:
 | **Operator** | Full access to all services in the project, including creating and deleting services. |
 
 1. Select an **MCP role**.
-1. Under **Available tools**, select the tool groups the agent can use:
-   **Services**, **Kafka**, **PostgreSQL**, **Integrations**,
-   **Applications**, and **Other**.
-1. Click **Save changes**.
+1. Under **Available tools**, select the tool groups the agent can use.
+1. Select **Save changes**.
 
 <RelatedPages/>
 

--- a/docs/tools/agents/manage-integrations.md
+++ b/docs/tools/agents/manage-integrations.md
@@ -11,11 +11,11 @@ import RelatedPages from "@site/src/components/RelatedPages";
 
 Choose which tools an agent can use, including built-in tools and [Aiven MCP](/docs/tools/mcp-server).
 
-You can also add other Model Context Protocol, also called MCP, integrations.
+You can also add other Model Context Protocol (MCP) integrations.
 
 ## Prerequisites
 
-- Access to Managed Agents for the project. If you don't have access yet, see
+- Access to Managed Agents for the project. If you don't have access, see
   [Managed Agents](/docs/tools/agents).
 - An existing agent. To create one, see
   [Create an agent](/docs/tools/agents/create-agent).

--- a/docs/tools/agents/manage-integrations.md
+++ b/docs/tools/agents/manage-integrations.md
@@ -3,7 +3,7 @@ title: Manage integrations
 sidebar_label: Manage integrations
 description: Configure the tools and integrations an agent can use, including access to Aiven resources.
 limited: true
-keywords: [Aiven Agents, MCP, integrations, permissions]
+keywords: [Managed Agents, MCP, integrations, permissions]
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
@@ -15,8 +15,8 @@ You can also add other Model Context Protocol, also called MCP, integrations.
 
 ## Prerequisites
 
-- Access to Aiven Agents for the project. If you don't have access yet, see
-  [Aiven Agents](/docs/tools/agents).
+- Access to Managed Agents for the project. If you don't have access yet, see
+  [Managed Agents](/docs/tools/agents).
 - An existing agent. To create one, see
   [Create an agent](/docs/tools/agents/create-agent).
 
@@ -52,7 +52,7 @@ The following roles are available:
 
 <RelatedPages/>
 
-- [Aiven Agents](/docs/tools/agents)
+- [Managed Agents](/docs/tools/agents)
 - [Aiven MCP](/docs/tools/mcp-server)
 - [Create an agent](/docs/tools/agents/create-agent)
 - [Manage an agent](/docs/tools/agents/manage-agent)

--- a/docs/tools/agents/manage-integrations.md
+++ b/docs/tools/agents/manage-integrations.md
@@ -45,9 +45,9 @@ The following roles are available:
 | **Operator** | Full access to all services in the project, including creating and deleting services. |
 
 1. Select an **MCP role**.
-1. Under **Available tools**, select the tool groups the agent can use, such as
-   **Services**, **Kafka**, **PostgreSQL**, **Integrations**, and
-   **Applications**.
+1. Under **Available tools**, select the tool groups the agent can use:
+   **Services**, **Kafka**, **PostgreSQL**, **Integrations**,
+   **Applications**, and **Other**.
 1. Click **Save changes**.
 
 <RelatedPages/>

--- a/docs/tools/agents/schedule-agent.md
+++ b/docs/tools/agents/schedule-agent.md
@@ -3,7 +3,7 @@ title: Schedule an agent
 sidebar_label: Schedule an agent
 description: Create scheduled tasks so an agent runs automatically.
 limited: true
-keywords: [Aiven Agents, schedule, automation, recurring tasks]
+keywords: [Managed Agents, schedule, automation, recurring tasks]
 ---
 
 import ConsoleLabel from "@site/src/components/ConsoleIcons";
@@ -20,8 +20,8 @@ You can also set **On demand** or a schedule when you
 
 ## Prerequisites
 
-- Access to Aiven Agents for the project. If you don't have access yet, see
-  [Aiven Agents](/docs/tools/agents).
+- Access to Managed Agents for the project. If you don't have access yet, see
+  [Managed Agents](/docs/tools/agents).
 - An existing agent. To create one, see
   [Create an agent](/docs/tools/agents/create-agent).
 
@@ -93,6 +93,6 @@ For more information, see
 
 <RelatedPages/>
 
-- [Aiven Agents](/docs/tools/agents)
+- [Managed Agents](/docs/tools/agents)
 - [Create an agent](/docs/tools/agents/create-agent)
 - [Chat with an agent](/docs/tools/agents/chat-with-agent)

--- a/docs/tools/agents/schedule-agent.md
+++ b/docs/tools/agents/schedule-agent.md
@@ -20,7 +20,7 @@ You can also set **On demand** or a schedule when you
 
 ## Prerequisites
 
-- Access to Managed Agents for the project. If you don't have access yet, see
+- Access to Managed Agents for the project. If you don't have access, see
   [Managed Agents](/docs/tools/agents).
 - An existing agent. To create one, see
   [Create an agent](/docs/tools/agents/create-agent).
@@ -70,7 +70,7 @@ To disable a schedule:
 1. On <ConsoleLabel name="agent schedules"/>, find the schedule to disable.
 1. Click <ConsoleLabel name="actions"/> > **Disable**.
 
-## Run a schedule now
+## Run a schedule
 
 1. On <ConsoleLabel name="agent schedules"/>, find the schedule to run.
 1. Click <ConsoleLabel name="actions"/> > **Run now**.

--- a/docs/tools/agents/schedule-agent.md
+++ b/docs/tools/agents/schedule-agent.md
@@ -1,0 +1,98 @@
+---
+title: Schedule an agent
+sidebar_label: Schedule an agent
+description: Create scheduled tasks so an agent runs automatically.
+limited: true
+keywords: [Aiven Agents, schedule, automation, recurring tasks]
+---
+
+import ConsoleLabel from "@site/src/components/ConsoleIcons";
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Create scheduled tasks so an agent runs automatically at a specified time or interval.
+
+Use a schedule for recurring work, such as a daily summary of service health. To
+interact with an agent on demand, see
+[Chat with an agent](/docs/tools/agents/chat-with-agent).
+
+You can also set **On demand** or a schedule when you
+[create an agent](/docs/tools/agents/create-agent).
+
+## Prerequisites
+
+- Access to Aiven Agents for the project. If you don't have access yet, see
+  [Aiven Agents](/docs/tools/agents).
+- An existing agent. To create one, see
+  [Create an agent](/docs/tools/agents/create-agent).
+
+## Create a schedule
+
+1. In the Aiven Console, open your project.
+1. Click <ConsoleLabel name="agents"/>.
+1. Click the agent.
+1. Click <ConsoleLabel name="agent schedules"/>.
+1. Click **Create schedule**.
+1. Enter a **Name**.
+1. In **Task**, enter the work the agent performs on each run.
+
+   For example:
+
+   > Summarize yesterday's signups and flag anomalies.
+
+1. Select the **Cadence**. If the cadence runs at a specific time, set **Time**
+   and **Time zone**.
+1. Click **Create schedule**.
+
+The Console shows when the schedule runs. For example:
+**Runs daily at 09:00 Europe/Berlin**.
+
+**System instructions** define how the agent behaves. **Task** defines the work
+this schedule performs.
+
+## Edit a schedule
+
+1. On <ConsoleLabel name="agent schedules"/>, find the schedule to edit.
+1. Click <ConsoleLabel name="actions"/> > **Edit**.
+1. Change the **Name**, **Task**, **Cadence**, **Time**, or **Time zone**.
+
+## Enable or disable a schedule
+
+The **Status** column shows **Enabled** or **Disabled**. A disabled schedule
+does not run.
+
+To enable a schedule:
+
+1. On <ConsoleLabel name="agent schedules"/>, find the schedule to enable.
+1. Click <ConsoleLabel name="actions"/> > **Enable**.
+
+To disable a schedule:
+
+1. On <ConsoleLabel name="agent schedules"/>, find the schedule to disable.
+1. Click <ConsoleLabel name="actions"/> > **Disable**.
+
+## Run a schedule now
+
+1. On <ConsoleLabel name="agent schedules"/>, find the schedule to run.
+1. Click <ConsoleLabel name="actions"/> > **Run now**.
+
+The agent opens in a chat and runs the **Task** from the schedule. You can send
+follow-up messages in the same conversation.
+
+For more information, see
+[Chat with an agent](/docs/tools/agents/chat-with-agent).
+
+## View schedule runs
+
+1. On <ConsoleLabel name="agent schedules"/>, find the schedule.
+1. Click <ConsoleLabel name="actions"/> > **View runs**.
+
+## Delete a schedule
+
+1. On <ConsoleLabel name="agent schedules"/>, find the schedule to delete.
+1. Click <ConsoleLabel name="actions"/> > **Delete**.
+
+<RelatedPages/>
+
+- [Aiven Agents](/docs/tools/agents)
+- [Create an agent](/docs/tools/agents/create-agent)
+- [Chat with an agent](/docs/tools/agents/chat-with-agent)

--- a/docs/tools/agents/schedule-agent.md
+++ b/docs/tools/agents/schedule-agent.md
@@ -78,9 +78,6 @@ To disable a schedule:
 The agent opens in a chat and runs the **Task** from the schedule. You can send
 follow-up messages in the same conversation.
 
-For more information, see
-[Chat with an agent](/docs/tools/agents/chat-with-agent).
-
 ## View schedule runs
 
 1. On <ConsoleLabel name="agent schedules"/>, find the schedule.

--- a/docs/tools/agents/schedule-agent.md
+++ b/docs/tools/agents/schedule-agent.md
@@ -20,10 +20,8 @@ You can also set **On demand** or a schedule when you
 
 ## Prerequisites
 
-- Access to Managed Agents for the project. If you don't have access, see
-  [Managed Agents](/docs/tools/agents).
-- An existing agent. To create one, see
-  [Create an agent](/docs/tools/agents/create-agent).
+An existing agent. To create one, see
+[Create an agent](/docs/tools/agents/create-agent).
 
 ## Create a schedule
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -324,6 +324,11 @@ const sidebars: SidebarsConfig = {
       collapsible: false,
       items: [
         'ai-features',
+        {
+          type: 'link',
+          label: 'Aiven Agents',
+          href: '/docs/tools/agents',
+        },
         'tools/mcp-server',
         {
           type: 'link',
@@ -350,6 +355,21 @@ const sidebars: SidebarsConfig = {
         'tools',
         'tools/api',
         'tools/mcp-server',
+        {
+          type: 'category',
+          label: 'Aiven Agents',
+          link: {
+            id: 'tools/agents',
+            type: 'doc',
+          },
+          items: [
+            'tools/agents/create-agent',
+            'tools/agents/chat-with-agent',
+            'tools/agents/manage-agent',
+            'tools/agents/manage-integrations',
+            'tools/agents/schedule-agent',
+          ],
+        },
         {
           type: 'category',
           label: 'Aiven Provider for Terraform',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -326,7 +326,7 @@ const sidebars: SidebarsConfig = {
         'ai-features',
         {
           type: 'link',
-          label: 'Aiven Agents',
+          label: 'Managed Agents',
           href: '/docs/tools/agents',
         },
         'tools/mcp-server',
@@ -357,7 +357,7 @@ const sidebars: SidebarsConfig = {
         'tools/mcp-server',
         {
           type: 'category',
-          label: 'Aiven Agents',
+          label: 'Managed Agents',
           link: {
             id: 'tools/agents',
             type: 'doc',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -365,9 +365,9 @@ const sidebars: SidebarsConfig = {
           items: [
             'tools/agents/create-agent',
             'tools/agents/chat-with-agent',
+            'tools/agents/schedule-agent',
             'tools/agents/manage-agent',
             'tools/agents/manage-integrations',
-            'tools/agents/schedule-agent',
           ],
         },
         {

--- a/src/components/ConsoleIcons/index.tsx
+++ b/src/components/ConsoleIcons/index.tsx
@@ -103,6 +103,36 @@ export default function ConsoleLabel({name}): ReactElement {
           <ConsoleIconWrapper icon={ConsoleIcons.database} /> <b>Services</b>
         </>
       );
+    case 'agents':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.cpuChip} /> <b>Agents</b>
+        </>
+      );
+    case 'agentoverview':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.dashboard} /> <b>Overview</b>
+        </>
+      );
+    case 'agentschedules':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.time} /> <b>Agent schedules</b>
+        </>
+      );
+    case 'newchat':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.plusCircle} /> <b>New chat</b>
+        </>
+      );
+    case 'chathistory':
+      return (
+        <>
+          <ConsoleIconWrapper icon={ConsoleIcons.chat} /> <b>Chat history</b>
+        </>
+      );
     case 'aiinsights':
       return (
         <>


### PR DESCRIPTION
## Describe your changes

- Add Managed Agents docs (limited availability): overview plus how-tos to create, chat, manage, configure integrations, and schedule agents.
- Link Agents from AI tools and Aiven dev tools, and add the topic to the Tools sidebar.
- Add Console labels for Agents navigation (including agent Overview, schedules, New chat, and Chat history) and `Jira` to the Vale accept list.

Jira: [EVERSQL-2019](https://aiven.atlassian.net/browse/EVERSQL-2019)

Preview: https://eversql-2019-add-aiven-agent.aiven-docs.pages.dev/docs/tools/agents


## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [x] My links start with `/docs/`.


[EVERSQL-2019]: https://aiven.atlassian.net/browse/EVERSQL-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ