### PR TITLE
update: ClickHouse sink connector HTTP compression note

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/clickhouse-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/clickhouse-sink-connector.md
@@ -128,9 +128,8 @@ Create a file named `clickhouse_sink_connector.json` with the following configur
 - `username`: Username for authentication in the ClickHouse service.
 - `password`: Password for authentication in the ClickHouse service.
 - `ssl`: Set to `true` to enable SSL encryption.
-- `jdbcConnectionProperties`: Extra ClickHouse connection properties. For
-  ClickHouse 25.10 or later, set
-  `custom_http_params=enable_http_compression=0`.
+- `jdbcConnectionProperties`: Turns off HTTP response compression for ClickHouse
+  25.10 or later. Set `custom_http_params=enable_http_compression=0`.
 
 For more configuration options, see the
 [ClickHouse sink connector GitHub repository](https://github.com/ClickHouse/clickhouse-kafka-connect).

--- a/docs/products/kafka/kafka-connect/howto/clickhouse-sink-connector.md
+++ b/docs/products/kafka/kafka-connect/howto/clickhouse-sink-connector.md
@@ -28,6 +28,19 @@ Before you begin, ensure that you have the following:
   - Hostname, port, and credentials for the ClickHouse service.
   - A pre-created target database and table.
 
+:::note[ClickHouse version compatibility]
+ClickHouse 25.10 and later enable HTTP response compression by default. The
+ClickHouse sink connector can't decode this compression, so queries that
+return data fail even though the connector reports a successful connection.
+
+To use the sink connector with a ClickHouse service running version 25.10 or
+later, turn off HTTP compression in your connector configuration:
+
+```json
+"jdbcConnectionProperties": "custom_http_params=enable_http_compression=0"
+```
+:::
+
 ## Limitations
 
 <!-- vale off -->
@@ -99,6 +112,7 @@ Create a file named `clickhouse_sink_connector.json` with the following configur
     "username": "avnadmin",
     "password": "mypassword",
     "ssl": "true",
+    "jdbcConnectionProperties": "custom_http_params=enable_http_compression=0",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.storage.StringConverter"
 }
@@ -114,6 +128,9 @@ Create a file named `clickhouse_sink_connector.json` with the following configur
 - `username`: Username for authentication in the ClickHouse service.
 - `password`: Password for authentication in the ClickHouse service.
 - `ssl`: Set to `true` to enable SSL encryption.
+- `jdbcConnectionProperties`: Extra ClickHouse connection properties. For
+  ClickHouse 25.10 or later, set
+  `custom_http_params=enable_http_compression=0`.
 
 For more configuration options, see the
 [ClickHouse sink connector GitHub repository](https://github.com/ClickHouse/clickhouse-kafka-connect).
@@ -184,7 +201,8 @@ following properties:
     "database": "default",
     "username": "avnadmin",
     "password": "mypassword",
-    "ssl": "true"
+    "ssl": "true",
+    "jdbcConnectionProperties": "custom_http_params=enable_http_compression=0"
 }
 ```
 


### PR DESCRIPTION
## Describe your changes

Note the ClickHouse 25.10 HTTP compression workaround for the sink connector.

Page preview: https://kcon-751-add-click-house-ver.aiven-docs.pages.dev/docs/products/clickhouse/howto/integrate-kafka

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [ ] My links start with `/docs/`.
