### PR TITLE
fix: add alias swap command to large-shard split guide

### DIFF
--- a/docs/products/opensearch/howto/resolve-shards-too-large.md
+++ b/docs/products/opensearch/howto/resolve-shards-too-large.md
@@ -83,10 +83,30 @@ need to recreate them.
     }'
     ```
 
-The split creates an index under a new name. If your application references the index by
-name rather than through an alias, add an alias that points to the new index so existing
-clients keep working without changes. For more information, see
-[Aliases](/docs/products/opensearch/concepts/indices#aliases).
+1. The split creates an index under a new name. If your application references the
+   index by name rather than through an alias, add an alias so existing clients keep
+   working without changes. Verify that INDEX_NAME and NEW_INDEX_NAME have the same
+   document count first, because the `remove_index` action below deletes INDEX_NAME
+   outright rather than only detaching the alias:
+
+    ```bash
+    curl -X POST "https://USER:PASSWORD@HOST:PORT/_aliases" \
+         -H 'Content-Type: application/json' \
+         -d '{
+      "actions": [
+        { "remove_index": { "index": "INDEX_NAME" } },
+        { "add": { "index": "NEW_INDEX_NAME", "alias": "INDEX_NAME" } }
+      ]
+    }'
+    ```
+
+Both actions apply in the same request, so there's no window where INDEX_NAME resolves
+to nothing, and existing clients keep reading and writing through INDEX_NAME unchanged.
+For more information, see [Aliases](/docs/products/opensearch/concepts/indices#aliases).
+
+If the security plugin is enabled, ACL rules matching INDEX_NAME don't automatically
+extend to its alias. For more information, see
+[Access control for aliases](/docs/products/opensearch/concepts/access_control#access-control-for-aliases).
 
 ## Reindex with more shards
 


### PR DESCRIPTION
## Why

The [Manage large shards](https://aiven.io/docs/products/opensearch/howto/resolve-shards-too-large) guide walks through making an index read-only and running the Split API, then says to "add an alias so existing clients keep working without changes" — without showing the command. The [Manage indices](https://aiven.io/docs/products/opensearch/concepts/indices) page it links to for more detail discusses aliases conceptually but has no `_aliases` API example either. A reader following the split workflow hits a dead end at exactly the step they need most.

## What changed

Added a concrete step to the split-index procedure with the `_aliases` request that atomically removes the old index and points the alias at the new one, plus:
- a warning that `remove_index` deletes the old index outright, so document counts should be verified first
- a cross-reference to the existing ACL-and-aliases guidance on the access control page, rather than duplicating it

## Testing

Ran `markdownlint-cli2` on the changed file (repo's configured linter) — clean, aside from a pre-existing line-length exception on the intro sentence that the style guide already excludes. Confirmed the command matches OpenSearch's `_aliases` API and the existing split-index workflow already on the page.