### PR TITLE
fix: restore ClickHouse service management links

### DIFF
--- a/docs/products/clickhouse.md
+++ b/docs/products/clickhouse.md
@@ -32,20 +32,26 @@ appropriate for the plan you have selected.
 ## Easy management
 
 -   **Scalability:** You can seamlessly
-    scale your ClickHouse cluster horizontally or vertically as your data and needs change
-    using the pre-packaged plans. Aiven for ClickHouse also supports
-    [sharding](/docs/products/clickhouse/howto/use-shards-with-distributed-table) as a horizontal cluster scaling strategy.
+    [scale your ClickHouse cluster](/docs/products/clickhouse/howto/change-service-plan)
+    horizontally or vertically as your data and needs change
+    using the pre-packaged plans. You can also
+    [scale disk storage](/docs/products/clickhouse/howto/scale-disk-storage)
+    independently of the plan. Aiven for ClickHouse also supports
+    [sharding](/docs/products/clickhouse/howto/use-shards-with-distributed-table)
+    as a horizontal cluster scaling strategy.
 -   **Resource tags:** You can assign metadata to your services in the
     form of tags. They help you organize, search, and filter Aiven
     resources. You can
-    tag your service by purpose, owner, environment, or any other criteria.
+    [tag your service](/docs/products/clickhouse/howto/tag-service)
+    by purpose, owner, environment, or any other criteria.
 -   **Forking:** Forking an Aiven for ClickHouse service creates a new
     database service containing the latest snapshot of an existing
     service. Forks don't stay up-to-date with the parent database, but
     you can write to them. It provides a risk-free way of working with
     your production data and schema. For example, you can use them to
     test upgrades, new schema migrations, or load test your app with a
-    different plan.
+    different plan. Learn how to
+    [fork an Aiven for ClickHouse® service](/docs/products/clickhouse/howto/fork-service).
 
 ## Effective maintenance
 
@@ -53,11 +59,15 @@ appropriate for the plan you have selected.
     that the ClickHouse software and the underlying platform stays
     up-to-date with the latest patches and updates with zero downtime.
     You can set
-    maintenance windows for your service to make sure the changes occur during
+    [maintenance windows](/docs/products/clickhouse/howto/maintenance-updates)
+    for your service to make sure the changes occur during
     times that do not affect productivity.
 -   **Backups and disaster recovery:** Aiven for ClickHouse has
     automatic backups taken every 24 hours. The retention period depends
-    on your plan tier. See the details on [Plan
+    on your plan tier. See
+    [disaster recovery](/docs/products/clickhouse/concepts/disaster-recovery),
+    [schedule backups](/docs/products/clickhouse/howto/configure-backup),
+    and [Plan
     comparison](https://aiven.io/pricing?product=clickhouse&tab=plan-comparison).
 
 ## Intelligent observability
@@ -109,10 +119,11 @@ ClickHouse in
     [Aiven CLI](/docs/tools/cli) client
     provides greater flexibility of use for proficient administrators
     allowing scripting repetitive actions with ease.
--   **REST APIs:** [Aiven APIs](/docs/tools/api) allow you to manage Aiven resources in a programmatic
-    way using HTTP requests. The whole functionality available via Aiven
-    Console is also available via APIs enabling you to build custom
-    integrations with ClickHouse and the Aiven platform.
+-   **REST APIs:** [Aiven APIs](/docs/tools/api) allow you to manage Aiven
+    resources in a programmatic way using HTTP requests. The whole
+    functionality available via Aiven Console is also available via APIs
+    enabling you to build custom integrations with ClickHouse and the Aiven
+    platform.
 
 <!-- vale off -->
 <RelatedPages/>

--- a/docs/products/clickhouse/howto/monitor-performance.md
+++ b/docs/products/clickhouse/howto/monitor-performance.md
@@ -40,7 +40,7 @@ collected metrics.
         -   **For Aiven for PostgreSQL**: This stores metrics in a relational format, suitable
             if you prefer SQL-based querying
         -   If you choose to use a new service, follow instructions on
-            how to create a service.
+            [how to create a service](/docs/products/clickhouse/get-started#create-an-aiven-for-clickhouse-service).
         -   If you're already using Aiven for Metrics or Aiven for PostgreSQL,
             you can submit your Aiven for ClickHouse metrics to the existing service.
     1.  Click **Enable**.
@@ -59,7 +59,7 @@ collected metrics.
 1. In the **Dashboard integration** window:
    1. Choose either a new or existing Aiven for Grafana service.
       - If you choose to use a new service, follow the instructions on
-        how to create a service.
+        [how to create a service](/docs/products/clickhouse/get-started#create-an-aiven-for-clickhouse-service).
       - If you're already using Grafana on Aiven, you can integrate
         your Aiven for Metrics or Aiven for PostgreSQL as an additional data source for that
         existing Grafana.

--- a/docs/products/clickhouse/howto/restore-backup.md
+++ b/docs/products/clickhouse/howto/restore-backup.md
@@ -13,7 +13,7 @@ by forking to a new service.
 :::important
 You cannot restore Aiven for ClickHouse services to a fewer number of nodes.
 Reducing the number of nodes is only possible by
-switching the service plan from **Business** to
+[switching the service plan](/docs/products/clickhouse/howto/change-service-plan) from **Business** to
 **Startup** on a running service.
 :::
 

--- a/docs/products/clickhouse/howto/use-shards-with-distributed-table.md
+++ b/docs/products/clickhouse/howto/use-shards-with-distributed-table.md
@@ -13,7 +13,7 @@ data evenly across all the cluster nodes.
 
 ## Set up a sharded service with a database
 
-1.  Create an Aiven for ClickHouse® service
+1.  [Create an Aiven for ClickHouse® service](/docs/products/clickhouse/get-started#create-an-aiven-for-clickhouse-service)
     with multiple shards.
 
     :::note

--- a/docs/products/clickhouse/reference/version-lifecycle.md
+++ b/docs/products/clickhouse/reference/version-lifecycle.md
@@ -24,4 +24,5 @@ stages, and security updates, see
 
 - [Manage Aiven for ClickHouse® versions](/docs/products/clickhouse/howto/manage-clickhouse-versions)
 - [Maintenance and updates](/docs/products/clickhouse/howto/maintenance-updates)
+- [Fork your Aiven for ClickHouse® service](/docs/products/clickhouse/howto/fork-service)
 - [Upgrade to Aiven for ClickHouse 26.3](/docs/products/clickhouse/reference/upgrade-to-26-3)


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [ ] My links start with `/docs/`.
