### PR TITLE
update: ClickHouse 26.3 GA

### DIFF
--- a/docs/products/clickhouse/howto/manage-clickhouse-versions.md
+++ b/docs/products/clickhouse/howto/manage-clickhouse-versions.md
@@ -15,13 +15,13 @@ Aiven for ClickHouse supports the following major versions:
 
 - `25.3`: default for services created before May 5, 2026
 - `25.8`: default for services created on or after May 5, 2026
-- `26.3`: available in Early Availability from August 1, 2026
+- `26.3`: available in General Availability from September 1, 2026
 
 If you don't specify a version when you create a service, Aiven uses the default
-version in effect on the creation date. During Early Availability, you can select
-`26.3` when creating a new service or when upgrading a service running version
-`25.8`. Services running `25.3` must first upgrade to `25.8`. Version `25.8`
-remains the default for new services.
+version in effect on the creation date. You can select `26.3` when creating a
+new service or when upgrading a service running version `25.8`. Upgrade
+services running `25.3` to `25.8` first. Version `25.8` remains the default for
+new services.
 
 Aiven doesn't automatically upgrade existing `25.3` services to `25.8`. When using
 infrastructure as code (for example, the [Aiven Provider for Terraform](/docs/tools/terraform)

--- a/docs/products/clickhouse/reference/upgrade-to-26-3.md
+++ b/docs/products/clickhouse/reference/upgrade-to-26-3.md
@@ -1,20 +1,17 @@
 ---
 title: Upgrade to Aiven for ClickHouse® 26.3
 sidebar_label: Upgrade to 26.3
-early: true
 ---
 
 import RelatedPages from "@site/src/components/RelatedPages";
 
-Aiven for ClickHouse® 26.3 is a long-term support (LTS) release available in
-Early Availability starting August 1, 2026. You can select it for new services
-or upgrade an existing service from version 25.8. Version 25.8 remains the
-default for new services.
+Aiven for ClickHouse® 26.3 is a long-term support (LTS) release.
+You can create a new service with version 26.3 or upgrade an existing service
+from version 25.8. Version 25.8 remains the default for new services.
 
-Version 26.3 makes full-text search generally available, enables asynchronous
-inserts by default, and introduces materialized common table expressions
-(CTEs), the native `Geometry` type, and improvements to JSON processing and
-query performance.
+Version 26.3 enables full-text search, asynchronous inserts by default,
+materialized common table expressions (CTEs), the native `Geometry` type, and
+improvements to JSON processing and query performance.
 
 Before upgrading:
 


### PR DESCRIPTION
## Describe your changes

 Aiven for ClickHouse 26.3 as generally available from 1 September 2026

https://aiven.atlassian.net/browse/FLEECH-594


Preview: 
- https://fleech-594-docs-update-26-3.aiven-docs.pages.dev/docs/products/clickhouse/howto/manage-clickhouse-versions
- https://fleech-594-docs-update-26-3.aiven-docs.pages.dev/docs/products/clickhouse/reference/upgrade-to-26-3


## Checklist

- [x] The first paragraph of the page is on one line.
- [x] The other lines have a line break at 90 characters.
- [x] I checked the output.
- [x] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [x] My links start with `/docs/`.
