### PR TITLE
update: Kafka IPv6 client connectivity GA

### DIFF
--- a/docs/products/kafka/howto/ipv6-client-connectivity.md
+++ b/docs/products/kafka/howto/ipv6-client-connectivity.md
@@ -1,6 +1,7 @@
 ---
 title: Enable IPv6 connectivity for Aiven for Apache Kafka®
 sidebar_label: Enable IPv6 connectivity
+early: true
 ---
 
 import Tabs from '@theme/Tabs';
@@ -10,6 +11,10 @@ import ConsoleIcon from "@site/src/components/ConsoleIcons"
 
 Aiven for Apache Kafka® supports dual-stack IPv4 and IPv6 connectivity.
 Kafka clients can connect using either address type.
+
+:::warning
+This feature is in early availability. Enable it in a non-production environment first.
+:::
 
 ## Enable IPv6 connectivity
 


### PR DESCRIPTION
Removes the early availability badge and the early-availability warning from the IPv6 connectivity page.