### PR TITLE
fix: clarify plan downgrade support

### DIFF
--- a/static/includes/change-service-plan.md
+++ b/static/includes/change-service-plan.md
@@ -18,7 +18,9 @@ speeds up the upgrade itself.
 
 - When changing a service plan, reserve an additional 25% of disk space. This requirement
   applies to upgrades and downgrades.
-- Downgrading to a plan with fewer VMs is supported for Aiven for ClickHouse® only.
+- Downgrading to a plan with fewer VMs is supported for most services, including
+  Aiven for ClickHouse®, Aiven for Apache Kafka®, Aiven for OpenSearch®,
+  Aiven for Valkey™, Aiven for Dragonfly, and Aiven for Metrics.
 - Changing a service plan triggers a node recycle, service rebuilding, and any pending
   maintenance updates.
 


### PR DESCRIPTION
## Describe your changes

## Checklist

- [ ] The first paragraph of the page is on one line.
- [ ] The other lines have a line break at 90 characters.
- [ ] I checked the output.
- [ ] I applied the [style guide](../.ai-agents/docs/styleguide.md).
- [ ] My links start with `/docs/`.
