### PR TITLE
update: document S3-compatible object storage support for custom repositories

### DIFF
--- a/docs/products/opensearch/howto/custom-repositories.md
+++ b/docs/products/opensearch/howto/custom-repositories.md
@@ -45,7 +45,7 @@ Use the Aiven Console or API for configuring custom repositories in Aiven for Op
 
 You can configure custom repositories for the following object storage services:
 
-- Amazon S3, or any S3-compatible object storage service
+- Amazon S3 or any S3-compatible object storage service
 - Google Cloud Storage (GCS)
 - Microsoft Azure Blob Storage
 
@@ -53,7 +53,7 @@ You can configure custom repositories for the following object storage services:
 <TabItem value="api" label="Aiven API">
 
 - Supported storage services
-  - Amazon S3, or any S3-compatible object storage service
+  - Amazon S3 or any S3-compatible object storage service
   - Google Cloud Storage (GCS)
   - Microsoft Azure Blob Storage
 - To

--- a/docs/products/opensearch/howto/custom-repositories.md
+++ b/docs/products/opensearch/howto/custom-repositories.md
@@ -45,7 +45,7 @@ Use the Aiven Console or API for configuring custom repositories in Aiven for Op
 
 You can configure custom repositories for the following object storage services:
 
-- Amazon S3
+- Amazon S3, or any S3-compatible object storage service
 - Google Cloud Storage (GCS)
 - Microsoft Azure Blob Storage
 
@@ -53,7 +53,7 @@ You can configure custom repositories for the following object storage services:
 <TabItem value="api" label="Aiven API">
 
 - Supported storage services
-  - Amazon S3
+  - Amazon S3, or any S3-compatible object storage service
   - Google Cloud Storage (GCS)
   - Microsoft Azure Blob Storage
 - To
@@ -116,6 +116,7 @@ curl -s --url "https://api.aiven.io/v1/project/{project_name}/service/{service_n
           "base_path": "your/path",
           "bucket": "AWS_BUCKET",
           "region": "AWS_REGION",
+          "endpoint": "S3_ENDPOINT",
           "server_side_encryption": true,
           "readonly": false
         }
@@ -124,6 +125,12 @@ curl -s --url "https://api.aiven.io/v1/project/{project_name}/service/{service_n
   }
 }'
 ```
+
+:::note
+
+Aiven for OpenSearch supports Amazon S3 and any S3-compatible object storage service. To connect to a service other than Amazon S3, set `endpoint` to that service's S3 API endpoint URL.
+
+:::
 
 </TabItem>
 </Tabs>

--- a/docs/products/opensearch/howto/manage-custom-repo/custom-repositories-os-api.md
+++ b/docs/products/opensearch/howto/manage-custom-repo/custom-repositories-os-api.md
@@ -25,7 +25,7 @@ Use the OpenSearch® API for configuring custom repositories in Aiven for OpenSe
 ## Limitations
 
 - Supported storage services
-  - Amazon S3
+  - Amazon S3, or any S3-compatible object storage service
   - Google Cloud Storage (GCS)
   - Microsoft Azure Blob Storage
 - The following operations are not supported via native OpenSearch API:

--- a/docs/products/opensearch/howto/manage-custom-repo/custom-repositories-os-api.md
+++ b/docs/products/opensearch/howto/manage-custom-repo/custom-repositories-os-api.md
@@ -25,7 +25,7 @@ Use the OpenSearch® API for configuring custom repositories in Aiven for OpenSe
 ## Limitations
 
 - Supported storage services
-  - Amazon S3, or any S3-compatible object storage service
+  - Amazon S3 or any S3-compatible object storage service
   - Google Cloud Storage (GCS)
   - Microsoft Azure Blob Storage
 - The following operations are not supported via native OpenSearch API:


### PR DESCRIPTION
## Summary

- Note that Aiven for OpenSearch custom repositories support any S3-compatible object storage service (not only Amazon S3), by setting the `endpoint` field.
- Add the `endpoint` field to the S3 custom repository creation example in the Aiven API guide.
- Align the same limitations wording in the native OpenSearch API guide.

## Testing

- Reviewed against the current `custom_repos` S3 settings schema to confirm `endpoint` and its description.
- Manually checked rendered Markdown/MDX for the edited sections.