### PR TITLE
update: add LibreDB Studio connection guide for PostgreSQL

### DIFF
--- a/.github/vale/styles/config/vocabularies/Aiven/accept.txt
+++ b/.github/vale/styles/config/vocabularies/Aiven/accept.txt
@@ -235,6 +235,7 @@ Klaw
 Kpow
 Kubernetes
 kuromoji
+LibreDB
 LLM
 LLMs
 Loggly

--- a/docs/products/postgresql/howto/connect-libredb-studio.md
+++ b/docs/products/postgresql/howto/connect-libredb-studio.md
@@ -1,0 +1,61 @@
+---
+title: Connect to Aiven for PostgreSQL® with LibreDB Studio
+sidebar_label: LibreDB Studio
+---
+
+import RelatedPages from "@site/src/components/RelatedPages";
+
+Use [LibreDB Studio](https://libredb.org/) to connect to your Aiven for PostgreSQL®
+service from a browser. LibreDB Studio is an open source SQL client that you host
+yourself, so a team connects through one URL instead of installing a client on every
+machine.
+
+## Prerequisites
+
+- Access to the [Aiven Console](https://console.aiven.io/)
+- At least one running Aiven for PostgreSQL service
+- LibreDB Studio running on your machine or your network, for example with Docker:
+
+  ```bash
+  docker run -p 3000:3000 -v libredb:/app/data \
+    -e STORAGE_PROVIDER=sqlite ghcr.io/libredb/libredb-studio:0.15.0
+  ```
+
+  `STORAGE_PROVIDER=sqlite` keeps saved connections on the server instead of in the
+  browser, and the volume keeps them when the container is replaced. On the first run,
+  the admin password is printed to the container log, so read it with `docker logs`
+  before you sign in.
+
+## Get the service URI from Aiven Console
+
+1. Log in to [Aiven Console](https://console.aiven.io/) and go to your
+   organization > project > Aiven for PostgreSQL service.
+1. On the service **Overview** page, go to the **Connection information** section.
+1. Copy the **Service URI**. It carries the host, port, user, password, database name,
+   and `sslmode=require`.
+
+## Connect to the service URI from LibreDB Studio
+
+1. Open LibreDB Studio, sign in, and create a connection.
+1. Select **Paste URL**, paste the service URI, and select **Parse**. The host, port,
+   user, password, and database name are filled in, and SSL is set to `REQUIRE` because
+   the URI carries `sslmode=require`.
+1. Select **Test Connection** to verify the settings, and **Establish Connection** to
+   save the connection.
+
+Your tables are listed in the object browser, and the query editor and `EXPLAIN` plans
+run against the service.
+
+## Connection limits on smaller plans
+
+LibreDB Studio keeps a connection pool open while a connection is active, so it uses
+several of the connections your plan allows. Plans with a low connection limit, such as
+the free plan with a limit of 20, leave less room for other clients. Check **Connections**
+on the service **Overview** page if several tools connect at the same time.
+
+<RelatedPages/>
+
+- [Connect to Aiven for PostgreSQL](/docs/products/postgresql/howto/list-code-samples) for
+more tools you can use for connecting to your service
+- [LibreDB Studio](https://libredb.org/)
+- [LibreDB Studio on GitHub](https://github.com/libredb/libredb-studio)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -2103,6 +2103,7 @@ const sidebars: SidebarsConfig = {
                     'products/postgresql/howto/connect-zapier',
                     'products/postgresql/howto/connect-datagrip',
                     'products/postgresql/howto/connect-dbeaver',
+                    'products/postgresql/howto/connect-libredb-studio',
                   ],
                 },
                 {


### PR DESCRIPTION
Adds a connection guide for LibreDB Studio to the PostgreSQL connection methods, alongside the existing DBeaver, DataGrip and pgAdmin pages.

LibreDB Studio is an MIT licensed SQL client you host yourself and open in a browser, so a team connects through one URL instead of installing a client on every machine.

Everything in the guide was tested against a real service on 12 September 2026: a free plan Aiven for PostgreSQL service running Postgres 18.6, with LibreDB Studio 0.15.0 from its Docker image. Pasting the service URI filled in the host, the non standard port, user, password and database name, and set SSL to require because the URI carries sslmode=require. The connection came up in 1139 ms with no workaround, the object browser listed both test tables with correct row counts, a join and group by returned in 482 ms, and EXPLAIN rendered the full plan tree.

Two things in the guide are there because the test surfaced them rather than because they read well. The first run prints the admin password to the container log, which is easy to miss, so the prerequisites say to read it with docker logs. And LibreDB Studio holds a connection pool open, which matters on plans with a low connection limit, so there is a short section pointing at Connections on the service Overview page.

Changes:
- docs/products/postgresql/howto/connect-libredb-studio.md
- sidebars.ts, one entry under Connection methods
- .github/vale/styles/config/vocabularies/Aiven/accept.txt, the product name

Checked before opening: lines wrap at 90, Vale reports no errors, markdownlint is clean, and the commit is signed off.

Happy to add the MySQL page as a separate PR if this one is useful.

Repo: https://github.com/libredb/libredb-studio
Site: https://libredb.org